### PR TITLE
improve package.tools.cmake

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -116,13 +116,8 @@ function _get_cflags(package, opt)
         table.join2(result, opt.cxflags)
     end
     table.join2(result, _get_cflags_from_packagedeps(package, opt))
-    for i, flag in ipairs(result) do
-        if flag:match(" ") then
-            result[i] = '"' .. flag .. '"'
-        end
-    end
     if #result > 0 then
-        return table.concat(result, ' ')
+        return os.args(result)
     end
 end
 
@@ -146,13 +141,8 @@ function _get_cxxflags(package, opt)
         table.join2(result, opt.cxflags)
     end
     table.join2(result, _get_cflags_from_packagedeps(package, opt))
-    for i, flag in ipairs(result) do
-        if flag:match(" ") then
-            result[i] = '"' .. flag .. '"'
-        end
-    end
     if #result > 0 then
-        return table.concat(result, ' ')
+        return os.args(result)
     end
 end
 
@@ -170,13 +160,8 @@ function _get_asflags(package, opt)
     if opt.asflags then
         table.join2(result, opt.asflags)
     end
-    for i, flag in ipairs(result) do
-        if flag:match(" ") then
-            result[i] = '"' .. flag .. '"'
-        end
-    end
     if #result > 0 then
-        return table.concat(result, ' ')
+        return os.args(result)
     end
 end
 
@@ -194,13 +179,8 @@ function _get_ldflags(package, opt)
     if opt.ldflags then
         table.join2(result, opt.ldflags)
     end
-    for i, flag in ipairs(result) do
-        if flag:match(" ") then
-            result[i] = '"' .. flag .. '"'
-        end
-    end
     if #result > 0 then
-        return table.concat(result, ' ')
+        return os.args(result)
     end
 end
 
@@ -218,13 +198,8 @@ function _get_shflags(package, opt)
     if opt.shflags then
         table.join2(result, opt.shflags)
     end
-    for i, flag in ipairs(result) do
-        if flag:match(" ") then
-            result[i] = '"' .. flag .. '"'
-        end
-    end
     if #result > 0 then
-        return table.concat(result, ' ')
+        return os.args(result)
     end
 end
 

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -116,6 +116,11 @@ function _get_cflags(package, opt)
         table.join2(result, opt.cxflags)
     end
     table.join2(result, _get_cflags_from_packagedeps(package, opt))
+    for i, flag in ipairs(result) do
+        if flag:match(" ") then
+            result[i] = '"' .. flag .. '"'
+        end
+    end
     if #result > 0 then
         return table.concat(result, ' ')
     end
@@ -141,6 +146,11 @@ function _get_cxxflags(package, opt)
         table.join2(result, opt.cxflags)
     end
     table.join2(result, _get_cflags_from_packagedeps(package, opt))
+    for i, flag in ipairs(result) do
+        if flag:match(" ") then
+            result[i] = '"' .. flag .. '"'
+        end
+    end
     if #result > 0 then
         return table.concat(result, ' ')
     end
@@ -159,6 +169,11 @@ function _get_asflags(package, opt)
     table.join2(result, package:config("asflags"))
     if opt.asflags then
         table.join2(result, opt.asflags)
+    end
+    for i, flag in ipairs(result) do
+        if flag:match(" ") then
+            result[i] = '"' .. flag .. '"'
+        end
     end
     if #result > 0 then
         return table.concat(result, ' ')
@@ -179,6 +194,11 @@ function _get_ldflags(package, opt)
     if opt.ldflags then
         table.join2(result, opt.ldflags)
     end
+    for i, flag in ipairs(result) do
+        if flag:match(" ") then
+            result[i] = '"' .. flag .. '"'
+        end
+    end
     if #result > 0 then
         return table.concat(result, ' ')
     end
@@ -197,6 +217,11 @@ function _get_shflags(package, opt)
     table.join2(result, _get_ldflags_from_packagedeps(package, opt))
     if opt.shflags then
         table.join2(result, opt.shflags)
+    end
+    for i, flag in ipairs(result) do
+        if flag:match(" ") then
+            result[i] = '"' .. flag .. '"'
+        end
     end
     if #result > 0 then
         return table.concat(result, ' ')


### PR DESCRIPTION
使用packagedeps的时候路径含空格会出问题

正确的flag是
```
"-DCMAKE_SHARED_LINKER_FLAGS=\"-libpath:C:/Program Files (x86)/Intel/oneAPI/tbb/latest/lib/intel64/vc14\" tbb.lib tbbmalloc.lib tbbmalloc_proxy.lib"
```

而目前的flag是
```
"-DCMAKE_SHARED_LINKER_FLAGS=-libpath:C:/Program Files (x86)/Intel/oneAPI/tbb/latest/lib/intel64/vc14 tbb.lib tbbmalloc.lib tbbmalloc_proxy.lib"
```