### PR TITLE
exclude more symbols for utils.symbols.export_all

### DIFF
--- a/xmake/rules/utils/symbols/export_all/export_all.lua
+++ b/xmake/rules/utils/symbols/export_all/export_all.lua
@@ -66,7 +66,13 @@ function main (target, opt)
                                     symbol = symbol:sub(2)
                                 end
                                 if export_classes or not symbol:startswith("?") then
-                                    allsymbols:insert(symbol)
+                                    if export_classes then
+                                        if not symbol:startswith("??_G") and not symbol:startswith("??_E") then
+                                            allsymbols:insert(symbol)
+                                        end
+                                    else
+                                        allsymbols:insert(symbol)
+                                    end
                                 end
                             end
                         end


### PR DESCRIPTION
exclude symbols starts with "??_G" and "??_E" when export symbols with option `export_classes`.

close #1491 