### PR TITLE
fix debugging flags for ldc2

### DIFF
--- a/xmake/modules/core/tools/ldc2.lua
+++ b/xmake/modules/core/tools/ldc2.lua
@@ -47,4 +47,12 @@ function nf_optimize(self, level)
     return maps[level]
 end
 
+-- make the symbol flag
+function nf_symbol(self, level)
+    local maps =
+    {
+        debug = "-g --d-debug"
+    }
+    return maps[level]
+end
 


### PR DESCRIPTION
Hello,

ldc2 does not accept a `-debug` flag, like dmd does. Instead it uses `--d-debug[=<level/idents>]`