### PR TITLE
use -lineinfo for cuda debug symbol

### DIFF
--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -63,7 +63,7 @@ function nf_symbol(self, level, target)
     -- debug? generate *.pdb file
     local flags = nil
     if level == "debug" then
-        flags = "-g -G"
+        flags = "-g -lineinfo"
         if is_plat("windows") then
             local host_flags = nil
             local symbolfile = nil


### PR DESCRIPTION
`-G` will disable all optimization
![图片](https://user-images.githubusercontent.com/13471233/61443852-e1275180-a97c-11e9-9ff9-feb35db4af8c.png)
