### PR TITLE
unresolved external symbol qInitResources_xxxx

### DIFF
--- a/xmake/rules/qt/qrc/xmake.lua
+++ b/xmake/rules/qt/qrc/xmake.lua
@@ -91,7 +91,7 @@ rule("qt.qrc")
         end
 
         -- compile qrc 
-        os.vrunv(rcc, {"-name", "qml", sourcefile_qrc, "-o", sourcefile_cpp})
+        os.vrunv(rcc, {"-name", path.basename(sourcefile_qrc), sourcefile_qrc, "-o", sourcefile_cpp})
 
         -- trace
         if option.get("verbose") then


### PR DESCRIPTION
rcc -name 后面的参数应该是按照文件名称变化的,否则 Q_INIT_RESOURCE(XXXX);无法编译