### PR TITLE
Fix package toplevel

### DIFF
--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -663,6 +663,11 @@ function _load_package(packagename, requireinfo, opt)
     -- get package from cache first
     local package_cached = _memcache():get2("packages", packagekey)
     if package_cached then
+        -- since toplevel is not part of packagekey, we need to ensure it's part of the cached package table too
+        if requireinfo.is_toplevel and not package_cached:is_toplevel() then
+            package_cached:requireinfo().is_toplevel = true
+        end
+
         return package_cached
     end
 


### PR DESCRIPTION
If a package is required by a target and by a dependency of a package added to a target:
Happens here with [nodeeditor package](https://github.com/DigitalPulseSoftware/NazaraEngine/commit/4dd78284096ecf255bc4dc5bb15582e58aa78164#diff-39c8f99d573d45398262ba26270252bc71342cdaefaa818351609873d4350fcf) used in [NazaraShaderNodes target](https://github.com/DigitalPulseSoftware/NazaraEngine/commit/4dd78284096ecf255bc4dc5bb15582e58aa78164#diff-aafa64472737451d80279de20f3125a18869c0d9a7fd4904cf000d0d943ae4f4R91).
Which [fails the compilation](https://github.com/DigitalPulseSoftware/NazaraEngine/runs/3182692504#step:9:4423)

This is because `qt5core` will be loaded and cached as not a toplevel dependency, xmake will never set toplevel boolean for it, which means it won't be part of `NazaraShaderNodes` as a package (`target:pkg("qt5core")` returns nil)

This fixes it, but I think this may be improved later