### PR TITLE
Use sysincludes for Qt frameworks

### DIFF
--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -88,7 +88,7 @@ end
 function _add_includedirs(target, includedirs)
     for _, includedir in ipairs(includedirs) do
         if os.isdir(includedir) then
-            target:add("includedirs", includedir)
+            target:add("sysincludedirs", includedir)
         end
     end
 end

--- a/xmake/rules/qt/moc/xmake.lua
+++ b/xmake/rules/qt/moc/xmake.lua
@@ -53,7 +53,7 @@ rule("qt.moc")
         local flags = {}
         table.join2(flags, compiler.map_flags("cxx", "define", target:get("defines")))
         table.join2(flags, compiler.map_flags("cxx", "includedir", target:get("includedirs")))
-        table.join2(flags, compiler.map_flags("cxx", "includedir", target:get("sysincludedirs")))
+        table.join2(flags, compiler.map_flags("cxx", "includedir", target:get("sysincludedirs"))) -- for now, moc process doesn't support MSVC external includes flags and will fail
         table.join2(flags, compiler.map_flags("cxx", "frameworkdir", target:get("frameworkdirs")))
         batchcmds:mkdir(path.directory(sourcefile_moc))
         batchcmds:vrunv(moc, table.join(flags, sourcefile, "-o", sourcefile_moc))

--- a/xmake/rules/qt/moc/xmake.lua
+++ b/xmake/rules/qt/moc/xmake.lua
@@ -53,7 +53,7 @@ rule("qt.moc")
         local flags = {}
         table.join2(flags, compiler.map_flags("cxx", "define", target:get("defines")))
         table.join2(flags, compiler.map_flags("cxx", "includedir", target:get("includedirs")))
-        table.join2(flags, compiler.map_flags("cxx", "sysincludedir", target:get("sysincludedirs")))
+        table.join2(flags, compiler.map_flags("cxx", "includedir", target:get("sysincludedirs")))
         table.join2(flags, compiler.map_flags("cxx", "frameworkdir", target:get("frameworkdirs")))
         batchcmds:mkdir(path.directory(sourcefile_moc))
         batchcmds:vrunv(moc, table.join(flags, sourcefile, "-o", sourcefile_moc))


### PR DESCRIPTION
Make Qt frameworks use sysincludedirs instead of includedirs, to prevent errors from Qt headers.
I found out that by doing so, the moc step could fail (and maybe other as well?) because it doesn't support MSVC experimental sysincludes flags. So I disabled sysincludes for the moc step (maybe we should do it as well for other Qt steps)

log:
```
moc: Unknown options: experimental:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore, experimental:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore\5.15.0, experime
ntal:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore\5.15.0\QtCore, experimental:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtGui, experimental:external, external:
W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtGui\5.15.0, experimental:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtGui\5.15.0\QtGui, experimental:external, external:W0, external:IC:\Pr
ojets\Libs\Qt\5.15.0\msvc2019_64\include\QtWidgets, experimental:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtWidgets\5.15.0, experimental:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msv
c2019_64\include\QtWidgets\5.15.0\QtWidgets, experimental:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include, experimental:external, external:W0, external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\mkspecs\win32-m
svc.
error: @programdir\modules\private\async\runjobs.lua:217: @programdir\core\sandbox\modules\os.lua:388: execv(C:\Projets\Libs\Qt\5.15.0\msvc2019_64\bin\moc.exe -DQT_NO_DEBUG -DQT_DEPRECATED_WARNINGS -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS
_LIB -Iinclude -Isrc -Ithirdparty\include -IC:\Projets\Burgwar\BurgWar\build\.gens\BurgWarMapEditor\windows\x64\release\rules\qt\ui -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore -expe
rimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore\5.15.0 -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore\5.15.0\QtCore -experimental:externa
l -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtGui -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtGui\5.15.0 -experimental:external -external:W0 -external:IC:\Pro
jets\Libs\Qt\5.15.0\msvc2019_64\include\QtGui\5.15.0\QtGui -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtWidgets -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\ms
vc2019_64\include\QtWidgets\5.15.0 -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtWidgets\5.15.0\QtWidgets -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_
64\include -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\mkspecs\win32-msvc src\MapEditor\Widgets\PlayWindow.hpp -o build\.gens\BurgWarMapEditor\windows\x64\release\rules\qt\moc\moc_PlayWindow.cpp)
failed(1)
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:787]: in function 'raise'
    [@programdir\core\sandbox\modules\os.lua:388]: in function 'runv'
    [@programdir\core\sandbox\modules\os.lua:285]: in function 'vrunv'
    [@programdir\modules\private\utils\batchcmds.lua:96]: in function 'script'
    [@programdir\modules\private\utils\batchcmds.lua:170]: in function '_runcmd'
    [@programdir\modules\private\utils\batchcmds.lua:177]: in function '_runcmds'
    [@programdir\modules\private\utils\batchcmds.lua:329]: in function 'callback'
    [@programdir\modules\core\project\depend.lua:186]: in function 'on_changed'
    [@programdir\modules\private\utils\batchcmds.lua:328]: in function 'runcmds'
    [@programdir\actions\build\kinds\object.lua:86]: in function 'jobfunc'
    [@programdir\modules\private\async\runjobs.lua:193]:
    [C]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:121]: in function 'try'
    [@programdir\modules\private\async\runjobs.lua:186]: in function 'cotask'
    [@programdir\core\base\scheduler.lua:317]:
```

Also, I noticed some flags were repeated in the command line with sysincludedirs, like here:
```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29910\bin\HostX64\x64\cl.exe -c /EHsc -nologo -Zi -FS -Fdbin\windows_x64_release\compile.BurgWarMapEditor.pdb -W4 -std:c++17 -MDd -Iinclude -Isrc -Ithirdpa
rty\include -IC:\Projets\Burgwar\BurgWar\build\.gens\BurgWarMapEditor\windows\x64\release\rules\qt\ui -Icontrib\lua\include -DQT_NO_DEBUG -DQT_DEPRECATED_WARNINGS -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS_LIB -DLUA_BUILD_AS_DLL -experiment
al:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore\5.15.0 -experimental:external -external:W0 -exte
rnal:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtCore\5.15.0\QtCore -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtGui -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt
\5.15.0\msvc2019_64\include\QtGui\5.15.0 -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtGui\5.15.0\QtGui -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64
\include\QtWidgets -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtWidgets\5.15.0 -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include\QtWidgets\5.15.
0\QtWidgets -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\include -experimental:external -external:W0 -external:IC:\Projets\Libs\Qt\5.15.0\msvc2019_64\mkspecs\win32-msvc -experimental:external -exte
rnal:W0 -external:IC:\Users\Lynix\AppData\Local\.xmake\packages\c\concurrentqueue\master\0d7f1f1d4f2f4da98ea5f47106cbb14f\include -experimental:external -external:W0 -external:IC:\Users\Lynix\AppData\Local\.xmake\packages\f\fmt\7.1.3\607
b035c20554b63865fb256d5dfded4\include -experimental:external -external:W0 -external:IC:\Users\Lynix\AppData\Local\.xmake\packages\n\nlohmann_json\v3.9.1\856813e803be4e2e9bd166db0671a402\include -experimental:external -external:W0 -extern
al:IC:\Users\Lynix\AppData\Local\.xmake\packages\n\nazaraengine\2021.04.01\65574c0e296a4e268ca1e98b4fbbdb47\include /bigobj /Zc:__cplusplus /Zc:referenceBinding /Zc:throwingNew /FC /w44062 /wd4251 -Fobuild\.objs\BurgWarMapEditor\windows\
x64\release\gens\rules\qt\moc\moc_MapCanvas.cpp.obj build\.gens\BurgWarMapEditor\windows\x64\release\rules\qt\moc\moc_MapCanvas.cppmoc_WorldCanvas.cpp
```

`-experimental:external -external:W0` appears **13** times, wouldn't be nice if xmake removed duplicates like this one?