### PR TITLE
Enable more warnings on "all" settings

### DIFF
--- a/xmake/modules/core/tools/cl.lua
+++ b/xmake/modules/core/tools/cl.lua
@@ -136,7 +136,7 @@ function nf_warning(self, level)
         none       = "-W0"
     ,   less       = "-W1"
     ,   more       = "-W3"
-    ,   all        = "-W4" -- = "-Wall" will enable too more warnings
+    ,   all        = "-W3" -- = "-Wall" will enable too more warnings
     ,   everything = "-Wall"
     ,   error      = "-WX"
     }

--- a/xmake/modules/core/tools/cl.lua
+++ b/xmake/modules/core/tools/cl.lua
@@ -136,7 +136,7 @@ function nf_warning(self, level)
         none       = "-W0"
     ,   less       = "-W1"
     ,   more       = "-W3"
-    ,   all        = "-W3" -- = "-Wall" will enable too more warnings
+    ,   all        = "-W4" -- = "-Wall" will enable too more warnings
     ,   everything = "-Wall"
     ,   error      = "-WX"
     }

--- a/xmake/modules/core/tools/cl.lua
+++ b/xmake/modules/core/tools/cl.lua
@@ -139,6 +139,7 @@ function nf_warning(self, level)
     ,   all        = "-W3" -- = "-Wall" will enable too more warnings
     ,   everything = "-Wall"
     ,   error      = "-WX"
+    ,   extra      = "-W4"
     }
 
     -- make it

--- a/xmake/modules/core/tools/cl.lua
+++ b/xmake/modules/core/tools/cl.lua
@@ -137,9 +137,9 @@ function nf_warning(self, level)
     ,   less       = "-W1"
     ,   more       = "-W3"
     ,   all        = "-W3" -- = "-Wall" will enable too more warnings
+    ,   allextra   = "-W4"
     ,   everything = "-Wall"
     ,   error      = "-WX"
-    ,   extra      = "-W4"
     }
 
     -- make it

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -117,7 +117,7 @@ function nf_warning(self, level)
         none       = "-w"
     ,   less       = "-Wall"
     ,   more       = "-Wall"
-    ,   all        = "-Wextra -Wall"
+    ,   all        = "-Wall"
     ,   everything = "-Weverything"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -118,6 +118,7 @@ function nf_warning(self, level)
     ,   less       = "-Wall"
     ,   more       = "-Wall"
     ,   all        = "-Wall"
+    ,   allextra   = "-Wall -Wextra"
     ,   everything = "-Weverything"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -117,7 +117,7 @@ function nf_warning(self, level)
         none       = "-w"
     ,   less       = "-Wall"
     ,   more       = "-Wall"
-    ,   all        = "-Wall"
+    ,   all        = "-Wextra -Wall"
     ,   everything = "-Weverything"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/clang_cl.lua
+++ b/xmake/modules/core/tools/clang_cl.lua
@@ -33,7 +33,7 @@ function init(self)
         ["-W1"] = "-Wall"
     ,   ["-W2"] = "-Wall"
     ,   ["-W3"] = "-Wall"
-    ,   ["-W4"] = "-Wextra"
+    ,   ["-W4"] = "-Wall -Wextra"
     ,   ["-Weverything"] = "-Wall -Wextra -Weffc++"
 
         -- language

--- a/xmake/modules/core/tools/cparser.lua
+++ b/xmake/modules/core/tools/cparser.lua
@@ -94,7 +94,7 @@ function nf_warning(self, level)
         none       = "-w"
     ,   less       = "-Wall"
     ,   more       = "-Wall"
-    ,   all        = "-Wextra -Wall"
+    ,   all        = "-Wall"
     ,   everything = "-Wextra -Wall"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/cparser.lua
+++ b/xmake/modules/core/tools/cparser.lua
@@ -94,7 +94,7 @@ function nf_warning(self, level)
         none       = "-w"
     ,   less       = "-Wall"
     ,   more       = "-Wall"
-    ,   all        = "-Wall"
+    ,   all        = "-Wextra -Wall"
     ,   everything = "-Wextra -Wall"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -112,9 +112,9 @@ function nf_warning(self, level)
     ,   less       = "-Wall"
     ,   more       = "-Wall"
     ,   all        = "-Wall"
+    ,   allextra   = "-Wall -Wextra"
     ,   everything = "-Wall -Wextra -Weffc++"
     ,   error      = "-Werror"
-    ,   extra      = "-Wextra"
     }
     return maps[level]
 end

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -111,7 +111,7 @@ function nf_warning(self, level)
         none       = "-w"
     ,   less       = "-Wall"
     ,   more       = "-Wall"
-    ,   all        = "-Wall"
+    ,   all        = "-Wall -Wextra"
     ,   everything = "-Wall -Wextra -Weffc++"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -111,7 +111,7 @@ function nf_warning(self, level)
         none       = "-w"
     ,   less       = "-Wall"
     ,   more       = "-Wall"
-    ,   all        = "-Wall -Wextra"
+    ,   all        = "-Wall"
     ,   everything = "-Wall -Wextra -Weffc++"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -114,6 +114,7 @@ function nf_warning(self, level)
     ,   all        = "-Wall"
     ,   everything = "-Wall -Wextra -Weffc++"
     ,   error      = "-Werror"
+    ,   extra      = "-Wextra"
     }
     return maps[level]
 end

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -122,7 +122,7 @@ function nf_warning(self, level)
         none       = "-w"
     ,   less       = "-Wall"
     ,   more       = "-Wall"
-    ,   all        = "-Wall"
+    ,   all        = "-Wall -Wextra"
     ,   everything = "-Weverything -Wall -Wextra -Weffc++"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -110,6 +110,7 @@ function nf_warning(self, level)
     ,   all        = "-W3" -- = "-Wall" will enable too more warnings
     ,   everything = "-Wall"
     ,   error      = "-WX"
+    ,   extra      = "-W4"
     }
 
     -- for gcc & clang on linux, may be work for other gnu compatible compilers such as icc
@@ -125,6 +126,7 @@ function nf_warning(self, level)
     ,   all        = "-Wall"
     ,   everything = "-Weverything -Wall -Wextra -Weffc++"
     ,   error      = "-Werror"
+    ,   extra      = "-Wextra"
     }
 
     -- get warning for nvcc

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -107,7 +107,7 @@ function nf_warning(self, level)
         none       = "-W0"
     ,   less       = "-W1"
     ,   more       = "-W3"
-    ,   all        = "-W3" -- = "-Wall" will enable too more warnings
+    ,   all        = "-W4" -- = "-Wall" will enable too more warnings
     ,   everything = "-Wall"
     ,   error      = "-WX"
     }

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -122,7 +122,7 @@ function nf_warning(self, level)
         none       = "-w"
     ,   less       = "-Wall"
     ,   more       = "-Wall"
-    ,   all        = "-Wall -Wextra"
+    ,   all        = "-Wall"
     ,   everything = "-Weverything -Wall -Wextra -Weffc++"
     ,   error      = "-Werror"
     }

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -107,7 +107,7 @@ function nf_warning(self, level)
         none       = "-W0"
     ,   less       = "-W1"
     ,   more       = "-W3"
-    ,   all        = "-W4" -- = "-Wall" will enable too more warnings
+    ,   all        = "-W3" -- = "-Wall" will enable too more warnings
     ,   everything = "-Wall"
     ,   error      = "-WX"
     }

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -108,9 +108,9 @@ function nf_warning(self, level)
     ,   less       = "-W1"
     ,   more       = "-W3"
     ,   all        = "-W3" -- = "-Wall" will enable too more warnings
+    ,   allextra   = "-W4"
     ,   everything = "-Wall"
     ,   error      = "-WX"
-    ,   extra      = "-W4"
     }
 
     -- for gcc & clang on linux, may be work for other gnu compatible compilers such as icc

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -124,9 +124,9 @@ function nf_warning(self, level)
     ,   less       = "-Wall"
     ,   more       = "-Wall"
     ,   all        = "-Wall"
+    ,   allextra   = "-Wall -Wextra"
     ,   everything = "-Weverything -Wall -Wextra -Weffc++"
     ,   error      = "-Werror"
-    ,   extra      = "-Wextra"
     }
 
     -- get warning for nvcc

--- a/xmake/modules/core/tools/tcc.lua
+++ b/xmake/modules/core/tools/tcc.lua
@@ -78,8 +78,8 @@ function nf_warning(self, level)
     ,   less       = "-W1"
     ,   more       = "-W3"
     ,   all        = "-Wall"
-    ,   extra      = "-Wunsupported"
-    ,   everything = "-Wall -Wunsupported -Wwrite-strings"
+    ,   allextra   = "-Wall -Wunsupported -Wwrite-strings -Wimplicit-function-declaration"
+    ,   everything = "-Wall -Wunsupported -Wwrite-strings -Wimplicit-function-declaration"
     ,   error      = "-Werror"
     }
     return maps[level]

--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -285,7 +285,7 @@ function _add_target_warnings(cmakelists, target)
         none  = "-W0"
     ,   less  = "-W1"
     ,   more  = "-W3"
-    ,   all   = "-W4" -- = "-Wall" will enable too more warnings
+    ,   all   = "-W3" -- = "-Wall" will enable too more warnings
     ,   error = "-WX"
     }
     local warnings = target:get("warnings")

--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -285,7 +285,7 @@ function _add_target_warnings(cmakelists, target)
         none  = "-W0"
     ,   less  = "-W1"
     ,   more  = "-W3"
-    ,   all   = "-W3" -- = "-Wall" will enable too more warnings
+    ,   all   = "-W4" -- = "-Wall" will enable too more warnings
     ,   error = "-WX"
     }
     local warnings = target:get("warnings")

--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -274,21 +274,21 @@ end
 function _add_target_warnings(cmakelists, target)
     local flags_gcc =
     {
-        none  = "-w"
-    ,   less  = "-Wall"
-    ,   more  = "-Wall"
-    ,   all   = "-Wall"
-    ,   error = "-Werror"
-    ,   extra = "-Wextra"
+        none     = "-w"
+    ,   less     = "-Wall"
+    ,   more     = "-Wall"
+    ,   all      = "-Wall"
+    ,   allextra = "-Wall -Wextra"
+    ,   error    = "-Werror"
     }
     local flags_msvc =
     {
-        none  = "-W0"
-    ,   less  = "-W1"
-    ,   more  = "-W3"
-    ,   all   = "-W3" -- = "-Wall" will enable too more warnings
-    ,   error = "-WX"
-    ,   extra = "-W4"
+        none     = "-W0"
+    ,   less     = "-W1"
+    ,   more     = "-W3"
+    ,   all      = "-W3" -- = "-Wall" will enable too more warnings
+    ,   allextra = "-W4"
+    ,   error    = "-WX"
     }
     local warnings = target:get("warnings")
     if warnings then

--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -277,7 +277,7 @@ function _add_target_warnings(cmakelists, target)
         none  = "-w"
     ,   less  = "-Wall"
     ,   more  = "-Wall"
-    ,   all   = "-Wall"
+    ,   all   = "-Wall -Wextra"
     ,   error = "-Werror"
     }
     local flags_msvc =

--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -277,7 +277,7 @@ function _add_target_warnings(cmakelists, target)
         none  = "-w"
     ,   less  = "-Wall"
     ,   more  = "-Wall"
-    ,   all   = "-Wall -Wextra"
+    ,   all   = "-Wall"
     ,   error = "-Werror"
     }
     local flags_msvc =

--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -279,6 +279,7 @@ function _add_target_warnings(cmakelists, target)
     ,   more  = "-Wall"
     ,   all   = "-Wall"
     ,   error = "-Werror"
+    ,   extra = "-Wextra"
     }
     local flags_msvc =
     {
@@ -287,6 +288,7 @@ function _add_target_warnings(cmakelists, target)
     ,   more  = "-W3"
     ,   all   = "-W3" -- = "-Wall" will enable too more warnings
     ,   error = "-WX"
+    ,   extra = "-W4"
     }
     local warnings = target:get("warnings")
     if warnings then


### PR DESCRIPTION
It seems that xmake warnings settings "all" and "more" are mostly equivalents, for MSVC and GCC/Clang. This PR enables more warnings on the "all" settings (using -Wextra and /W4).