### PR TITLE
Handle french and japanese outputs when using /showIncludes with cl.exe

### DIFF
--- a/xmake/modules/private/tools/cl/parse_include.lua
+++ b/xmake/modules/private/tools/cl/parse_include.lua
@@ -34,8 +34,10 @@ function main(line)
     --
     _g.notes = _g.notes or
     {
-        "Note: including file: "
-    ,   "注意: 包含文件: "
+        "Note: including file: " -- en
+    ,   "注意: 包含文件: " -- zh
+    ,   "Remarque : inclusion du fichier : " -- fr
+    ,   "メモ: インクルード ファイル: " -- jp
     }
 
     -- contain notes?


### PR DESCRIPTION
As discussed in #1072 