### PR TITLE
fix ~ allow empty/`nil` taskmenu

### DIFF
--- a/xmake/core/base/option.lua
+++ b/xmake/core/base/option.lua
@@ -446,7 +446,9 @@ function option.defaults(task)
 
     -- get the default options for the given task
     local defaults = {}
-    option.populate_defaults(taskmenu.options, defaults)
+    if taskmenu then
+        option.populate_defaults(taskmenu.options, defaults)
+    end
     return defaults
 end
 


### PR DESCRIPTION
 * taskmenu may empty for `xmake` recipes with solely internal tasks

... for example, here's an xmake file with two internal tasks (two print routines used by other tasks, and a global internal `_on_init()` function allowing use within tasks overriding the usual global `on_init()`) ...

``` xmake
set_project("issue-taskmenu")

-- local theme styles
local theme_local = {
    ["color.info"]="blue", ["text.info"]="i  ",
    ["color.note"]="bright blue", ["text.note"]="#  ",
    ["text.warning"] = "*  warning: ", ["text.error"] = "!  error: ",
    ["text.success"] = "+  ", ["text.failure"] = "-  failed: ",
}

on_load( function (target)
    import("core.project.task")
    task.run("_on_load", {}, target)
    -- ... irrelevant code ...
end )

-- add target
target("issue-taskmenu")
    on_load( function(target)
        import("core.base.option")
        import("core.project.task")
        task.run("_on_load", {}, target)
        task.run("print_note", {}, vformat("task:on_load(%s)", target:name()))
    end )

    set_kind("binary")

    add_files("src/*.c")

    after_build( function(target)
        import("core.project.task")
        local msg = string.format('["%s"] => '..target:targetfile(), target:name())
        task.run("print_info", {}, msg)
    end )


-- ## internal tasks (aka functions)

task("print_info")
    on_run( function(format, ...)
        import("core.base.colors")
        import("core.base.option")
        if not option.get("quiet") then
            theme = colors.theme()
            color = theme["color.info"] or theme_local["color.info"] or ""
            text = theme["text.info"] or theme_local["text.info"] or ""
            local msg = string.format("${%s}%s${clear}", color, text) .. string.tryformat(format, ...)
            cprint(msg)
        end
    end )

task("print_note")
    on_run( function(format, ...)
        import("core.base.colors")
        import("core.base.option")
        if not option.get("quiet") and (option.get("diagnosis") or option.get("verbose")) then
            theme = colors.theme()
            color = theme["color.note"] or theme_local["color.note"] or ""
            text = theme["text.note"] or theme_local["text.note"] or ""
            local msg = string.format("${%s}%s${clear}", color, text) .. string.tryformat(format, ...)
            cprint(msg)
        end
    end )

task("_on_load")
    on_run( function(target)
        -- ... lots of irrelevant code ...
    end )
```

This recipe worked with earlier versions. But,  I upgraded while trying to speed-up non-MSVC compiles (a separate PR), I started experiencing an `error: attempt to index local 'taskmenu' (a nil value)` error.

This PR fixes it.