### PR TITLE
fix mingw link to Qt library by mode debug

### DIFF
--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -28,6 +28,8 @@ function _link(framework, major)
         local debug_suffix = "_debug"
         if is_plat("windows") then
             debug_suffix = "d"
+        elseif is_plat("mingw") then
+            debug_suffix = "d"
         elseif is_plat("android") then
             debug_suffix = ""
         end
@@ -41,6 +43,8 @@ function _find_static_links(linkdirs, libpattern)
     local links = {}
     local debug_suffix = "_debug"
     if is_plat("windows") then
+        debug_suffix = "d"
+    elseif is_plat("mingw") then
         debug_suffix = "d"
     elseif is_plat("android") then
         debug_suffix = ""


### PR DESCRIPTION
on plat windows Qt library debug mode suffix is `d`, will mingw use default suffix `_debug`.
Add plat test for mingw, set debug mode suffix to `d`.

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

