### PR TITLE
Use ninja instead of make when generator is ninja

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -378,6 +378,10 @@ function _get_configs_for_mingw(package, configs, opt)
         envs.CMAKE_MAKE_PROGRAM = path.join(mingw, "bin", "mingw32-make.exe")
     end
 
+    if opt.cmake_generator == "Ninja" then
+        envs.CMAKE_MAKE_PROGRAM = "ninja"
+    end
+
     for k, v in pairs(envs) do
         table.insert(configs, "-D" .. k .. "=" .. v)
     end


### PR DESCRIPTION
在mingw下，CMake使用ninja时使用的CMAKE_MAKE_PROGRAM仍然是mingw32-make，导致如下报错：
```
-- The C compiler identification is GNU 8.1.0
-- The CXX compiler identification is GNU 8.1.0
-- Check for working C compiler: C:/mingw64/bin/x86_64-w64-mingw32-gcc.exe
CMake Error:
  The detected version of Ninja (GNU Make 4.2.1

  Built for x86_64-w64-mingw32

  Copyright (C) 1988-2016 Free Software Foundation, Inc.

  License GPLv3+: GNU GPL version 3 or later
  <http://gnu.org/licenses/gpl.html>

  This is free software: you are free to change and redistribute it.

  There is NO WARRANTY, to the extent permitted by law.) is less than the
  version of Ninja required by CMake (1.3).


CMake Error at C:/Program Files/CMake/share/cmake-3.14/Modules/CMakeTestCCompiler.cmake:44 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  CMakeLists.txt:28 (project)


-- Configuring incomplete, errors occurred!
```
生成的CMake命令中有`-DCMAKE_MAKE_PROGRAM=C:\mingw64\bin\mingw32-make.exe`和`-G Ninja`，与[StackOverflow上的问题](https://stackoverflow.com/questions/48407391/vs-2017-cmake-ninja-mingw)类似。