### PR TITLE
Improve vstudio projects

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -252,6 +252,9 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
     target:set("pcheader", nil)
     target:set("pcxxheader", nil)
 
+    -- save languages
+    targetinfo.languages = table.wrap(target:get("languages"))
+
     -- save symbols
     targetinfo.symbols = target:get("symbols")
 

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -248,7 +248,7 @@ function _make_configurations(vcxprojfile, vsinfo, target)
                 flag:gsub("[%-/]external:I(.*)", function (dir) table.insert(externaldirs, dir) end)
             end
             if #externaldirs > 0 then
-                vcxprojfile:print("<ExternalIncludePath>%s;</ExternalIncludePath>", table.concat(externaldirs, ";"))
+                vcxprojfile:print("<ExternalIncludePath>%s;$(VC_IncludePath);$(WindowsSDK_IncludePath);</ExternalIncludePath>", table.concat(externaldirs, ";"))
             end
         vcxprojfile:leave("</PropertyGroup>")
     end


### PR DESCRIPTION
Add supports for the following vcxproj xml nodes:
1. `<ExternalIncludePath>`
1. `<DisableSpecificWarnings>`
1. `<AdditionalLibraryDirectories>`
1. `<AdditionalDependencies>`
1. `<LanguageStandard>`
1. `<LanguageStandard_C>`

I had to move common flags building in a separate function because I needed them in `_make_configurations` (for external include path)

Using `<ExternalIncludePath>` instead of `-external:I` fixes the Intellisense issue with "go to definition" or "open file" erroring on external include paths.

The next big step I would like to implement now is rule support, using phony project inside of VS.