### PR TITLE
fix double quote escape for defines in compile_commands.json

### DIFF
--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -42,6 +42,10 @@ function _translate_arguments(arguments)
             arg = arg:gsub("[%-/]external:I", "-I")
         elseif arg:find("[%-/]external:W") or arg:find("[%-/]experimental:external") then
             arg = nil
+        -- escape '"' for the defines
+        -- https://github.com/xmake-io/xmake/issues/1506
+        elseif arg:find("^-D") then
+            arg = arg:gsub("\"", "\\\"")
         end
         -- @see use msvc-style flags for msvc to support language-server better
         -- https://github.com/xmake-io/xmake/issues/1284


### PR DESCRIPTION
Fixes the issue reported at: https://github.com/xmake-io/xmake/issues/1506

Result:

`add_defines("HELLO=\"hello\"")`

![image](https://user-images.githubusercontent.com/13299626/125285777-9400cf00-e34d-11eb-9da7-877313186fed.png)
