### PR TITLE
-W4 implies -Wall and -Wextra with gcc and clang

### DIFF
--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -52,7 +52,7 @@ function init(self)
         ["-W1"] = "-Wall"
     ,   ["-W2"] = "-Wall"
     ,   ["-W3"] = "-Wall"
-    ,   ["-W4"] = "-Wextra"
+    ,   ["-W4"] = "-Wall -Wextra"
 
          -- strip
     ,   ["-s"]  = "-s"

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -53,7 +53,7 @@ function init(self)
         ["-W1"] = "-Wall"
     ,   ["-W2"] = "-Wall"
     ,   ["-W3"] = "-Wall"
-    ,   ["-W4"] = "-Wextra"
+    ,   ["-W4"] = "-Wall -Wextra"
     ,   ["-Weverything"] = "-Wall -Wextra -Weffc++"
 
          -- strip


### PR DESCRIPTION
`-Wall` is not in `-Wextra` and must be added.

```cpp
int main()
{
  int i{2}; // no warning with only -Wextra
              // -Wunused-variable with -Wall
}
```