### PR TITLE
Fix sdkdir in ifortenv and iccenv

### DIFF
--- a/xmake/modules/detect/sdks/find_iccenv.lua
+++ b/xmake/modules/detect/sdks/find_iccenv.lua
@@ -140,7 +140,7 @@ function _find_intel_on_linux(opt)
         local icc = find_file("icc", paths)
         if icc then
             local bindir = path.directory(icc)
-            local sdkdir = path.directory(bindir)
+            local sdkdir = path.directory(path.directory(bindir))
             return {sdkdir = sdkdir, bindir = bindir, libdir = path.join(sdkdir, "compiler", "lib", arch)}
         end
     end

--- a/xmake/modules/detect/sdks/find_ifortenv.lua
+++ b/xmake/modules/detect/sdks/find_ifortenv.lua
@@ -141,7 +141,7 @@ function _find_intel_on_linux(opt)
         local ifort = find_file("ifort", paths)
         if ifort then
             local bindir = path.directory(ifort)
-            local sdkdir = path.directory(bindir)
+            local sdkdir = path.directory(path.directory(bindir))
             return {sdkdir = sdkdir, bindir = bindir, libdir = path.join(sdkdir, "compiler", "lib", arch)}
         end
     end


### PR DESCRIPTION
Fixes #1893

`sdkdir` was previously pointing to `bin`. Now it is correctly pointing to the parent of this directory. Which correctly creates the `LD_LIBRARY_PATH` entry.