### PR TITLE
Recursively add target dependency env

### DIFF
--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -90,12 +90,15 @@ function _on_run_target(target)
 end
 
 -- recursively target add env
-function _add_target_pkgenvs(target)
+function _add_target_pkgenvs(target, oldenvs)
     for name, values in pairs(target:pkgenvs()) do
+        if not oldenvs[name] then
+            oldenvs[name] = os.getenv(name)
+        end
         os.addenv(name, unpack(values))
     end
     for _, dep in ipairs(target:orderdeps()) do
-        _add_target_pkgenvs(dep)
+        _add_target_pkgenvs(dep, oldenvs)
     end
 end
 
@@ -104,10 +107,7 @@ function _run(target)
 
     -- enter the environments of the target packages
     local oldenvs = {}
-    for name, values in pairs(target:pkgenvs()) do
-        oldenvs[name] = os.getenv(name)
-    end
-    _add_target_pkgenvs(target)
+    _add_target_pkgenvs(target, oldenvs)
 
     -- the target scripts
     local scripts =

--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -90,7 +90,11 @@ function _on_run_target(target)
 end
 
 -- recursively target add env
-function _add_target_pkgenvs(target, oldenvs)
+function _add_target_pkgenvs(target, oldenvs, targets_added)
+    if targets_added[target:name()] then
+        return
+    end
+    targets_added[target:name()] = true
     for name, values in pairs(target:pkgenvs()) do
         if not oldenvs[name] then
             oldenvs[name] = os.getenv(name)
@@ -98,7 +102,7 @@ function _add_target_pkgenvs(target, oldenvs)
         os.addenv(name, unpack(values))
     end
     for _, dep in ipairs(target:orderdeps()) do
-        _add_target_pkgenvs(dep, oldenvs)
+        _add_target_pkgenvs(dep, oldenvs, targets_added)
     end
 end
 
@@ -107,7 +111,7 @@ function _run(target)
 
     -- enter the environments of the target packages
     local oldenvs = {}
-    _add_target_pkgenvs(target, oldenvs)
+    _add_target_pkgenvs(target, oldenvs, {})
 
     -- the target scripts
     local scripts =

--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -89,6 +89,16 @@ function _on_run_target(target)
     _do_run_target(target)
 end
 
+-- recursively target add env
+function _add_target_pkgenvs(target)
+    for name, values in pairs(target:pkgenvs()) do
+        os.addenv(name, unpack(values))
+    end
+    for _, dep in ipairs(target:orderdeps()) do
+        _add_target_pkgenvs(dep)
+    end
+end
+
 -- run the given target
 function _run(target)
 
@@ -96,8 +106,8 @@ function _run(target)
     local oldenvs = {}
     for name, values in pairs(target:pkgenvs()) do
         oldenvs[name] = os.getenv(name)
-        os.addenv(name, unpack(values))
     end
+    _add_target_pkgenvs(target)
 
     -- the target scripts
     local scripts =


### PR DESCRIPTION
For example, there is a project like this
```
target("xxlib")
    set_kind("shared")
    add_packages("xxpkg")

target("mainexe")
    set_kind("binary")
    add_deps("xxlib")
```
when use `xmake r` to run the target mainexe, the env of package xxpkg could not be set.
so changed the code to recursively add target dependency env.