### PR TITLE
Support cudart flags

### DIFF
--- a/xmake/modules/detect/tools/nvcc/has_flags.lua
+++ b/xmake/modules/detect/tools/nvcc/has_flags.lua
@@ -48,8 +48,14 @@ end
 function _check_from_arglist(flags, opt, islinker)
 
     -- check for the builtin flags
-    local builtin_flags = {["-code"] = true, ["--gpu-code"] = true, ["-gencode"] = true, ["--generate-code"] = true, ["-arch"] = true, ["--gpu-architecture"] = true}
+    local builtin_flags = {["-code"] = true, ["--gpu-code"] = true, ["-gencode"] = true, ["--generate-code"] = true, ["-arch"] = true, ["--gpu-architecture"] = true, ["-cudart=none"] = true, ["--cudart=none"] = true}
     if builtin_flags[flags[1]] then
+        return true
+    end
+
+    local cudart_flags = {["none"] = true, ["shared"] = true, ["static"] = true}
+    local builtin_flags_pair = {["-cudart"] = cudart_flags, ["--cudart"] = cudart_flags}
+    if #flags > 1 and builtin_flags_pair[flags[1]] and builtin_flags_pair[flags[1]][flags[2]] then
         return true
     end
 


### PR DESCRIPTION
Fix check failed of `-cudart none` (Default is `-cudart static` aka `-lcudart_static`)
```
checking for the flags (-cudart none ) ... no
> nvcc -cudart none -m64 -LC:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v10.1\lib
checkinfo: C:\Program Files (x86)\xmake/core/base/os.lua:715: nvcc_has_flags.cu
tmpxft_00003f20_00000000-18_nvcc_has_flags.obj : error LNK2019: 无法解析的外部符号 __cudaRegisterFatBinary，该符号在函数 "void __cdecl __nv_cudaEntityRegisterCallback(void * *)" (?__nv_cudaEntityRegisterCallback@@YAXPEAPEAX@Z) 中被引用
tmpxft_00003f20_00000000-18_nvcc_has_flags.obj : error LNK2019: 无法解析的外部符号 __cudaRegisterFatBinaryEnd，该符号在函数 "void __cdecl __nv_cudaEntityRegisterCallback(void * *)" (?__nv_cudaEntityRegisterCallback@@YAXPEAPEAX@Z) 中被引用
tmpxft_00003f20_00000000-18_nvcc_has_flags.obj : error LNK2019: 无法解析的外部符号 __cudaUnregisterFatBinary，该符号在函数 "void __cdecl __cudaUnregisterBinaryUtil(void)" (?__cudaUnregisterBinaryUtil@@YAXXZ) 中被引用
C:\Users\lzy\AppData\Local\Temp\.xmake\190520\detect\nvcc_has_flags.cu.o : fatal error LNK1120: 3 个无法解析的外部命令

stack traceback:
    [C]: in function 'error'
    [C:\Program Files (x86)\xmake/core/base/os.lua:715]: in function 'raise'
    [C:\Program Files (x86)\xmake\core\sandbox\modules\os.lua:309]: in function 'runv'
    [...iles (x86)\xmake\modules\detect\tools\nvcc\has_flags.lua:44]:
```

This will compile with `-lcudart` or `-lcudart_static`