### PR TITLE
Fix find_cudadevices in nvidia docker

### DIFF
--- a/xmake/modules/lib/detect/find_cudadevices.lua
+++ b/xmake/modules/lib/detect/find_cudadevices.lua
@@ -125,7 +125,7 @@ function _find_devices(verbose)
 
     -- get cuda devices
     local sourcefile = path.join(os.programdir(), "scripts", "find_cudadevices.cpp")
-    local outfile = os.tmpfile()
+    local outfile = os.tmpfile({ramdisk = false}) -- no execution permision in docker's /shm
     local compile_errors = nil
     local results, errors = try
     {


### PR DESCRIPTION
其他地方有没有同样的问题？是否需要添加对docker环境的探测？