### PR TITLE
Qt deploy for Windows

### DIFF
--- a/xmake/rules/qt/install/windows.lua
+++ b/xmake/rules/qt/install/windows.lua
@@ -19,21 +19,16 @@
 --
 
 -- imports
-import("core.theme.theme")
 import("core.base.option")
 import("core.project.config")
-import("core.project.depend")
 import("core.tool.toolchain")
 import("detect.sdks.find_vstudio")
-import("private.utils.progress")
 
 -- install application package for windows
 function main(target, opt)
 
     local targetfile = target:targetfile()
     local installfile = path.join(target:installdir(), "bin", path.filename(targetfile))
-
-    -- do deploy
     
     -- get qt sdk
     local qt = target:data("qt")

--- a/xmake/rules/qt/install/windows.lua
+++ b/xmake/rules/qt/install/windows.lua
@@ -34,7 +34,7 @@ function main(target, opt)
     local installfile = path.join(target:installdir(), "bin", path.filename(targetfile))
 
     -- need re-generate this app?
-    local dependfile = target:dependfile(targetfile)
+    local dependfile = target:dependfile(installfile)
 
     depend.on_changed(function ()
         -- do deploy
@@ -83,5 +83,5 @@ function main(target, opt)
         table.insert(argv, installfile)
 
         os.vrunv(windeployqt, argv, {envs = envs})
-    end, {dependfile = dependfile, files = targetfile})
+    end, {dependfile = dependfile, files = installfile})
 end

--- a/xmake/rules/qt/install/windows.lua
+++ b/xmake/rules/qt/install/windows.lua
@@ -23,6 +23,7 @@ import("core.theme.theme")
 import("core.base.option")
 import("core.project.config")
 import("core.project.depend")
+import("core.tool.toolchain")
 import("detect.sdks.find_vstudio")
 import("private.utils.progress")
 

--- a/xmake/rules/qt/install/windows.lua
+++ b/xmake/rules/qt/install/windows.lua
@@ -22,7 +22,7 @@
 import("core.base.option")
 import("core.project.config")
 import("core.tool.toolchain")
-import("detect.sdks.find_vstudio")
+import("lib.detect.find_path")
 
 -- install application package for windows
 function main(target, opt)

--- a/xmake/rules/qt/install/windows.lua
+++ b/xmake/rules/qt/install/windows.lua
@@ -1,0 +1,86 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-2020, TBOOX Open Source Group.
+--
+-- @author      ruki
+-- @file        macosx.lua
+--
+
+-- imports
+import("core.theme.theme")
+import("core.base.option")
+import("core.project.config")
+import("core.project.depend")
+import("detect.sdks.find_vstudio")
+import("private.utils.progress")
+
+-- install application package for windows
+function main(target, opt)
+
+    local targetfile = target:targetfile()
+    local installfile = path.join(target:installdir(), "bin", path.filename(targetfile))
+
+    -- need re-generate this app?
+    local dependfile = target:dependfile(targetfile)
+
+    depend.on_changed(function ()
+        -- do deploy
+        
+        -- get qt sdk
+        local qt = target:data("qt")
+
+        -- get windeployqt
+        local windeployqt = path.join(qt.bindir, "windeployqt.exe")
+        assert(os.isexec(windeployqt), "windeployqt.exe not found!")
+
+        -- find qml directory
+        local qmldir = nil
+        for _, sourcebatch in pairs(target:sourcebatches()) do
+            if sourcebatch.rulename == "qt.qrc" then
+                for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
+                    qmldir = find_path("*.qml", path.directory(sourcefile))
+                    if qmldir then
+                        break
+                    end
+                end
+            end
+        end
+
+        -- find msvc to set VCINSTALLDIR env
+        local envs = nil
+        local msvc = toolchain.load("msvc", {plat = target:plat(), arch = target:arch()})
+        if msvc then
+            local vcvars = msvc:config("vcvars")
+            if vcvars and vcvars.VSInstallDir then
+                envs = {VCINSTALLDIR = path.join(vcvars.VSInstallDir, "VC")}
+            end
+        end
+
+        local argv = {"--force"}
+        if option.get("diagnosis") then
+            table.insert(argv, "--verbose=2")
+        elseif option.get("verbose") then
+            table.insert(argv, "--verbose=1")
+        else
+            table.insert(argv, "--verbose=0")
+        end
+        if qmldir then
+            table.insert(argv, "--qmldir=" .. qmldir)
+        end
+        table.insert(argv, installfile)
+
+        os.vrunv(windeployqt, argv, {envs = envs})
+    end, {dependfile = dependfile, files = targetfile})
+end

--- a/xmake/rules/qt/xmake.lua
+++ b/xmake/rules/qt/xmake.lua
@@ -75,6 +75,8 @@ rule("qt.console")
         import("load")(target, {frameworks = {"QtCore"}})
     end)
 
+    after_install("windows", "install.windows")
+
 -- define rule: qt widgetapp
 rule("qt.widgetapp")
     add_deps("qt.ui", "qt.moc", "qt._wasm_app", "qt.qrc")
@@ -94,6 +96,7 @@ rule("qt.widgetapp")
 
     -- install application for android
     on_install("android", "install.android")
+    after_install("windows", "install.windows")
 
 -- define rule: qt static widgetapp
 rule("qt.widgetapp_static")
@@ -143,6 +146,7 @@ rule("qt.widgetapp_static")
 
     -- install application for android
     on_install("android", "install.android")
+    after_install("windows", "install.windows")
 
 -- define rule: qt quickapp
 rule("qt.quickapp")
@@ -163,6 +167,7 @@ rule("qt.quickapp")
 
     -- install application for android
     on_install("android", "install.android")
+    after_install("windows", "install.windows")
 
 -- define rule: qt static quickapp
 rule("qt.quickapp_static")
@@ -212,6 +217,7 @@ rule("qt.quickapp_static")
 
     -- install application for android
     on_install("android", "install.android")
+    after_install("windows", "install.windows")
 
 -- define rule: qt application (deprecated)
 rule("qt.application")


### PR DESCRIPTION
xmake currently supports qt deploying for android and macos, a similar tool exists for windows (windeployqt.exe) and this PR adds support for it.

It's based on qt.deploy.macos which is the closest from what exists on Windows.

Here's an output I got by using it:
```
checking for vswhere.exe ... C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe
C:\Projets\Libs\Qt\5.15.0\msvc2019_64\bin\windeployqt.exe --force --verbose=1 test_qt\bin\BurgWarMapEditor.exe
C:\Projets\Burgwar\BurgWar\test_qt\bin\BurgWarMapEditor.exe 64 bit, release executable
Adding Qt5Svg for qsvgicon.dll
Direct dependencies: Qt5Core Qt5Gui Qt5Widgets
All dependencies   : Qt5Core Qt5Gui Qt5Widgets
To be deployed     : Qt5Core Qt5Gui Qt5Svg Qt5Widgets
Updating Qt5Core.dll.
Updating Qt5Gui.dll.
Updating Qt5Svg.dll.
Updating Qt5Widgets.dll.
Updating libGLESv2.dll.
Updating libEGL.dll.
Updating D3Dcompiler_47.dll.
Updating opengl32sw.dll.
Updating vc_redist.x64.exe.
Creating directory C:/Projets/Burgwar/BurgWar/test_qt/bin/iconengines.
Updating qsvgicon.dll.
Creating directory C:/Projets/Burgwar/BurgWar/test_qt/bin/imageformats.
Updating qgif.dll.
Updating qicns.dll.
Updating qico.dll.
Updating qjpeg.dll.
Updating qsvg.dll.
Updating qtga.dll.
Updating qtiff.dll.
Updating qwbmp.dll.
Updating qwebp.dll.
Creating directory C:/Projets/Burgwar/BurgWar/test_qt/bin/platforms.
Updating qwindows.dll.
Creating directory C:/Projets/Burgwar/BurgWar/test_qt/bin/styles.
Updating qwindowsvistastyle.dll.
Creating C:\Projets\Burgwar\BurgWar\test_qt\bin\translations...
Creating qt_ar.qm...
Creating qt_bg.qm...
Creating qt_ca.qm...
Creating qt_cs.qm...
Creating qt_da.qm...
Creating qt_de.qm...
Creating qt_en.qm...
Creating qt_es.qm...
Creating qt_fi.qm...
Creating qt_fr.qm...
Creating qt_gd.qm...
Creating qt_he.qm...
Creating qt_hu.qm...
Creating qt_it.qm...
Creating qt_ja.qm...
Creating qt_ko.qm...
Creating qt_lv.qm...
Creating qt_pl.qm...
Creating qt_ru.qm...
Creating qt_sk.qm...
Creating qt_uk.qm...
Creating qt_zh_TW.qm...
```

**Please note this PR has still some problems/questions I couldn't fix by myself**:

- I'm searching for the app file (.exe) using
```lua
    local installfile = path.join(target:installdir(), "bin", target:basename() .. ".exe")
```

is this correct?

- I tried to keep the progression print but it seems `opt` doesn't exist
```lua
    -- trace progress info
    -- progress.show(opt.progress, "${color.build.target}generating.qt.app %s.app", target:basename())
```

- windeployqt.exe will try to fetch some files from Visual Studio to copy a runtime installer, and it needs a VCINSTALLDIR env for that, I did something that works for me but should be improved:
```lua
    -- do deploy
    local vs_studio = find_vstudio()

    -- Find Visual Studio
    local installDir = path.join(vs_studio["2019"].vcvarsall[target:arch()].VSInstallDir, "VC")
    os.addenv("VCINSTALLDIR", installDir)
```

- Instead of deploying everytime the application is built, I'm deploying only on installation. I did this because the deploying takes some time. So I'm not sure if it should be done on build or install.
- I did it also for the qt.console rule, as the fact it's a console application doesn't prevent it from needing Qt DLL and suchs.

Here you are!