### PR TITLE
add the category to the git package to fix installation

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -153,7 +153,7 @@ install_tools()
     { yum --version >/dev/null 2>&1 && $sudoprefix yum install -y git readline-devel ccache && $sudoprefix yum groupinstall -y 'Development Tools'; } ||
     { zypper --version >/dev/null 2>&1 && $sudoprefix zypper --non-interactive install git readline-devel ccache && $sudoprefix zypper --non-interactive install -t pattern devel_C_C++; } ||
     { pacman -V >/dev/null 2>&1 && $sudoprefix pacman -S --noconfirm --needed git base-devel ccache; } ||
-    { emerge -V >/dev/null 2>&1 && $sudoprefix emerge -atv git ccache gentoolkit; } ||
+    { emerge -V >/dev/null 2>&1 && $sudoprefix emerge -atv dev-vcs/git ccache gentoolkit; } ||
     { pkg list-installed >/dev/null 2>&1 && $sudoprefix pkg install -y git getconf build-essential readline ccache; } || # termux
     { pkg help >/dev/null 2>&1 && $sudoprefix pkg install -y git readline ccache ncurses; } || # freebsd
     { apk --version >/dev/null 2>&1 && $sudoprefix apk add git gcc g++ make readline-dev ncurses-dev libc-dev linux-headers; }


### PR DESCRIPTION
Packages on gentoo are named as `category/package`, allowing there to be multiple packages of the same name.
Typically just specifying the package is fine as there aren't usually conflicting packages.
However in this case, there are multiple `git` packages.