### PR TITLE
provide sources path for vs searching

### DIFF
--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -158,7 +158,7 @@ function _make_targetinfo(mode, arch, target)
     targetinfo.configfiledir = _make_dirs(target:get("configdir"))
     targetinfo.includedirs   = _make_dirs(_get_values(target, "includedirs"))
     targetinfo.linkdirs      = _make_dirs(_get_values(target, "linkdirs"))
-    targetinfo.vcsourcepaths = _make_dirs(config.get("vcsourcepaths"))
+    targetinfo.vcsourcepaths = _make_dirs(target:values("project.vsxmake.vcsourcepaths"))
 
     -- save defines
     targetinfo.defines       = _make_arrs(_get_values(target, "defines"))

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -158,6 +158,7 @@ function _make_targetinfo(mode, arch, target)
     targetinfo.configfiledir = _make_dirs(target:get("configdir"))
     targetinfo.includedirs   = _make_dirs(_get_values(target, "includedirs"))
     targetinfo.linkdirs      = _make_dirs(_get_values(target, "linkdirs"))
+    targetinfo.vcsourcepaths = _make_dirs(config.get("vcsourcepaths"))
 
     -- save defines
     targetinfo.defines       = _make_arrs(_get_values(target, "defines"))

--- a/xmake/plugins/project/vsxmake/vsproj/Xmake.props
+++ b/xmake/plugins/project/vsxmake/vsproj/Xmake.props
@@ -124,6 +124,7 @@
     <LibraryPath>$(XmakeLinkDir);$(LibraryPath)</LibraryPath>
     <OutDir>$(XmakeTargetDir)\</OutDir>
     <IntDir>$(XmakeBuilDir)\.vs\$(TargetName)\$(XmakeArch)\$(XmakeMode)\</IntDir>
+    <SourcePath>$(VC_SourcePath);$(XmakeVCSourcePaths);</SourcePath>
   </PropertyGroup>
 
   <PropertyGroup Label="Debugger">

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/XmakePath(mode,arch)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/XmakePath(mode,arch)
@@ -6,4 +6,5 @@
     <XmakeIncludeDir>#includedirs#</XmakeIncludeDir>
     <XmakeLinkDir>#linkdirs#</XmakeLinkDir>
     <XmakeRunDir>#rundir#</XmakeRunDir>
+    <XmakeVCSourcePaths>#vcsourcepaths#</XmakeVCSourcePaths>
   </PropertyGroup>


### PR DESCRIPTION
@OpportunityLiu 
這是根據討論 #257 過程中曾經提到的 `<SourcePath>` 標籤，提出的修改建議。
在使用VS的時候，我這邊很頻繁的會需要設置這個內容以方便在debug過程指向正確源代碼。
例如說 Qt5、xtreme toolkit、ps4/xbox tool、 都會有機會需要設置這個項目。

這個提交的內容，使用方法只要在xmake.lua 中加入`set_config("vcsourcepaths", "D:\\Qt\\5.9.3\\Src")` 就OK了。

麻煩你們看一下，謝謝。