### PR TITLE
improve environment management on cmd

### DIFF
--- a/scripts/xrepo-hook.psm1
+++ b/scripts/xrepo-hook.psm1
@@ -15,6 +15,10 @@ function Enter-XrepoEnvironment {
     begin {
         $script:xrepoOldEnvs = (Get-ChildItem -Path Env:);
         $xrepoPrompt = (& $Env:XMAKE_EXE lua private.xrepo.action.env.info prompt | Out-String);
+        if (-not $?) {
+            Write-Host $xrepoPrompt
+            Exit 1
+        }
         $activateCommand = (& $Env:XMAKE_EXE lua private.xrepo.action.env.info script.powershell | Out-String);
 
         Write-Verbose "[xrepo env script.powershell]`n$activateCommand";
@@ -39,7 +43,9 @@ function Exit-XrepoEnvironment {
     param();
 
     begin {
-        # Write-Host $script:xrepoOldEnvs;
+        ForEach ($p in (Get-ChildItem Env:)) {
+            [Environment]::SetEnvironmentVariable($p.Name, $Null);
+        }
         ForEach ($p in $script:xrepoOldEnvs) {
             [Environment]::SetEnvironmentVariable($p.Name, $p.Value);
         }

--- a/scripts/xrepo.bat
+++ b/scripts/xrepo.bat
@@ -1,11 +1,13 @@
-@REM @echo off
+@echo off
 
 @set "XMAKE_EXE=%~dp0xmake.exe"
 @if [%1]==[env] (
     if [%2]==[quit] (
         if defined XMAKE_PROMPT_BACKUP (
             call %XMAKE_ENV_BACKUP%
-            if %errorlevel% neq 0 exit /B %errorlevel%
+            setlocal EnableDelayedExpansion
+            if !errorlevel! neq 0 exit /B !errorlevel!
+            endlocal
             set PROMPT=%XMAKE_PROMPT_BACKUP%
             set XMAKE_ENV_BACKUP=
             set XMAKE_PROMPT_BACKUP=
@@ -15,18 +17,35 @@
     if [%2]==[shell] (
         if defined XMAKE_PROMPT_BACKUP (
             call %XMAKE_ENV_BACKUP%
-            if %errorlevel% neq 0 exit /B %errorlevel%
+            setlocal EnableDelayedExpansion
+            if !errorlevel! neq 0 exit /B !errorlevel!
+            @%XMAKE_EXE% lua private.xrepo.action.env.info prompt 1>nul
+            if !errorlevel! neq 0 (
+                echo error: xmake.lua not found^^!
+                exit /B !errorlevel!
+            )
+            endlocal
             set PROMPT=%XMAKE_PROMPT_BACKUP%
-            for /f %%i in ('%XMAKE_EXE% lua private.xrepo.action.env.info prompt') do @set "PROMPT=%%i %XMAKE_PROMPT_BACKUP%"
+            set XMAKE_ENV_BACKUP=
+            set XMAKE_PROMPT_BACKUP=
+            echo Please rerun `xrepo env shell` to enter the environment.
+            exit /B 1
         ) else (
+            setlocal EnableDelayedExpansion
+            @%XMAKE_EXE% lua private.xrepo.action.env.info prompt 1>nul
+            if !errorlevel! neq 0 (
+                echo error: xmake.lua not found^^!
+                exit /B !errorlevel!
+            )
+            endlocal
+            for /f %%i in ('@%XMAKE_EXE% lua private.xrepo.action.env.info prompt') do @set "PROMPT=%%i %PROMPT%"
             set XMAKE_PROMPT_BACKUP=%PROMPT%
-            for /f %%i in ('%XMAKE_EXE% lua private.xrepo.action.env.info prompt') do @set "PROMPT=%%i %PROMPT%"
         )
-        for /f %%i in ('%XMAKE_EXE% lua private.xrepo.action.env.info envfile') do @(
+        for /f %%i in ('@%XMAKE_EXE% lua private.xrepo.action.env.info envfile') do @(
             set "XMAKE_ENV_BACKUP=%%i.bat"
             @"%XMAKE_EXE%" lua private.xrepo.action.env.info backup.cmd 1>"%%i.bat"
         )
-        for /f %%i in ('%XMAKE_EXE% lua private.xrepo.action.env.info envfile') do @(
+        for /f %%i in ('@%XMAKE_EXE% lua private.xrepo.action.env.info envfile') do @(
             @"%XMAKE_EXE%" lua private.xrepo.action.env.info script.cmd 1>"%%i.bat"
             call "%%i.bat"
         )

--- a/scripts/xrepo.bat
+++ b/scripts/xrepo.bat
@@ -1,2 +1,39 @@
-@echo off
-xmake lua private.xrepo %*
+@REM @echo off
+
+@set "XMAKE_EXE=%~dp0xmake.exe"
+@if [%1]==[env] (
+    if [%2]==[quit] (
+        if defined XMAKE_PROMPT_BACKUP (
+            call %XMAKE_ENV_BACKUP%
+            if %errorlevel% neq 0 exit /B %errorlevel%
+            set PROMPT=%XMAKE_PROMPT_BACKUP%
+            set XMAKE_ENV_BACKUP=
+            set XMAKE_PROMPT_BACKUP=
+        )
+        goto :ENDXREPO
+    )
+    if [%2]==[shell] (
+        if defined XMAKE_PROMPT_BACKUP (
+            call %XMAKE_ENV_BACKUP%
+            if %errorlevel% neq 0 exit /B %errorlevel%
+            set PROMPT=%XMAKE_PROMPT_BACKUP%
+            for /f %%i in ('%XMAKE_EXE% lua private.xrepo.action.env.info prompt') do @set "PROMPT=%%i %XMAKE_PROMPT_BACKUP%"
+        ) else (
+            set XMAKE_PROMPT_BACKUP=%PROMPT%
+            for /f %%i in ('%XMAKE_EXE% lua private.xrepo.action.env.info prompt') do @set "PROMPT=%%i %PROMPT%"
+        )
+        for /f %%i in ('%XMAKE_EXE% lua private.xrepo.action.env.info envfile') do @(
+            set "XMAKE_ENV_BACKUP=%%i.bat"
+            @"%XMAKE_EXE%" lua private.xrepo.action.env.info backup.cmd 1>"%%i.bat"
+        )
+        for /f %%i in ('%XMAKE_EXE% lua private.xrepo.action.env.info envfile') do @(
+            @"%XMAKE_EXE%" lua private.xrepo.action.env.info script.cmd 1>"%%i.bat"
+            call "%%i.bat"
+        )
+        goto :ENDXREPO
+    )
+)
+
+@call %XMAKE_EXE% lua private.xrepo %*
+
+:ENDXREPO

--- a/xmake/modules/private/xrepo/action/env.lua
+++ b/xmake/modules/private/xrepo/action/env.lua
@@ -267,13 +267,13 @@ function info(key)
         assert(os.isfile(os.projectfile()), "xmake.lua not found!")
         print("[%s]", path.filename(os.projectdir()))
     elseif key == "envfile" then
-        print("%s", os.tmpfile())
+        print(os.tmpfile())
     elseif key:startswith("script.") then
         local shell = key:match("script%.(.+)")
         print(_get_env_script(_package_getenvs(), shell, false))
     elseif key:startswith("backup.") then
         local shell = key:match("backup%.(.+)")
-        
+
         -- remove current environment variables first
         print(_get_env_script(_package_getenvs(), shell, true))
         print(_get_env_script(os.getenvs(), shell, false))


### PR DESCRIPTION
新增命令

- `private.xrepo.action.env.info envfile`: 避免直接调用os.tmpfile()的颜色和双引号
- `private.xrepo.action.env.info backup.cmd`: 由于cmd没有提供script-wide variable，备份要用临时文件来做

改动

- 不再使用hashset实现