### PR TITLE
Update pacman find_package.lua to handle multiple .pc files and no .pc files

### DIFF
--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -53,7 +53,7 @@ function _find_package_from_list(list, opt, name, pacman)
                 end
             end
             table.insert(result.includedirs, path.directory(hpath))
-        -- revove lib and .a, .dll.a and .so to have the links
+        -- remove lib and .a, .dll.a and .so to have the links
         elseif line:endswith(".dll.a") then -- only for mingw
             local apath = os.iorunv(cygpath.program, {"--windows", line})
             table.insert(result.linkdirs, path.directory(apath))

--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -40,8 +40,15 @@ function main(name, opt)
     end
 
     -- for msys2/mingw? mingw-w64-[i686|x86_64]-xxx
+    local cygpath = nil
     if opt.plat == "mingw" then
         name = (opt.arch == "x86_64" and "mingw-w64-x86_64-" or "mingw-w64-i686-") .. name
+        
+        -- mingw + pacman = cygpath available
+        cygpath = find_tool("cygpath")
+        if not cygpath then
+            return
+        end
     end
 
     -- get package files list
@@ -49,7 +56,7 @@ function main(name, opt)
     if not list then
         return
     end
-
+        
     -- parse package files list
     local linkdirs = {}
     local has_includes = false
@@ -65,28 +72,116 @@ function main(name, opt)
             has_includes = true
         end
     end
-
-    -- get pkgconfig file
-    local pkgconfig_file = pkgconfig_files[name]
-    if not pkgconfig_file then
-        for _, file in pairs(pkgconfig_files) do
-            pkgconfig_file = file
-            break
-        end
-    end
-
-    -- find package
-    local result = nil
-    if pkgconfig_file then
+    
+    -- we iterate over each pkgconfig file to extract the required data
+    local result = {}
+    local myIncludedirs = {}
+    local myLinkdirs = {}
+    local myLinks = {}
+    myVersion = "0"
+    local foundPC = false
+    for key, file in pairs(pkgconfig_files) do
+        pkgconfig_file = file
         local pkgconfig_dir = path.directory(pkgconfig_file)
         local pkgconfig_name = path.basename(pkgconfig_file)
         linkdirs = table.unique(linkdirs)
         includedirs = table.unique(includedirs)
-        result = find_package_from_pkgconfig(pkgconfig_name, {configdirs = pkgconfig_dir, linkdirs = linkdirs})
-        if not result and has_includes then
-            -- header only and hidden /usr/include? we need only return empty {}
-            result = {}
+        local myResult = {}
+        myResult = find_package_from_pkgconfig(pkgconfig_name, {configdirs = pkgconfig_dir, linkdirs = linkdirs})
+            
+        -- the pkgconfig file has been parse successfully
+        if myResult ~= nil then
+            for _, locIncludeDir in pairs(myResult.includedirs) do
+                table.insert(myIncludedirs, locIncludeDir)
+            end
+                    
+            for _, locLinkDir in pairs(myResult.linkdirs) do
+                table.insert(myLinkdirs, locLinkDir)
+            end
+            
+            for _, locLink in pairs(myResult.links) do
+                table.insert(myLinks, locLink)
+            end
+
+            -- version should be the same if a pacman package contains multiples .pc
+            myVersion = myResult.version
+            
+            foundPC = true
         end
     end
+        
+    if foundPC == true then
+        myIncludedirs = table.unique(myIncludedirs)
+        myLinkdirs = table.unique(myLinkdirs)
+        myLinks = table.unique(myLinks)
+        
+        result.includedirs = myIncludedirs
+        result.linkdirs = myLinkdirs
+        result.links = myLinks
+        result.version = myVersion
+    else -- if there is no .pc, we parse the package content to obtain the data we want
+        for _, line in ipairs(list:split('\n', {plain = true})) do -- on msys cygpath should be use to convert local path to windows path
+            line = line:trim():split('%s+')[2]
+            if line:find("/include/", 1, true) and (line:endswith(".h") or line:endswith(".hpp")) then
+                local hPath = line
+                if opt.plat == "mingw" then
+                    hPath = os.iorunv(cygpath.program, {"--windows", line})
+                end
+                table.insert(myIncludedirs, path.directory(hPath))
+                if(opt.arch == "x86_64") then
+                    local baseHPath = os.iorunv(cygpath.program, {"--windows", "/mingw64/include"})
+                    table.insert(myIncludedirs, baseHPath)
+                else
+                    local baseHPath = os.iorunv(cygpath.program, {"--windows", "/mingw32/include"})
+                    table.insert(myIncludedirs, baseHPath)
+                end
+            -- revove lib and .a, .dll.a and .so to have the links
+            elseif line:endswith(".dll.a") then
+                local aPath = os.iorunv(cygpath.program, {"--windows", line})
+                table.insert(myLinkdirs, path.directory(aPath))
+                aPath = path.filename(aPath)
+                if aPath:startswith("lib") then
+                    aPath = aPath:sub(4, aPath:len())
+                end
+                table.insert(myLinks, aPath:sub(1, aPath:len() - 7))
+            elseif line:endswith(".so") then
+                local aPath = line
+                table.insert(myLinkdirs, path.directory(aPath))
+                aPath = path.filename(aPath)
+                if aPath:startswith("lib") then
+                    aPath = aPath:sub(4, aPath:len())
+                end
+                table.insert(myLinks, aPath:sub(1, aPath:len() - 4))
+            elseif line:endswith(".a") then
+                local aPath = line
+                if opt.plat == "mingw" then
+                    aPath = os.iorunv(cygpath.program, {"--windows", line})
+                end
+                aPath = path.filename(aPath)
+                if aPath:startswith("lib") then
+                    aPath = aPath:sub(4, aPath:len())
+                end
+                table.insert(myLinks, aPath:sub(1, aPath:len() - 3))
+            end
+        end
+        
+        myLinkdirs = table.unique(myLinkdirs)
+        myLinks = table.unique(myLinks)
+        myIncludedirs = table.unique(myIncludedirs)
+        
+        -- use pacman package version as version
+        local myVersion = "0"
+        local nameVersion = try { function() return os.iorunv(pacman.program, {"-Q", name}) end }
+        if nameVersion then
+            myVersion = nameVersion:trim():split('%s+')[2]
+        end
+
+        result = {}
+        result.includedirs = myIncludedirs
+        result.linkdirs    = myLinkdirs
+        result.links       = myLinks
+        result.version     = myVersion
+    end
+        
     return result
 end


### PR DESCRIPTION
See #1592.

I can ensure this patch allows NazaraEngine to be built with a lot of dependencies comming from pacman, for example:
- vorbis,
- newton-dynamics,
- chipmunk,
- sdl2,
- etc.

