### PR TITLE
Avoid blank pkg_installdir on WSL2

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1771,9 +1771,20 @@ end
 
 -- the install directory
 function package.installdir()
+    local empty_or_self = function (s)
+        if s == "" 
+            then return nil
+            else return s
+        end
+    end
+
     local installdir = package._INSTALLDIR
+
     if not installdir then
-        installdir = os.getenv("XMAKE_PKG_INSTALLDIR") or global.get("pkg_installdir") or path.join(global.directory(), "packages")
+        installdir = empty_or_self(os.getenv("XMAKE_PKG_INSTALLDIR")) or empty_or_self(global.get("pkg_installdir")) or empty_or_self(path.join(global.directory(), "packages"))
+        if not empty_or_self(installdir) then
+            raise("Unknow error, please report your operating environment to github. You can avoid it temporarily by `export/set` XMAKE_PKG_INSTALLDIR.")
+        end
         package._INSTALLDIR = installdir
     end
     return installdir


### PR DESCRIPTION
在 Lua 中空字符串跟 Python 不太一样, 空串不会被看做条件假

```console
xmake> 'a' or 'b'
< "a"
xmake> '' or 'b'
< ""

>>> 'a' or 'b'
'a'
>>> '' or 'b'
'b'
```

加上未知原因导致在 WSL2 上 `global.get("pkg_installdir")` 为空字符串, 导致使用包时路径都偏移到了`/p/packagename/`这样的路径上, 而不是`/home/<user>/.xmake/p/packagename/`. 

应当考虑把 empty_or_self 丢到 utils 里去, 然后定义一个自动连续`or`之类的函数(为了实现短路操作还应该用宏再来一层), 然后在判断环境变量类的字符串的时候都套一下.

---

另外我全局搜了一下, 没有找到`pkg_installdir`的用例, 是不是这东西已经删掉了? 