### PR TITLE
Add compile mode parameter for windeployqt.exe

### DIFF
--- a/xmake/rules/qt/install/windows.lua
+++ b/xmake/rules/qt/install/windows.lua
@@ -71,7 +71,7 @@ function main(target, opt)
 
     if is_mode("debug") then
         table.insert(argv, "--debug")
-    elseif is_mode("release") then
+    else
         table.insert(argv, "--release")
     end
 

--- a/xmake/rules/qt/install/windows.lua
+++ b/xmake/rules/qt/install/windows.lua
@@ -68,6 +68,13 @@ function main(target, opt)
     else
         table.insert(argv, "--verbose=0")
     end
+
+    if is_mode("debug") then
+        table.insert(argv, "--debug")
+    elseif is_mode("release") then
+        table.insert(argv, "--release")
+    end
+
     if qmldir then
         table.insert(argv, "--qmldir=" .. qmldir)
     end


### PR DESCRIPTION
When using the install command on a Qt project, the debug library is copied to the installation directory even if the project is set to release mode. This problem can occur on windows systems with multiple versions of Qt installed.
For more details: https://blog.csdn.net/qq_36170958/article/details/108721408

Therefore, when running windeployqt.exe, set the debug or release parameter according to the project mode