### PR TITLE
fix bug when parallel checking flags

### DIFF
--- a/xmake/modules/detect/tools/nvcc/has_flags.lua
+++ b/xmake/modules/detect/tools/nvcc/has_flags.lua
@@ -113,11 +113,10 @@ function _check_try_running(flags, opt, islinker)
     end
 
     -- check flags
-    local objectfile = is_plat("windows") and sourcefile .. ".o" or os.nuldev()
     if islinker then
-        return _try_running(opt.program, table.join(flags, "-o", objectfile, sourcefile))
+        return _try_running(opt.program, table.join(flags, "-o", os.nuldev(), sourcefile))
     else
-        return _try_running(opt.program, table.join(flags, "-c", "-o", objectfile, sourcefile))
+        return _try_running(opt.program, table.join(flags, "-c", "-o", os.nuldev(), sourcefile))
     end
 end
 

--- a/xmake/plugins/project/vsxmake/vsproj/Xmake.targets
+++ b/xmake/plugins/project/vsxmake/vsproj/Xmake.targets
@@ -107,8 +107,7 @@
       <File Include="$([MSBuild]::MakeRelative('$(XmakeProjectDirResolved)', $([System.IO.Path]::GetFullPath('%(SelectedFile.Identity)'))))" />
     </ItemGroup>
     <PropertyGroup>
-      <FileList>@(File)</FileList>
-      <FileFlag>--files="$(FileList)"</FileFlag>
+      <FileFlag>--files="@(File)"</FileFlag>
     </PropertyGroup>
     <Message Text="$xmake build $(_XmakeCommonFlags) $(_XmakeBuildFileFlags) $(FileFlag) $(XmakeTarget)" Importance="High" />
     <Exec StdOutEncoding="utf-8" StdErrEncoding="utf-8" Command="$(_XmakeEnv)


### PR DESCRIPTION
```
fatal error C1083: 无法打开编译器生成的文件: “C:\Users\lzy\AppData\Local\Temp\.xmake\190722\detect\nvcc_has_flags.cu.o”: Permission denied
```
