### PR TITLE
fix error caused by the new vsDevCmd.bat of vs2019

### DIFF
--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -45,6 +45,7 @@ function _load_vcvarsall(vcvarsall, arch, vcvars_ver, sdkver)
     local genvcvars_dat = os.tmpfile() .. "_genvcvars.txt"
     local file = io.open(genvcvars_bat, "w")
     file:print("@echo off")
+    file:print("set VSCMD_SKIP_SENDTELEMETRY=yes")
     if vcvars_ver then
         file:print("call \"%s\" %s %s -vcvars_ver=%s > nul", vcvarsall, arch,  sdkver and sdkver or "", vcvars_ver)
     else


### PR DESCRIPTION
A specific block of the new vsDevCmd.bat may cause system error. Use env var 'VSCMD_SKIP_SENDTELEMETRY' to skip it.
Solution referrer: <https://developercommunity.visualstudio.com/content/problem/694847/vsdevcmdbat-developer-prompt-causes-the-input-line.html>

