### PR TITLE
添加 vc project 使用 custom build command 時候的訊息

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -561,6 +561,7 @@ function _make_source_file_forall(vcxprojfile, vsinfo, target, sourcefile, sourc
     -- enter it
     local nodename = ifelse(sourcekind == "as", "CustomBuild", ifelse(sourcekind == "mrc", "ResourceCompile", "ClCompile"))
     sourcefile = path.relative(path.absolute(sourcefile), vcxprojdir)
+    sourcefilename = path.filename(sourcefile)
     vcxprojfile:enter("<%s Include=\"%s\">", nodename, sourcefile)
 
         -- for *.asm files
@@ -573,6 +574,7 @@ function _make_source_file_forall(vcxprojfile, vsinfo, target, sourcefile, sourc
                 vcxprojfile:print("<Outputs Condition=\"\'%$(Configuration)|%$(Platform)\'==\'%s\'\">%s</Outputs>", info.mode .. '|' .. info.arch, objectfile)
                 vcxprojfile:print("<Command Condition=\"\'%$(Configuration)|%$(Platform)\'==\'%s\'\">%s</Command>", info.mode .. '|' .. info.arch, compcmd)
             end
+            vcxprojfile:print("<Message>%s</Message>", sourcefilename)
 
         -- for *.rc files
         elseif sourcekind == "mrc" then

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -561,7 +561,6 @@ function _make_source_file_forall(vcxprojfile, vsinfo, target, sourcefile, sourc
     -- enter it
     local nodename = ifelse(sourcekind == "as", "CustomBuild", ifelse(sourcekind == "mrc", "ResourceCompile", "ClCompile"))
     sourcefile = path.relative(path.absolute(sourcefile), vcxprojdir)
-    sourcefilename = path.filename(sourcefile)
     vcxprojfile:enter("<%s Include=\"%s\">", nodename, sourcefile)
 
         -- for *.asm files
@@ -574,7 +573,7 @@ function _make_source_file_forall(vcxprojfile, vsinfo, target, sourcefile, sourc
                 vcxprojfile:print("<Outputs Condition=\"\'%$(Configuration)|%$(Platform)\'==\'%s\'\">%s</Outputs>", info.mode .. '|' .. info.arch, objectfile)
                 vcxprojfile:print("<Command Condition=\"\'%$(Configuration)|%$(Platform)\'==\'%s\'\">%s</Command>", info.mode .. '|' .. info.arch, compcmd)
             end
-            vcxprojfile:print("<Message>%s</Message>", sourcefilename)
+            vcxprojfile:print("<Message>%s</Message>", path.filename(sourcefile))
 
         -- for *.rc files
         elseif sourcekind == "mrc" then


### PR DESCRIPTION
- 原本的狀況下只會顯示大量相同的 `Performing Custom Build Tools` ，一旦出錯很難定位是哪一個源代碼
- 修改後維持原始 VC 風格，輸出近似於：
    ```
    1>------ Build started: Project: vpx, Configuration: debug x64 ------
    1>  avg_ssse3_x86_64.asm
    1>  vpx_subpixel_bilinear_ssse3.asm
    1>  loopfilter_block_sse2_x86_64.asm
    1>  bitdepth_conversion_sse2.asm
    1>       yasm : warning : can open only one input file, only the last file will be processed
    1>       yasm: FATAL: unable to open include file 
    1>  vpx_scale.c
    1>  vp9_blockd.c
    ```