### PR TITLE
toolchain: remove includedirs and linkdirs of system path

### DIFF
--- a/xmake/toolchains/clang/xmake.lua
+++ b/xmake/toolchains/clang/xmake.lua
@@ -62,18 +62,4 @@ toolchain("clang")
             toolchain:add("ldflags", march)
             toolchain:add("shflags", march)
         end
-
-        -- add includedirs and linkdirs
-        if not toolchain:is_plat("windows") and os.isdir("/usr") then
-            for _, includedir in ipairs({"/usr/local/include", "/usr/include"}) do
-                if os.isdir(includedir) then
-                    toolchain:add("includedirs", includedir)
-                end
-            end
-            for _, linkdir in ipairs({"/usr/local/lib", "/usr/lib"}) do
-                if os.isdir(linkdir) then
-                    toolchain:add("linkdirs", linkdir)
-                end
-            end
-        end
     end)

--- a/xmake/toolchains/gcc/xmake.lua
+++ b/xmake/toolchains/gcc/xmake.lua
@@ -62,18 +62,4 @@ toolchain("gcc")
             toolchain:add("ldflags", march)
             toolchain:add("shflags", march)
         end
-
-        -- add includedirs and linkdirs
-        if not toolchain:is_plat("windows") and os.isdir("/usr") then
-            for _, includedir in ipairs({"/usr/local/include", "/usr/include"}) do
-                if os.isdir(includedir) then
-                    toolchain:add("includedirs", includedir)
-                end
-            end
-            for _, linkdir in ipairs({"/usr/local/lib", "/usr/lib"}) do
-                if os.isdir(linkdir) then
-                    toolchain:add("linkdirs", linkdir)
-                end
-            end
-        end
     end)

--- a/xmake/toolchains/icc/load.lua
+++ b/xmake/toolchains/icc/load.lua
@@ -103,18 +103,6 @@ function _load_intel_on_linux(toolchain)
         toolchain:add("ldflags", march)
         toolchain:add("shflags", march)
     end
-
-    -- add includedirs and linkdirs
-    for _, includedir in ipairs({"/usr/local/include", "/usr/include"}) do
-        if os.isdir(includedir) then
-            toolchain:add("includedirs", includedir)
-        end
-    end
-    for _, linkdir in ipairs({"/usr/local/lib", "/usr/lib"}) do
-        if os.isdir(linkdir) then
-            toolchain:add("linkdirs", linkdir)
-        end
-    end
 end
 
 -- main entry

--- a/xmake/toolchains/xcode/load_macosx.lua
+++ b/xmake/toolchains/xcode/load_macosx.lua
@@ -47,11 +47,6 @@ function main(toolchain)
     if xcode_sdkdir then
         toolchain:add("cxflags", "-isysroot " .. xcode_sdkdir)
         toolchain:add("ldflags", "-isysroot " .. xcode_sdkdir)
-    else
-        toolchain:add("includedirs", "/usr/local/include")
-        toolchain:add("includedirs", "/usr/include")
-        toolchain:add("linkdirs", "/usr/local/lib")
-        toolchain:add("linkdirs", "/usr/lib")
     end
     toolchain:add("ldflags", "-stdlib=libc++")
     toolchain:add("syslinks", "z")


### PR DESCRIPTION
`/usr/{local/,}include` and `/usr/{local/,}lib` are in the default configuration of the compilers and forcing them to be added (before any other includes) conflicts with the project files.