### PR TITLE
Fix detecting of Intel Fortran Compiler 2021 on Windows

### DIFF
--- a/xmake/modules/detect/sdks/find_ifortenv.lua
+++ b/xmake/modules/detect/sdks/find_ifortenv.lua
@@ -100,11 +100,11 @@ function _find_intel_on_windows(opt)
     opt = opt or {}
 
     -- find ifortvars_bat.bat
-    local paths = {os.getenv("IFORT_COMPILER20")}
+    local paths = {"$(env IFORT_COMPILER20)"}
     local ifortvars_bat = find_file("bin/ifortvars.bat", paths)
     -- look for setvars.bat which is new in 2021
     if not ifortvars_bat then
-        paths = {os.getenv("IFORT_COMPILER21")}
+        paths = {"$(env IFORT_COMPILER21)"}
         ifortvars_bat = find_file("../../../setvars.bat", paths)
     end
 

--- a/xmake/modules/detect/sdks/find_ifortenv.lua
+++ b/xmake/modules/detect/sdks/find_ifortenv.lua
@@ -100,8 +100,14 @@ function _find_intel_on_windows(opt)
     opt = opt or {}
 
     -- find ifortvars_bat.bat
-    local paths = {"$(env IFORT_COMPILER20)"}
+    local paths = {os.getenv("IFORT_COMPILER20")}
     local ifortvars_bat = find_file("bin/ifortvars.bat", paths)
+    -- look for setvars.bat which is new in 2021
+    if not ifortvars_bat then
+        paths = {os.getenv("IFORT_COMPILER21")}
+        ifortvars_bat = find_file("../../../setvars.bat", paths)
+    end
+
     if ifortvars_bat then
 
         -- load ifortvars_bat


### PR DESCRIPTION
Previously the compiler could not be detected, because xmake was just looking for the environment variable IFORT_COMPILER20, but now it is also looking for IFORT_COMPILER21.