### PR TITLE
fix cuda with c++17

### DIFF
--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -178,6 +178,7 @@ function nf_language(self, stdname)
             cxx03       = "--std c++03"
         ,   cxx11       = "--std c++11"
         ,   cxx14       = "--std c++14"
+        ,   cxx17       = "--std c++17"
         }
         local cxxmaps2 = {}
         for k, v in pairs(_g.cxxmaps) do


### PR DESCRIPTION
fixes #1624

windows上测试发现不用加`-Xcompiler /std:c++17`，nvcc会自动处理