### PR TITLE
Add scons buildsystem to package.tools

### DIFF
--- a/xmake/modules/package/tools/scons.lua
+++ b/xmake/modules/package/tools/scons.lua
@@ -1,0 +1,36 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      PucklaMotzer09
+-- @file        scons.lua
+--
+
+-- imports
+import("core.base.option")
+import("lib.detect.find_tool")
+
+-- build package
+function build(package, configs, opt)
+    opt = opt or {}
+    local buildir = opt.buildir or os.curdir()
+    local njob = opt.jobs or option.get("jobs") or tostring(math.ceil(os.cpuinfo().ncpu * 3 / 2))
+    local scons = assert(find_tool("scons"), "scons not found!")
+    local argv = {"-C", buildir, "-j", njob}
+    if configs then
+        table.join2(argv, configs)
+    end
+    os.vrunv(scons.program, argv, {envs = opt.envs})
+end


### PR DESCRIPTION
This adds the scons buildsystem so that it can be more easily used inside packages.