### PR TITLE
Automatically set CMAKE_POSITION_INDEPENDENT_CODE if pic isn't set to false

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -225,6 +225,9 @@ function _get_configs_for_generic(package, configs, opt)
     if shflags then
         table.insert(configs, "-DCMAKE_SHARED_LINKER_FLAGS=" .. shflags)
     end
+    if package:config("pic") ~= false then
+        table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+    end
 end
 
 -- get configs for windows


### PR DESCRIPTION
Setting CMAKE_POSITION_INDEPENDENT_CODE in every package is quite redondant since it's a standard cmake option.

Since we already set `CMAKE_MSVC_RUNTIME_LIBRARY` according to the `vs_runtime` config, why not handle `pic` automatically as well?