### PR TITLE
Speedup non-MSVC builds

### DIFF
--- a/xmake/modules/private/platform/check_arch.lua
+++ b/xmake/modules/private/platform/check_arch.lua
@@ -32,7 +32,6 @@ function main(config, default)
         config.set("arch", default or os.arch())
 
         -- trace
-        cprint("checking for the architecture ... ${green}%s", config.get("arch"))
+        cprint("checking for the architecture ... ${color.success}%s", config.get("arch"))
     end
 end
-

--- a/xmake/modules/private/platform/check_vstudio.lua
+++ b/xmake/modules/private/platform/check_vstudio.lua
@@ -87,15 +87,13 @@ function main(config)
         config.set("vs", vs, {readonly = true, force = true})
 
         -- trace
-        print("checking for the Microsoft Visual Studio (%s) version ... %s", config.get("arch"), vs)
+        cprint("checking for the Microsoft Visual Studio (%s) version ... ${color.success}%s", config.get("arch"), vs)
     else
         -- failed
-        print("checking for the Microsoft Visual Studio (%s) version ... no", config.get("arch"))
-        print("please run:")
-        print("    - xmake config --vs=xxx [--vs_toolset=xxx]")
-        print("or  - xmake global --vs=xxx")
+        cprint("checking for the Microsoft Visual Studio (%s) version ... ${color.failure}no", config.get("arch"))
+        cprint("please run:")
+        cprint("    - xmake config --vs=xxx [--vs_toolset=xxx]")
+        cprint("or  - xmake global --vs=xxx")
         raise()
     end
 end
-
-

--- a/xmake/platforms/windows/config.lua
+++ b/xmake/platforms/windows/config.lua
@@ -20,6 +20,7 @@
 
 -- imports
 import("core.project.config")
+import("core.base.global")
 import("core.base.singleton")
 import("core.platform.environment")
 import("private.platform.toolchain")
@@ -130,8 +131,11 @@ function main(platform, name)
         -- check arch 
         check_arch(config)
 
-        -- check vstudio
-        check_vstudio(config)
+        cc = config.get("cc") or global.get("cc") or "cl.exe"
+        if (cc == "cl") or (cc == "cl.exe") or (cc == "cl.com") or (cc == "cl.bat") or (cc == "cl.cmd") then
+            -- check vstudio
+            check_vstudio(config)
+        end
     end
 end
 


### PR DESCRIPTION
This PR bypasses the (relatively slow) `check_vstudio` routine for non-`cl` builds (eg, `clang` or `gcc` builds). The additional `cl` executables beyond `cl.exe` (`cl.com`, `cl.bat`, `cl.cmd`) may be a bit overkill.

I also normalized the color usage (success/ failure) for the "check_*" tasks.