### PR TITLE
fix armar error when too many file.

### DIFF
--- a/xmake/modules/core/tools/armar.lua
+++ b/xmake/modules/core/tools/armar.lua
@@ -24,3 +24,18 @@ function init(self)
     _super.init(self)
 end
 
+-- link the library file
+function link(self, objectfiles, targetkind, targetfile, flags)
+    os.mkdir(path.directory(targetfile))
+
+    -- @note remove the previous archived file first to force recreating a new file
+    os.tryrm(targetfile)
+
+    -- link it
+    local program, argv = linkargv(self, objectfiles, targetkind, targetfile, flags)
+    if argv[1]:startswith("@") then
+        argv[1] = argv[1]:replace("@", "", {plain = true})
+        table.insert(argv, 1, "--via")
+    end
+    os.runv(program, argv, {envs = self:runenvs()})
+end


### PR DESCRIPTION
修复当文件过多，armar参数长度超过限制时，winos.cmdargv通过文件传参，因文件传参头不同，造成的错误。 https://github.com/xmake-io/xmake/issues/1978
