### PR TITLE
Fix cmake find bug on windows.

### DIFF
--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -202,7 +202,7 @@ function _find_package(cmake, name, opt)
                         -- get links and linkdirs
                         local linkdir = path.directory(library)
                         linkdir = path.translate(linkdir) 
-                        if linkdir ~= "." and not linkdir:find(workdir) then
+                        if linkdir ~= "." and not linkdir:startswith(workdir) then
                             linkdirs = linkdirs or {}
                             table.insert(linkdirs, linkdir)
                             local link = target.linkname(path.filename(library))

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -201,7 +201,7 @@ function _find_package(cmake, name, opt)
 
                         -- get links and linkdirs
                         local linkdir = path.directory(library)
-                        if linkdir ~= "." then
+                        if linkdir ~= "." and string.find(string.gsub(linkdir,"/","\\"),workdir) == nil then
                             linkdirs = linkdirs or {}
                             table.insert(linkdirs, linkdir)
                             local link = target.linkname(path.filename(library))

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -201,7 +201,8 @@ function _find_package(cmake, name, opt)
 
                         -- get links and linkdirs
                         local linkdir = path.directory(library)
-                        if linkdir ~= "." and string.find(string.gsub(linkdir,"/","\\"),workdir) == nil then
+                        linkdir = path.translate(linkdir) 
+                        if linkdir ~= "." and not linkdir:find(workdir) then
                             linkdirs = linkdirs or {}
                             table.insert(linkdirs, linkdir)
                             local link = target.linkname(path.filename(library))


### PR DESCRIPTION
在windows上由于issue 1822 添加了对ImportLibrary的查找，在vcproj里面会有一个与项目同名的lib文件也被加入到link目录。
比如find_package cmake::OpenCV 会导致需要link一个名为OpenCV.lib的文件，但实际上并不存在这一文件，所以需要将其排除。

