### PR TITLE
Move vsxmake.autoupdate dependfile to the persistent .xmake cache folder

### DIFF
--- a/xmake/rules/plugin/vsxmake/xmake.lua
+++ b/xmake/rules/plugin/vsxmake/xmake.lua
@@ -37,7 +37,7 @@ rule("plugin.vsxmake.autoupdate")
         import("core.base.task")
 
         -- run only once for all xmake process in vs
-        local tmpfile = os.tmpfile(path.join(os.projectdir(), "plugin.vsxmake.autoupdate"))
+        local tmpfile = path.join(os.projectdir(), ".xmake", "plugin.vsxmake.autoupdate")
         local dependfile = tmpfile .. ".d"
         local lockfile = io.openlock(tmpfile .. ".lock")
         if lockfile:trylock() then


### PR DESCRIPTION
plugin.vsxmake.autoupdate relies on a temporary file to know if it should regenerate the vsxmake project or not. This can be annoying because Windows will regulary remove it (everyday at least once, or when you reboot your computer), regenerating the project (which may take some time).

This moves the dependfile to the persistent .xmake cache folder where it will not be automatically deleted by the system.