### PR TITLE
rename ARCH amd64 to x86_64: allows luajit to compile

### DIFF
--- a/makefile
+++ b/makefile
@@ -39,6 +39,9 @@ endif
 
 endif
 
+# map architecture amd64 to x86_64
+ARCH 		:=$(if $(findstring amd64,$(ARCH)),x86_64,$(ARCH))
+
 xmake_dir_install   :=$(prefix)/share/xmake
 xmake_core          :=./core/src/demo/demo.b
 xmake_core_install  :=$(xmake_dir_install)/xmake


### PR DESCRIPTION
Luajit has a directory for x86_64 but not for amd64 - to allow compilation the architecture variable is mapped.