### PR TITLE
fix: cl.exe warning D9024 :无法识别的源文件类型

### DIFF
--- a/xmake/rules/qt/moc/xmake.lua
+++ b/xmake/rules/qt/moc/xmake.lua
@@ -97,7 +97,7 @@ rule("qt.moc")
         -- we need compile this moc_xxx.cpp file if exists Q_PRIVATE_SLOT, @see https://github.com/xmake-io/xmake/issues/750 
         dependinfo.files = {}
         local mocdata = io.readfile(sourcefile)
-        if mocdata and mocdata:find("Q_PRIVATE_SLOT") then
+        if mocdata and mocdata:find("Q_PRIVATE_SLOT") or sourcefile_moc:endswith(".moc") then
             -- add includedirs of sourcefile_moc
             target:add("includedirs", path.directory(sourcefile_moc))
 


### PR DESCRIPTION
QT在对xxxx.moc文件处理时，不管xxxx.cpp文件有无Q_PRIVATE_SLOT私有槽函数，都不会对xxxx.moc文件进行编译，编译器无法识别xxx.moc报错