### PR TITLE
Fix .dll not being copied on install with MinGW

### DIFF
--- a/xmake/modules/package/manager/xmake/find_package.lua
+++ b/xmake/modules/package/manager/xmake/find_package.lua
@@ -99,7 +99,7 @@ function _find_package_from_repo(name, opt)
             table.insert(linkdirs, path.join(installdir, libdir))
         end
     end
-    if opt.plat == "windows" then
+    if opt.plat == "windows" or opt.plat == "mingw" then
         for _, file in ipairs(os.files(path.join(installdir, "lib", "*.dll"))) do
             result.shared = true
             table.insert(libfiles, file)


### PR DESCRIPTION
.dll were not copied on xmake install when built using MinGW because dll were not part of libfiles, this fixes it.