### PR TITLE
improve registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1098](https://github.com/xmake-io/xmake/issues/1098): Support stdin for os.execv
 * [#1079](https://github.com/xmake-io/xmake/issues/1079): Add autoupdate plugin rule for vsxmake, `add_rules("plugin.vsxmake.autoupdate")`
 * Add `xmake f --vs_runtime=MT` and `set_runtimes("MT")` to set vs runtime for targets and packages
+* [#1032](https://github.com/xmake-io/xmake/issues/1032): Support to enum registry keys and values
 
 ### Change
 
@@ -895,6 +896,7 @@
 * [#1098](https://github.com/xmake-io/xmake/issues/1098): 支持传递 stdin 到 os.execv 进行输入重定向
 * [#1079](https://github.com/xmake-io/xmake/issues/1079): 为 vsxmake 插件添加工程自动更新插件，`add_rules("plugin.vsxmake.autoupdate")`
 * 添加 `xmake f --vs_runtime=MT` 和 `set_runtimes("MT")` 去更方便的对 target 和 package 进行设置
+* [#1032](https://github.com/xmake-io/xmake/issues/1032): 支持枚举注册表 keys 和 values
 
 ### 改进
 

--- a/core/src/xmake/engine.c
+++ b/core/src/xmake/engine.c
@@ -185,6 +185,8 @@ tb_int_t xm_winos_ansi_cp(lua_State* lua);
 tb_int_t xm_winos_oem_cp(lua_State* lua);
 tb_int_t xm_winos_logical_drives(lua_State* lua);
 tb_int_t xm_winos_registry_query(lua_State* lua);
+tb_int_t xm_winos_registry_keys(lua_State* lua);
+tb_int_t xm_winos_registry_values(lua_State* lua);
 #endif
 
 // the string functions
@@ -287,6 +289,8 @@ static luaL_Reg const g_winos_functions[] =
 ,   { "ansi_cp",             xm_winos_ansi_cp           }
 ,   { "logical_drives",      xm_winos_logical_drives    }
 ,   { "registry_query",      xm_winos_registry_query    }
+,   { "registry_keys",       xm_winos_registry_keys     }
+,   { "registry_values",     xm_winos_registry_values   }
 ,   { tb_null,               tb_null                    }
 };
 #endif

--- a/core/src/xmake/makefile
+++ b/core/src/xmake/makefile
@@ -135,6 +135,8 @@ ifdef iswin
 xmake_C_FILES 			+= \
 						winos/ansi \
 						winos/logical_drives \
+						winos/registry_keys \
+						winos/registry_values \
 						winos/registry_query
 endif
 

--- a/core/src/xmake/winos/registry_keys.c
+++ b/core/src/xmake/winos/registry_keys.c
@@ -1,0 +1,182 @@
+/*!A cross-platform build utility based on Lua
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, TBOOX Open Source Group.
+ *
+ * @author      ruki
+ * @file        registry_keys.c
+ *
+ */
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * trace
+ */
+#define TB_TRACE_MODULE_NAME                "registry_keys"
+#define TB_TRACE_MODULE_DEBUG               (0)
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * includes
+ */
+#include "prefix.h"
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * types
+ */
+// the RegGetValueA func type
+typedef BOOL (WINAPI* xm_RegGetValueA_t)(HKEY hkey, LPCSTR lpSubKey, LPCSTR lpValue, DWORD dwFlags, LPDWORD pdwType, PVOID pvData, LPDWORD pcbData);
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * implementation
+ */
+
+/* get registry keys
+ *
+ * local value, errors = winos.registry_keys("HKEY_LOCAL_MACHINE", "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug", "Debugger")
+ */
+tb_int_t xm_winos_registry_keys(lua_State* lua)
+{
+    // check
+    tb_assert_and_check_return_val(lua, 0);
+
+    // get the arguments
+    tb_char_t const* rootkey   = luaL_checkstring(lua, 1);
+    tb_char_t const* rootdir   = luaL_checkstring(lua, 2);
+    tb_char_t const* valuename = luaL_checkstring(lua, 3);
+    tb_check_return_val(rootkey && rootdir && valuename, 0);
+
+    // query key-value
+    tb_bool_t   ok = tb_false;
+    HKEY        key = tb_null;
+    HKEY        keynew = tb_null;
+    tb_char_t*  value = tb_null;
+    do
+    {
+        // get registry rootkey
+        if (!tb_strcmp(rootkey, "HKEY_CLASSES_ROOT"))         key = HKEY_CLASSES_ROOT;
+        else if (!tb_strcmp(rootkey, "HKEY_CURRENT_CONFIG"))  key = HKEY_CURRENT_CONFIG;
+        else if (!tb_strcmp(rootkey, "HKEY_CURRENT_USER"))    key = HKEY_CURRENT_USER;
+        else if (!tb_strcmp(rootkey, "HKEY_LOCAL_MACHINE"))   key = HKEY_LOCAL_MACHINE;
+        else if (!tb_strcmp(rootkey, "HKEY_USERS"))           key = HKEY_USERS;
+        else
+        {
+            lua_pushnil(lua);
+            lua_pushfstring(lua, "invalid registry rootkey: %s", rootkey);
+            break;
+        }
+
+        // attempt to load RegGetValueA
+        static xm_RegGetValueA_t s_RegGetValueA = tb_null;
+        if (!s_RegGetValueA)
+        {
+            // load the advapi32 module
+            tb_dynamic_ref_t module = (tb_dynamic_ref_t)GetModuleHandleA("advapi32.dll");
+            if (!module) module = tb_dynamic_init("advapi32.dll");
+            if (module) s_RegGetValueA = (xm_RegGetValueA_t)tb_dynamic_func(module, "RegGetValueA");
+        }
+
+        // get registry value
+        DWORD type = 0;
+        if (s_RegGetValueA)
+        {
+            // get registry value size
+            DWORD valuesize = 0;
+            if (s_RegGetValueA(key, rootdir, valuename, RRF_RT_ANY, 0, tb_null, &valuesize) != ERROR_SUCCESS)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "get registry value size failed: %s\\%s;%s", rootkey, rootdir, valuename);
+                break;
+            }
+
+            // make value buffer
+            value = (tb_char_t*)tb_malloc0(valuesize + 1);
+            tb_assert_and_check_break(value);
+
+            // get value result
+            type = 0;
+            if (s_RegGetValueA(key, rootdir, valuename, RRF_RT_ANY, &type, (PVOID)value, &valuesize) != ERROR_SUCCESS)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "get registry value failed: %s\\%s;%s", rootkey, rootdir, valuename);
+                break;
+            }
+        }
+        else
+        {
+            // open registry key
+            if (RegOpenKeyExA(key, rootdir, 0, KEY_QUERY_VALUE, &keynew) != ERROR_SUCCESS && keynew)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "open registry key failed: %s\\%s", rootkey, rootdir);
+                break;
+            }
+
+            // get registry value size
+            DWORD valuesize = 0;
+            if (RegQueryValueExA(keynew, valuename, tb_null, tb_null, tb_null, &valuesize) != ERROR_SUCCESS)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "get registry value size failed: %s\\%s;%s", rootkey, rootdir, valuename);
+                break;
+            }
+
+            // make value buffer
+            value = (tb_char_t*)tb_malloc0(valuesize + 1);
+            tb_assert_and_check_break(value);
+
+            // get value result
+            type = 0;
+            if (RegQueryValueExA(keynew, valuename, tb_null, &type, (LPBYTE)value, &valuesize) != ERROR_SUCCESS)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "get registry value failed: %s\\%s;%s", rootkey, rootdir, valuename);
+                break;
+            }
+        }
+
+        // save result
+        switch (type)
+        {
+        case REG_SZ:
+        case REG_EXPAND_SZ:
+            lua_pushstring(lua, value);
+            ok = tb_true;
+            break;
+        case REG_DWORD:
+            lua_pushfstring(lua, "%d", *((tb_int_t*)value));
+            ok = tb_true;
+            break;
+        case REG_QWORD:
+            lua_pushfstring(lua, "%lld", *((tb_int64_t*)value));
+            ok = tb_true;
+            break;
+        default:
+            lua_pushnil(lua);
+            lua_pushfstring(lua, "unsupported registry value type: %d", type);
+            break;
+        }
+
+    } while (0);
+
+    // exit registry key
+    if (keynew)
+        RegCloseKey(keynew);
+    keynew = tb_null;
+
+    // exit value
+    if (value) tb_free(value);
+    value = tb_null;
+
+    // ok?
+    return ok? 1 : 2;
+}

--- a/core/src/xmake/winos/registry_values.c
+++ b/core/src/xmake/winos/registry_values.c
@@ -108,6 +108,7 @@ tb_int_t xm_winos_registry_values(lua_State* lua)
         for (i = 0; i < value_name_num; i++)
         {
             // get value name
+            value_name[0] = L'\0';
             DWORD value_name_size = tb_arrayn(value_name);
             if (RegEnumValueW(keynew, i, value_name, &value_name_size, tb_null, tb_null, tb_null, tb_null) != ERROR_SUCCESS)
             {

--- a/core/src/xmake/winos/registry_values.c
+++ b/core/src/xmake/winos/registry_values.c
@@ -1,0 +1,182 @@
+/*!A cross-platform build utility based on Lua
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, TBOOX Open Source Group.
+ *
+ * @author      ruki
+ * @file        registry_values.c
+ *
+ */
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * trace
+ */
+#define TB_TRACE_MODULE_NAME                "registry_values"
+#define TB_TRACE_MODULE_DEBUG               (0)
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * includes
+ */
+#include "prefix.h"
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * types
+ */
+// the RegGetValueA func type
+typedef BOOL (WINAPI* xm_RegGetValueA_t)(HKEY hkey, LPCSTR lpSubKey, LPCSTR lpValue, DWORD dwFlags, LPDWORD pdwType, PVOID pvData, LPDWORD pcbData);
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * implementation
+ */
+
+/* get registry values
+ *
+ * local value, errors = winos.registry_values("HKEY_LOCAL_MACHINE", "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug", "Debugger")
+ */
+tb_int_t xm_winos_registry_values(lua_State* lua)
+{
+    // check
+    tb_assert_and_check_return_val(lua, 0);
+
+    // get the arguments
+    tb_char_t const* rootkey   = luaL_checkstring(lua, 1);
+    tb_char_t const* rootdir   = luaL_checkstring(lua, 2);
+    tb_char_t const* valuename = luaL_checkstring(lua, 3);
+    tb_check_return_val(rootkey && rootdir && valuename, 0);
+
+    // query key-value
+    tb_bool_t   ok = tb_false;
+    HKEY        key = tb_null;
+    HKEY        keynew = tb_null;
+    tb_char_t*  value = tb_null;
+    do
+    {
+        // get registry rootkey
+        if (!tb_strcmp(rootkey, "HKEY_CLASSES_ROOT"))         key = HKEY_CLASSES_ROOT;
+        else if (!tb_strcmp(rootkey, "HKEY_CURRENT_CONFIG"))  key = HKEY_CURRENT_CONFIG;
+        else if (!tb_strcmp(rootkey, "HKEY_CURRENT_USER"))    key = HKEY_CURRENT_USER;
+        else if (!tb_strcmp(rootkey, "HKEY_LOCAL_MACHINE"))   key = HKEY_LOCAL_MACHINE;
+        else if (!tb_strcmp(rootkey, "HKEY_USERS"))           key = HKEY_USERS;
+        else
+        {
+            lua_pushnil(lua);
+            lua_pushfstring(lua, "invalid registry rootkey: %s", rootkey);
+            break;
+        }
+
+        // attempt to load RegGetValueA
+        static xm_RegGetValueA_t s_RegGetValueA = tb_null;
+        if (!s_RegGetValueA)
+        {
+            // load the advapi32 module
+            tb_dynamic_ref_t module = (tb_dynamic_ref_t)GetModuleHandleA("advapi32.dll");
+            if (!module) module = tb_dynamic_init("advapi32.dll");
+            if (module) s_RegGetValueA = (xm_RegGetValueA_t)tb_dynamic_func(module, "RegGetValueA");
+        }
+
+        // get registry value
+        DWORD type = 0;
+        if (s_RegGetValueA)
+        {
+            // get registry value size
+            DWORD valuesize = 0;
+            if (s_RegGetValueA(key, rootdir, valuename, RRF_RT_ANY, 0, tb_null, &valuesize) != ERROR_SUCCESS)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "get registry value size failed: %s\\%s;%s", rootkey, rootdir, valuename);
+                break;
+            }
+
+            // make value buffer
+            value = (tb_char_t*)tb_malloc0(valuesize + 1);
+            tb_assert_and_check_break(value);
+
+            // get value result
+            type = 0;
+            if (s_RegGetValueA(key, rootdir, valuename, RRF_RT_ANY, &type, (PVOID)value, &valuesize) != ERROR_SUCCESS)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "get registry value failed: %s\\%s;%s", rootkey, rootdir, valuename);
+                break;
+            }
+        }
+        else
+        {
+            // open registry key
+            if (RegOpenKeyExA(key, rootdir, 0, KEY_QUERY_VALUE, &keynew) != ERROR_SUCCESS && keynew)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "open registry key failed: %s\\%s", rootkey, rootdir);
+                break;
+            }
+
+            // get registry value size
+            DWORD valuesize = 0;
+            if (RegQueryValueExA(keynew, valuename, tb_null, tb_null, tb_null, &valuesize) != ERROR_SUCCESS)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "get registry value size failed: %s\\%s;%s", rootkey, rootdir, valuename);
+                break;
+            }
+
+            // make value buffer
+            value = (tb_char_t*)tb_malloc0(valuesize + 1);
+            tb_assert_and_check_break(value);
+
+            // get value result
+            type = 0;
+            if (RegQueryValueExA(keynew, valuename, tb_null, &type, (LPBYTE)value, &valuesize) != ERROR_SUCCESS)
+            {
+                lua_pushnil(lua);
+                lua_pushfstring(lua, "get registry value failed: %s\\%s;%s", rootkey, rootdir, valuename);
+                break;
+            }
+        }
+
+        // save result
+        switch (type)
+        {
+        case REG_SZ:
+        case REG_EXPAND_SZ:
+            lua_pushstring(lua, value);
+            ok = tb_true;
+            break;
+        case REG_DWORD:
+            lua_pushfstring(lua, "%d", *((tb_int_t*)value));
+            ok = tb_true;
+            break;
+        case REG_QWORD:
+            lua_pushfstring(lua, "%lld", *((tb_int64_t*)value));
+            ok = tb_true;
+            break;
+        default:
+            lua_pushnil(lua);
+            lua_pushfstring(lua, "unsupported registry value type: %d", type);
+            break;
+        }
+
+    } while (0);
+
+    // exit registry key
+    if (keynew)
+        RegCloseKey(keynew);
+    keynew = tb_null;
+
+    // exit value
+    if (value) tb_free(value);
+    value = tb_null;
+
+    // ok?
+    return ok? 1 : 2;
+}

--- a/core/src/xmake/winos/registry_values.c
+++ b/core/src/xmake/winos/registry_values.c
@@ -53,12 +53,11 @@ tb_int_t xm_winos_registry_values(lua_State* lua)
     tb_bool_t is_function    = lua_isfunction(lua, 3);
     tb_check_return_val(rootkey && rootdir && is_function, 0);
 
-    // query key-value
+    // enum values
     tb_bool_t   ok = tb_false;
     tb_int_t    count = 0;
     HKEY        key = tb_null;
     HKEY        keynew = tb_null;
-    tb_char_t*  value = tb_null;
     do
     {
         // get registry rootkey

--- a/xmake/core/base/winos.lua
+++ b/xmake/core/base/winos.lua
@@ -288,8 +288,19 @@ function winos.registry_values(keypath)
     -- get the root directory
     local rootdir = keypath:sub(p + 1)
 
-    -- get values
-    return winos._registry_values(rootkey, rootdir, pattern)
+    -- get value names
+    local value_names = {}
+    local count, errors = winos._registry_values(rootkey, rootdir, function (value_name)
+        if not pattern or value_name:match("^" .. pattern .. "$") then
+            table.insert(value_names, value_name)
+        end
+        return true
+    end)
+    if count ~= nil then
+        return value_names
+    else
+        return nil, errors
+    end
 end
 
 -- return module: winos

--- a/xmake/core/base/winos.lua
+++ b/xmake/core/base/winos.lua
@@ -26,10 +26,11 @@ local os     = require("base/os")
 local path   = require("base/path")
 local semver = require("base/semver")
 
-winos._ansi_cp        = winos._ansi_cp or winos.ansi_cp
-winos._oem_cp         = winos._oem_cp  or winos.oem_cp
-winos._registry_query = winos._registry_query or winos.registry_query
-winos._registry_keys  = winos._registry_keys or winos.registry_keys
+winos._ansi_cp         = winos._ansi_cp or winos.ansi_cp
+winos._oem_cp          = winos._oem_cp  or winos.oem_cp
+winos._registry_query  = winos._registry_query or winos.registry_query
+winos._registry_keys   = winos._registry_keys or winos.registry_keys
+winos._registry_values = winos._registry_values or winos.registry_values
 
 function winos.ansi_cp()
     if not winos._ANSI_CP then

--- a/xmake/core/base/winos.lua
+++ b/xmake/core/base/winos.lua
@@ -241,17 +241,29 @@ function winos.registry_keys(keypath)
     end
 
     -- get the root directory
+    local pattern
     local rootdir = keypath:sub(p + 1)
     p = rootdir:find("*", 1, true)
     if p then
         rootdir = path.directory(rootdir:sub(1, p - 1))
+        pattern = path.pattern(keypath)
     end
 
-    -- get key pattern with a lua pattern
-    local pattern = path.pattern(keypath)
+    print(rootkey, rootdir, pattern)
 
     -- get keys
-    return winos._registry_keys(rootkey, rootdir, pattern)
+    local keys = {}
+    local count, errors = winos._registry_keys(rootkey, rootdir, function (key)
+        if not pattern or key:match("^" .. pattern .. "$") then
+            table.insert(keys, key)
+        end
+        return true
+    end)
+    if count ~= nil then
+        return keys
+    else
+        return nil, errors
+    end
 end
 
 -- get registry values from the given key path

--- a/xmake/core/sandbox/modules/interpreter/winos.lua
+++ b/xmake/core/sandbox/modules/interpreter/winos.lua
@@ -25,9 +25,11 @@ local winos = require("base/winos")
 local sandbox_winos = sandbox_winos or {}
 
 -- export some readonly interfaces
-sandbox_winos.registry_query = winos.registry_query
-sandbox_winos.logical_drives = winos.logical_drives
-sandbox_winos.version        = winos.version
+sandbox_winos.registry_query  = winos.registry_query
+sandbox_winos.registry_keys   = winos.registry_keys
+sandbox_winos.registry_values = winos.registry_values
+sandbox_winos.logical_drives  = winos.logical_drives
+sandbox_winos.version         = winos.version
 
 -- return module
 return sandbox_winos

--- a/xmake/core/sandbox/modules/winos.lua
+++ b/xmake/core/sandbox/modules/winos.lua
@@ -31,7 +31,6 @@ sandbox_winos.ansi_cp           = winos.ansi_cp
 sandbox_winos.cp_info           = winos.cp_info
 sandbox_winos.console_cp        = winos.console_cp
 sandbox_winos.console_output_cp = winos.console_output_cp
-sandbox_winos.registry_query    = winos.registry_query
 sandbox_winos.logical_drives    = winos.logical_drives
 sandbox_winos.cmdargv           = winos.cmdargv
 
@@ -42,6 +41,33 @@ function sandbox_winos.version()
         raise("cannot get the version of the current winos!")
     end
     return winver
+end
+
+-- query registry value
+function sandbox_winos.registry_query(keypath)
+    local value, errors = winos.registry_query(keypath)
+    if not value then
+        raise(errors)
+    end
+    return value
+end
+
+-- get registry keys
+function sandbox_winos.registry_keys(pattern)
+    local keypaths, errors = winos.registry_keys(pattern)
+    if not keypaths then
+        raise(errors)
+    end
+    return keypaths
+end
+
+-- get registry values
+function sandbox_winos.registry_values(keypath)
+    local values, errors = winos.registry_values(keypath)
+    if not values then
+        raise(errors)
+    end
+    return values
 end
 
 -- return module

--- a/xmake/core/sandbox/modules/winos.lua
+++ b/xmake/core/sandbox/modules/winos.lua
@@ -53,12 +53,12 @@ function sandbox_winos.registry_query(keypath)
 end
 
 -- get registry keys
-function sandbox_winos.registry_keys(pattern)
-    local keypaths, errors = winos.registry_keys(pattern)
-    if not keypaths then
+function sandbox_winos.registry_keys(keypath)
+    local keys, errors = winos.registry_keys(keypath)
+    if not keys then
         raise(errors)
     end
-    return keypaths
+    return keys
 end
 
 -- get registry values


### PR DESCRIPTION
```lua
local value = winos.registry_query("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug")
local value = winos.registry_query("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug;Debugger")

local keys = winos.registry_keys("HKEY_LOCAL_MACHINE\\SOFTWARE\\*\\Windows NT\\*\\CurrentVersion\\AeDebug")
local keys = winos.registry_keys("HKEY_LOCAL_MACHINE\\SOFTWARE\\**")

local values = winos.registry_values("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug")
local values = winos.registry_values("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug;Debug*")
```

related issue: https://github.com/xmake-io/xmake/issues/1032