### PR TITLE
improve package.tools.gn

### DIFF
--- a/xmake/modules/package/tools/gn.lua
+++ b/xmake/modules/package/tools/gn.lua
@@ -61,7 +61,9 @@ function generate(package, configs, opt)
     table.insert(argv, _get_buildir(opt))
     for name, value in pairs(_get_configs(package, configs, opt)) do
         if type(value) == "string" then
-            table.insert(args, name .. '=\"' .. value .. "\"")
+            table.insert(args, name .. "=\"" .. value .. "\"")
+        elseif type(value) == "table" then
+            table.insert(args, name .. "=[\"" .. table.concat(value, "\",\"") .. "\"]")
         else
             table.insert(args, name .. "=" .. tostring(value))
         end


### PR DESCRIPTION
gn支持用--args="foo=[\"bar\"]"的格式传入table变量，修改后可支持从lua table到gn table的转换