### PR TITLE
修复在设置了代理而没有pac文件的情况下，curl不会走代理的问题

### DIFF
--- a/xmake/modules/net/proxy.lua
+++ b/xmake/modules/net/proxy.lua
@@ -88,6 +88,9 @@ function get(url)
         if proxy_pac and proxy_pac(url, host) then
             return global.get("proxy")
         end
+        if not proxy_pac and not proxy_hosts then
+            return global.get("proxy")
+        end 
         return
     end
 


### PR DESCRIPTION
根据xmake文档说明，在设置了代理而缺少pac文件的情况将会全局应用代理，实际使用时发现只设置代理而没有pac文件的情况下，curl不会使用代理。