### PR TITLE
improve virtualenv on linux

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -227,11 +227,17 @@ write_profile()
 install_profile()
 {
     if [ ! -d ~/.xmake ]; then mkdir ~/.xmake; fi
-    echo "export PATH=$prefix/bin:\$PATH" > ~/.xmake/profile
+    echo "export XMAKE_ROOTDIR=$prefix/bin" > ~/.xmake/profile
     if [ -f "$projectdir/scripts/register-completions.sh" ]; then
         cat "$projectdir/scripts/register-completions.sh" >> ~/.xmake/profile
     else
         remote_get_content "$gitrepo_raw/scripts/register-completions.sh" >> ~/.xmake/profile
+    fi
+
+    if [ -f "$projectdir/scripts/register-virtualenvs.sh" ]; then
+        cat "$projectdir/scripts/register-virtualenvs.sh" >> ~/.xmake/profile
+    else
+        remote_get_content "$gitrepo_raw/scripts/register-virtualenvs.sh" >> ~/.xmake/profile
     fi
 
     if   [[ "$SHELL" = */zsh ]]; then 

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -227,8 +227,8 @@ write_profile()
 install_profile()
 {
     if [ ! -d ~/.xmake ]; then mkdir ~/.xmake; fi
-    echo "export XMAKE_ROOTDIR=\"$prefix/bin\"" > ~/.xmake/profile
-    echo "export PATH=\"${XMAKE_ROOTDIR}:$PATH\"" >> ~/.xmake/profile
+    echo "export XMAKE_ROOTDIR=\"$prefix/bin\"\n" > ~/.xmake/profile
+    echo 'export PATH="$XMAKE_ROOTDIR:$PATH"' >> ~/.xmake/profile
     if [ -f "$projectdir/scripts/register-completions.sh" ]; then
         cat "$projectdir/scripts/register-completions.sh" >> ~/.xmake/profile
     else

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -227,7 +227,7 @@ write_profile()
 install_profile()
 {
     if [ ! -d ~/.xmake ]; then mkdir ~/.xmake; fi
-    echo "export XMAKE_ROOTDIR=\"$prefix/bin\"\n" > ~/.xmake/profile
+    echo "export XMAKE_ROOTDIR=\"$prefix/bin\"" > ~/.xmake/profile
     echo 'export PATH="$XMAKE_ROOTDIR:$PATH"' >> ~/.xmake/profile
     if [ -f "$projectdir/scripts/register-completions.sh" ]; then
         cat "$projectdir/scripts/register-completions.sh" >> ~/.xmake/profile

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -227,7 +227,8 @@ write_profile()
 install_profile()
 {
     if [ ! -d ~/.xmake ]; then mkdir ~/.xmake; fi
-    echo "export XMAKE_ROOTDIR=$prefix/bin" > ~/.xmake/profile
+    echo "export XMAKE_ROOTDIR=\"$prefix/bin\"" > ~/.xmake/profile
+    echo "export PATH=\"${XMAKE_ROOTDIR}:$PATH\"" >> ~/.xmake/profile
     if [ -f "$projectdir/scripts/register-completions.sh" ]; then
         cat "$projectdir/scripts/register-completions.sh" >> ~/.xmake/profile
     else

--- a/scripts/register-completions.sh
+++ b/scripts/register-completions.sh
@@ -1,8 +1,6 @@
 
 # parameter completions for *nix shell
 
-export PATH=${XMAKE_ROOTDIR}:$PATH
-
 if   [[ "$SHELL" = */zsh ]]; then
   # zsh parameter completion for xmake
   _xmake_zsh_complete() 

--- a/scripts/register-completions.sh
+++ b/scripts/register-completions.sh
@@ -1,6 +1,8 @@
 
 # parameter completions for *nix shell
 
+export PATH=${XMAKE_ROOTDIR}:$PATH
+
 if   [[ "$SHELL" = */zsh ]]; then
   # zsh parameter completion for xmake
   _xmake_zsh_complete() 

--- a/scripts/register-virtualenvs.sh
+++ b/scripts/register-virtualenvs.sh
@@ -19,7 +19,7 @@ function xrepo {
                     unset XMAKE_ENV_BACKUP
                 fi
                 "$XMAKE_EXE" lua private.xrepo.action.env.info config || return 1
-                local prompt="$("$XMAKE_EXE" lua private.xrepo.action.env.info prompt)" || return 1
+                local prompt="$("$XMAKE_EXE" lua --quiet private.xrepo.action.env.info prompt)" || return 1
                 if [ -z "${prompt+x}" ]; then
                     return 1
                 fi

--- a/scripts/register-virtualenvs.sh
+++ b/scripts/register-virtualenvs.sh
@@ -1,0 +1,48 @@
+
+# virtual environments for *nix shell
+
+if test "${XMAKE_ROOTDIR}"; then
+    export XMAKE_EXE=${XMAKE_ROOTDIR}/xmake
+else
+    export XMAKE_EXE=xmake
+fi
+
+function xrepo {
+    if [ $# -eq 2 ] && [ "$1" = "env" ]; then
+        local cmd="${2-x}"
+        case "$cmd" in
+            shell)
+                if test "${XMAKE_PROMPT_BACKUP}"; then
+                    PS1="${XMAKE_PROMPT_BACKUP}"
+                    source "${XMAKE_ENV_BACKUP}" || return 1
+                    unset XMAKE_PROMPT_BACKUP
+                    unset XMAKE_ENV_BACKUP
+                fi
+                "$XMAKE_EXE" lua private.xrepo.action.env.info config || return 1
+                local prompt="$("$XMAKE_EXE" lua private.xrepo.action.env.info prompt)" || return 1
+                if [ -z "${prompt+x}" ]; then
+                    return 1
+                fi
+                local activateCommand="$("$XMAKE_EXE" lua private.xrepo.action.env.info script.bash)" || return 1
+                export XMAKE_ENV_BACKUP="$("$XMAKE_EXE" lua private.xrepo.action.env.info envfile)"
+                export XMAKE_PROMPT_BACKUP="${PS1}"
+                "$XMAKE_EXE" lua private.xrepo.action.env.info backup.bash 1>"$XMAKE_ENV_BACKUP"
+                eval "$activateCommand"
+                PS1="${prompt} $PS1"
+                ;;
+            quit)
+                if test "${XMAKE_PROMPT_BACKUP}"; then
+                    PS1="${XMAKE_PROMPT_BACKUP}"
+                    source "${XMAKE_ENV_BACKUP}" || return 1
+                    unset XMAKE_PROMPT_BACKUP
+                    unset XMAKE_ENV_BACKUP
+                fi
+                ;;
+            *)
+                "$XMAKE_EXE" lua private.xrepo $@
+                ;;
+        esac
+    else
+        "$XMAKE_EXE" lua private.xrepo $@
+    fi
+}

--- a/scripts/xrepo.bat
+++ b/scripts/xrepo.bat
@@ -22,7 +22,7 @@
             if !errorlevel! neq 0 (
                 exit /B !errorlevel!
             )
-            @%XMAKE_EXE% lua private.xrepo.action.env.info prompt 1>nul
+            @%XMAKE_EXE% lua --quiet private.xrepo.action.env.info prompt 1>nul
             if !errorlevel! neq 0 (
                 echo error: xmake.lua not found^^!
                 exit /B !errorlevel!
@@ -39,13 +39,13 @@
             if !errorlevel! neq 0 (
                 exit /B !errorlevel!
             )
-            @%XMAKE_EXE% lua private.xrepo.action.env.info prompt 1>nul
+            @%XMAKE_EXE% lua --quiet private.xrepo.action.env.info prompt 1>nul
             if !errorlevel! neq 0 (
                 echo error: xmake.lua not found^^!
                 exit /B !errorlevel!
             )
             endlocal
-            for /f %%i in ('@%XMAKE_EXE% lua private.xrepo.action.env.info prompt') do @(
+            for /f %%i in ('@%XMAKE_EXE% lua --quiet private.xrepo.action.env.info prompt') do @(
                 @set "PROMPT=%%i %PROMPT%"
             )
             @set XMAKE_PROMPT_BACKUP=%PROMPT%

--- a/xmake/modules/private/xrepo/action/env.lua
+++ b/xmake/modules/private/xrepo/action/env.lua
@@ -317,7 +317,7 @@ end
 function info(key)
     if key == "prompt" then
         assert(os.isfile(os.projectfile()), "xmake.lua not found!")
-        print("[%s]", path.filename(os.projectdir()))
+        io.write("[" .. path.filename(os.projectdir()) .. "]")
     elseif key == "envfile" then
         print(os.tmpfile())
     elseif key == "config" then

--- a/xmake/modules/private/xrepo/action/env.lua
+++ b/xmake/modules/private/xrepo/action/env.lua
@@ -285,15 +285,29 @@ function _get_env_script(envs, shell, del)
     elseif shell == "cmd" then
         prefix = "@set \""
         suffix = "\""
+    elseif shell:endswith("sh") then
+        if del then
+            prefix = "unset "
+            connector = ""
+        else
+            prefix = "export "
+            connector = "='"
+            suffix = "'"
+        end
     end
+    local exceptions = hashset.of("_", "PS1", "PROMPT")
     local ret = ""
     if del then
         for name, _ in pairs(envs) do
-            ret = ret .. prefix .. name .. connector .. default .. suffix .. "\n"
+            if not exceptions:has(name) then
+                ret = ret .. prefix .. name .. connector .. default .. suffix .. "\n"
+            end
         end
     else
         for name, value in pairs(envs) do
-            ret = ret .. prefix .. name .. connector .. value .. suffix .. "\n"
+            if not exceptions:has(name) then
+                ret = ret .. prefix .. name .. connector .. value .. suffix .. "\n"
+            end
         end
     end
     return ret

--- a/xmake/scripts/xrepo-hook.psm1
+++ b/xmake/scripts/xrepo-hook.psm1
@@ -21,7 +21,7 @@ function Enter-XrepoEnvironment {
         }
 
         $xmakeColorTermBackup, $Env:XMAKE_COLORTERM = $Env:XMAKE_COLORTERM, "nocolor";
-        $xrepoPrompt = (& $Env:XMAKE_EXE lua private.xrepo.action.env.info prompt | Out-String);
+        $xrepoPrompt = (& $Env:XMAKE_EXE lua --quiet private.xrepo.action.env.info prompt | Out-String);
         $Env:XMAKE_COLORTERM = $xmakeColorTermBackup;
         if (-not $xrepoPrompt.StartsWith("[")) {
             Write-Host $xrepoPrompt;


### PR DESCRIPTION
在Debian上实测之前的`xrepo env shell`并不能正确显示prompt、保持历史记录。由于bash的机制，执行shell script必然会带起subshell，从而shell script无法改变外部环境变量（除非使用source命令）。参考anaconda的做法，这里应该在profile里面注册一个xrepo function，这样才能正确处理虚拟环境。测试在Debian 11上这种做法可行。