### PR TITLE
Support warning for cl.exe

### DIFF
--- a/xmake/modules/core/tools/cl.lua
+++ b/xmake/modules/core/tools/cl.lua
@@ -19,6 +19,7 @@
 --
 
 -- imports
+import("core.base.option")
 import("core.project.project")
 import("core.language.language")
 
@@ -408,6 +409,26 @@ function _compile1(self, sourcefile, objectfile, dependinfo, flags)
                     end
                 end
                 os.raise(results)
+            end
+        },
+        finally
+        {
+            function (ok, outdata, errdata)
+                -- show warnings?
+                if ok and ((outdata and #outdata > 0) or (errdata and #errdata > 0)) and (option.get("diagnosis") or option.get("warning")) then
+
+                    local lines = table.join2(outdata:split("\r\n"), errdata:split("\r\n"))
+                    local warnings = {}
+                    for _, line in ipairs(lines) do
+                        if string.match(line, "warning %a+[0-9]+%s*:") then
+                            table.insert(warnings, line)
+                        end
+                    end
+                    if #warnings > 0 then
+                        local warning = table.concat(table.slice(warnings, 1, ifelse(#warnings > 8, 8, #warnings)), "\n")
+                        cprint("${color.warning}%s", warning)
+                    end
+                end
             end
         }
     }

--- a/xmake/modules/core/tools/cl.lua
+++ b/xmake/modules/core/tools/cl.lua
@@ -386,7 +386,6 @@ end
 -- make the complie arguments list
 function _compargv1(self, sourcefile, objectfile, flags)
 
-    flags = _clean_up_flags(flags)
     -- precompiled header?
     local extension = path.extension(sourcefile)
     if (extension:startswith(".h") or extension == ".inl") then
@@ -410,15 +409,15 @@ function _compile1(self, sourcefile, objectfile, dependinfo, flags)
     local outdata = try
     {
         function ()
+            local compflags = _clean_up_flags(flags)
 
             -- generate includes file
-            local compflags = flags
             if dependinfo then
                 compflags = table.join(flags, "-showIncludes")
             end
             return os.iorunv(_compargv1(self, sourcefile, objectfile, compflags))
         end,
-        
+
         catch
         {
             function (errors)

--- a/xmake/modules/core/tools/cl.lua
+++ b/xmake/modules/core/tools/cl.lua
@@ -337,6 +337,30 @@ function _include_deps(self, outdata)
     return results
 end
 
+function _clean_up_flags(flags)
+
+    local out_flags = {}
+
+    local warning_level_flag = -1 -- suppress warning D9025, use only one /W[num] flags
+
+    for _, flag in ipairs(flags) do
+        if flag:match("%s*[-/]W[0-4]%s*") then
+            local level = tonumber(flag:sub(3))
+            if level and level > warning_level_flag then
+                warning_level_flag = level
+            end
+        else
+            table.insert(out_flags, flag)
+        end
+    end
+
+    if warning_level_flag >= 0 then
+        table.insert(out_flags, string.format("/W%d", warning_level_flag))
+    end
+
+    return out_flags
+end
+
 -- make the complie arguments list for the precompiled header
 function _compargv1_pch(self, pcheaderfile, pcoutputfile, flags)
 
@@ -362,6 +386,7 @@ end
 -- make the complie arguments list
 function _compargv1(self, sourcefile, objectfile, flags)
 
+    flags = _clean_up_flags(flags)
     -- precompiled header?
     local extension = path.extension(sourcefile)
     if (extension:startswith(".h") or extension == ".inl") then


### PR DESCRIPTION
另外，错误信息大部分也是从stdout返回的，导致报错信息也只包含部分无关紧要的warnings