### PR TITLE
fix powershell script download

### DIFF
--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -49,6 +49,7 @@ try{
 }
 Write-Host "Start downloading https://github.com/xmake-io/xmake/releases/download/$version/xmake-$branch.exe .."
 try{
+    [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
     Invoke-Webrequest "https://github.com/xmake-io/xmake/releases/download/$version/xmake-$branch.exe" -OutFile "$outfile"
 }catch{
     writeErrorTip 'Download failed!'


### PR DESCRIPTION
The Powershell install line in the README was failing on Windows 10 here with this error:

    Download failed!
    Check your network or... the news of S3 break
    Invoke-Webrequest : The request was aborted: Could not create SSL/TLS secure channel.

This is apparently because by default powershell uses TLS 1.0 so this change, from https://stackoverflow.com/a/48030563/1009432 , fixes the issue.

You can test with the Powershell command changed to get the script from my fork/branch:

     Invoke-Expression (Invoke-Webrequest 'https://raw.githubusercontent.com/paul-reilly/xmake/ps-fix/scripts/get.ps1' -UseBasicParsing).Content
