### PR TITLE
Refactor ~ enable `rc` search when needed

### DIFF
--- a/xmake/platforms/windows/config.lua
+++ b/xmake/platforms/windows/config.lua
@@ -130,7 +130,8 @@ function main(platform, name)
         -- check vstudio
         local cc  = path.basename(config.get("cc") or "cl"):lower()
         local cxx = path.basename(config.get("cxx") or "cl"):lower()
-        if cc == "cl" or cxx == "cl" then
+        local mrc = path.basename(config.get("mrc") or "rc"):lower()
+        if cc == "cl" or cxx == "cl" or mrc == "rc" then
             check_vstudio(config)
         end
     end


### PR DESCRIPTION
`clang` may require the use of MSVC `rc`.
This modification enable the needed `check_vstudio()` call when `rc` is requested.