### PR TITLE
fix nsis version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,8 +14,10 @@ install:
   - ps: New-Item ./winenv/bin -ItemType Directory
   #   NSIS
   - ps: Invoke-WebRequest "https://svwh.dl.sourceforge.net/project/nsis/NSIS 3/3.04/nsis-3.04.zip" -UseBasicParsing -OutFile ./nsis.zip
+  - ps: Invoke-WebRequest "https://svwh.dl.sourceforge.net/project/nsis/NSIS 3/3.04/nsis-3.04-strlen_8192.zip" -UseBasicParsing -OutFile ./nsis-longstr.zip
   - ps: Expand-Archive ./nsis.zip -DestinationPath ./nsis
   - ps: Move-Item ./nsis/*/* ./nsis
+  - ps: Expand-Archive ./nsis-longstr.zip -DestinationPath ./nsis -Force
   #   unzip
   - ps: Invoke-WebRequest "https://svwh.dl.sourceforge.net/project/gnuwin32/unzip/5.51-1/unzip-5.51-1-bin.zip" -UseBasicParsing -OutFile .\unzip.zip
   - ps: Expand-Archive ./unzip.zip -DestinationPath ./unzip


### PR DESCRIPTION

那怎么下载呢？还有需要特殊long string版本的nsis做安装包，否则安装注册环境变量的时候，如果系统path变量太长 会被阶段，导致安装后环境变量损坏 之前遇到过这个坑

_Originally posted by @waruqi in https://github.com/xmake-io/xmake/pull/444#issuecomment-500205213_