### PR TITLE
Disable -fsanitize=address for MSVC linker

### DIFF
--- a/xmake/modules/core/tools/link.lua
+++ b/xmake/modules/core/tools/link.lua
@@ -43,6 +43,7 @@ function init(self)
 
         -- others
     ,   ["-ftrapv"]             = ""
+    ,   ["-fsanitize=address"]  = ""
     })
 end
 


### PR DESCRIPTION
With MSVC, ASAN is a compile-only option.
See https://bugzilla.mozilla.org/show_bug.cgi?id=1307547

```
"C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.29.30037\\bin\\HostX64\\x64\\link.exe" -dll -nologo -machine:x64 -libpath:C:\Users\Lynix\AppData\Local\.xmake\packages\l\li
bflac\1.3.3\84f4285b1cf249f28a083a321bcb0e8c\lib -libpath:C:\Users\Lynix\AppData\Local\.xmake\packages\l\libvorbis\1.3.7\4bfe445c523e49ba9e14c98364bb1781\lib -libpath:C:\Users\Lynix\AppData\Local\.xmake\packages
\l\libogg\v1.3.4\2022c3ffa18349dc870e0552ed20b90d\lib -libpath:C:\Users\Lynix\AppData\Local\.xmake\packages\o\openal-soft\1.21.1\aead9651b5aa4f4cb6b6d1770b5866ee\lib -libpath:bin\windows_x64_asan -debug -pdb:bin
\windows_x64_asan\NazaraAudio.pdb FLAC.lib vorbis.lib vorbisenc.lib vorbisfile.lib ogg.lib NazaraCore.lib -fsanitize=address -out:bin\windows_x64_asan\NazaraAudio.dll build\.objs\NazaraAudio\windows\x64\asan\src
\Nazara\Audio\Audio.cpp.obj build\.objs\NazaraAudio\windows\x64\asan\src\Nazara\Audio\Debug\NewOverload.cpp.obj build\.objs\NazaraAudio\windows\x64\asan\src\Nazara\Audio\Formats\drwavLoader.cpp.obj build\.objs\N
azaraAudio\windows\x64\asan\src\Nazara\Audio\Formats\libflacLoader.cpp.obj build\.objs\NazaraAudio\windows\x64\asan\src\Nazara\Audio\Formats\libvorbisLoader.cpp.obj build\.objs\NazaraAudio\windows\x64\asan\src\N
azara\Audio\Formats\minimp3Loader.cpp.obj build\.objs\NazaraAudio\windows\x64\asan\src\Nazara\Audio\Music.cpp.obj build\.objs\NazaraAudio\windows\x64\asan\src\Nazara\Audio\OpenAL.cpp.obj build\.objs\NazaraAudio\
windows\x64\asan\src\Nazara\Audio\Sound.cpp.obj build\.objs\NazaraAudio\windows\x64\asan\src\Nazara\Audio\SoundBuffer.cpp.obj build\.objs\NazaraAudio\windows\x64\asan\src\Nazara\Audio\SoundEmitter.cpp.obj build\
.objs\NazaraAudio\windows\x64\asan\src\Nazara\Audio\SoundStream.cpp.obj
error: LINK : warning LNK4044: unrecognized option '/fsanitize=address'; ignored
```