### PR TITLE
fix default value of choice options displayed in the graphical menu

### DIFF
--- a/xmake/core/ui/mconfdialog.lua
+++ b/xmake/core/ui/mconfdialog.lua
@@ -252,14 +252,16 @@ function mconfdialog:show_help()
         if config.kind then
             text = text .. "\ntype: " .. config.kind
         end
-        if config.default then
-            text = text .. "\ndefault: " .. tostring(config.default)
-        end
         if config.kind == "choice" then
+            if config.default and config.values[config.default] then
+                text = text .. "\ndefault: " .. config.values[config.default]
+            end
             text = text .. "\nvalues: "
             for _, value in ipairs(config.values) do
                 text = text .. "\n    - " .. value
             end
+        elseif config.default then
+            text = text .. "\ndefault: " .. tostring(config.default)
         end
         if config.path then
             text = text .. "\npath: " .. config.path


### PR DESCRIPTION
With `option:set_values()` the index of the value was displayed instead of the value.