### PR TITLE
Change implib name on mingw (.lib -> .dll.a)

### DIFF
--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -334,7 +334,7 @@ function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
 
     -- add `-Wl,--out-implib,outputdir/libxxx.a` for xxx.dll on mingw/gcc
     if targetkind == "shared" and is_plat("mingw") then
-        table.insert(flags_extra, "-Wl,--out-implib," .. path.join(path.directory(targetfile), path.basename(targetfile) .. ".lib"))
+        table.insert(flags_extra, "-Wl,--out-implib," .. path.join(path.directory(targetfile), path.basename(targetfile) .. ".dll.a"))
     end
 
     -- init arguments

--- a/xmake/platforms/mingw/xmake.lua
+++ b/xmake/platforms/mingw/xmake.lua
@@ -31,7 +31,7 @@ platform("mingw")
     set_archs("i386", "x86_64", "arm", "arm64")
 
     -- set formats
-    set_formats("static", "$(name).lib")
+    set_formats("static", "$(name).a")
     set_formats("object", "$(name).obj")
     set_formats("shared", "$(name).dll")
     set_formats("binary", "$(name).exe")


### PR DESCRIPTION
On mingw, implib have generally the .dll.a extension instead of .lib. You can see for reference any msys2 package, for exemple: https://packages.msys2.org/package/mingw-w64-x86_64-chipmunk?repo=mingw64

