### PR TITLE
toolchain: add gcc-4.8 and gcc-4.9

### DIFF
--- a/xmake/core/platform/platform.lua
+++ b/xmake/core/platform/platform.lua
@@ -524,7 +524,7 @@ function platform.toolchains()
             if dirs then
                 for _, dir in ipairs(dirs) do
                     if os.isfile(path.join(dir, "xmake.lua")) then
-                        table.insert(toolchains, path.basename(dir))
+                        table.insert(toolchains, path.filename(dir))
                     end
                 end
             end

--- a/xmake/toolchains/gcc-4.8/xmake.lua
+++ b/xmake/toolchains/gcc-4.8/xmake.lua
@@ -1,0 +1,3 @@
+includes(path.join(os.scriptdir(), "../gcc/xmake.lua"))
+
+toolchain_gcc("4.8")

--- a/xmake/toolchains/gcc-4.9/xmake.lua
+++ b/xmake/toolchains/gcc-4.9/xmake.lua
@@ -1,0 +1,3 @@
+includes(path.join(os.scriptdir(), "../gcc/xmake.lua"))
+
+toolchain_gcc("4.9")


### PR DESCRIPTION
GCC-4.8 is still being used in many projects that doesn't use cxx11 abi.

GCC-4.9 is avaiable on Ubuntu 16.04, which is required to compile some software packages that don't support GCC 4.8. It's not as widely used as GCC-4.8.

The behavior `path.basename` is not the same as Unix `basename` command. It's removing the last part after dot. Thus I have to change it to `path.filename`, otherwise xmake will look for directory `toolchain/gcc-4` instead of `toolchain/gcc-4.8` etc.