### PR TITLE
improve vcpkg support for linux.

### DIFF
--- a/xmake/modules/package/manager/vcpkg/find_package.lua
+++ b/xmake/modules/package/manager/vcpkg/find_package.lua
@@ -48,11 +48,8 @@ function main(name, opt)
     local mode = opt.mode 
     if plat == "macosx" then
         plat = "osx"
-        if arch == "x86_64" then
-            arch = "x64"
-        end
     end
-    if plat == "linux" and arch == "x86_64" then
+    if arch == "x86_64" then
         arch = "x64"
     end
 

--- a/xmake/modules/package/manager/vcpkg/find_package.lua
+++ b/xmake/modules/package/manager/vcpkg/find_package.lua
@@ -52,6 +52,9 @@ function main(name, opt)
             arch = "x64"
         end
     end
+    if plat == "linux" and arch == "x86_64" then
+        arch = "x64"
+    end
 
     -- get the vcpkg installed directory
     local installdir = path.join(vcpkgdir, "installed")

--- a/xmake/modules/package/manager/vcpkg/install_package.lua
+++ b/xmake/modules/package/manager/vcpkg/install_package.lua
@@ -51,6 +51,9 @@ function main(name, opt)
             arch = "x64"
         end
     end
+    if plat == "linux" and arch == "x86_64" then
+        arch = "x64"
+    end
 
     -- check architecture
     if opt.arch ~= os.arch() then

--- a/xmake/modules/package/manager/vcpkg/install_package.lua
+++ b/xmake/modules/package/manager/vcpkg/install_package.lua
@@ -47,11 +47,8 @@ function main(name, opt)
     local mode = opt.mode 
     if plat == "macosx" then
         plat = "osx"
-        if arch == "x86_64" then
-            arch = "x64"
-        end
     end
-    if plat == "linux" and arch == "x86_64" then
+    if arch == "x86_64" then
         arch = "x64"
     end
 


### PR DESCRIPTION
### TLDR: 
When using vcpkg, machine architecture should change  **x86_64**  to **x64** not only on **macos** but also on **linux** .

### Detail:
Run `./vcpkg help triplet`
it show that the valid options of target machine architecture are as follows:
```
Available architecture triplets:
  arm-uwp
  arm-windows
  arm64-uwp
  arm64-windows
  x64-linux
  x64-osx
  x64-uwp
  x64-windows
  x64-windows-static
  x86-uwp
  x86-windows
  x86-windows-static
```
also refer to https://vcpkg.readthedocs.io/en/latest/users/triplets/#VCPKG_TARGET_ARCHITECTURE.