### PR TITLE
catch ctrl-c to get backtrace of stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2021](https://github.com/xmake-io/xmake/issues/2021): Support Swift for linux and windows
 * [#2024](https://github.com/xmake-io/xmake/issues/2024): Add asn1c support
 * [#2031](https://github.com/xmake-io/xmake/issues/2031): Support linker scripts and version scripts for add_files
+* [#2033](https://github.com/xmake-io/xmake/issues/2033): Catch ctrl-c to get current backtrace for debugging stuck
 
 ### Bugs fixed
 
@@ -1214,6 +1215,7 @@
 * [#2021](https://github.com/xmake-io/xmake/issues/2021): 支持 Linux/Windows 下构建 Swift 程序
 * [#2024](https://github.com/xmake-io/xmake/issues/2024): 添加 asn1c 支持
 * [#2031](https://github.com/xmake-io/xmake/issues/2031): 为 add_files 增加 linker scripts 和 version scripts 支持
+* [#2033](https://github.com/xmake-io/xmake/issues/2033): 捕获 ctrl-c 去打印当前运行栈，用于调试分析卡死问题
 
 ### Bugs 修复
 

--- a/core/src/xmake/engine.c
+++ b/core/src/xmake/engine.c
@@ -699,8 +699,7 @@ static tb_void_t xm_engine_dump_traceback(lua_State* lua)
     lua_getfield(lua, -1, "traceback");
     lua_replace(lua, -2);
     lua_pushvalue(lua, 1);
-    lua_pushinteger(lua, 2);
-    lua_call(lua, 2, 1);
+    lua_call(lua, 1, 1);
     tb_trace_i("%s", lua_tostring(lua, -1));
 }
 #endif

--- a/xmake/core/base/coroutine.lua
+++ b/xmake/core/base/coroutine.lua
@@ -31,8 +31,6 @@ coroutine._resume  = coroutine._resume or coroutine.resume
 
 -- resume coroutine
 function coroutine.resume(co, ...)
-
-    -- resume it
     local ok, results = coroutine._resume(co, ...)
     if not ok then
 
@@ -47,12 +45,8 @@ function coroutine.resume(co, ...)
                 errors = results:sub(pos + 1)
             end
         end
-
-        -- failed
         return false, errors
     end
-
-    -- ok
     return true, results
 end
 

--- a/xmake/core/base/os.lua
+++ b/xmake/core/base/os.lua
@@ -268,6 +268,23 @@ function os._deduplicate_pathenv(value)
     return value
 end
 
+-- trace process for profile(stuck,trace)?
+function os._is_tracing_process()
+    local is_tracing = os._IS_TRACING_PROCESS
+    if is_tracing == nil then
+        local profile = os.getenv("XMAKE_PROFILE")
+        if profile then
+            profile = profile:trim()
+            if profile == "trace" or profile == "stuck" then
+                is_tracing = true
+            end
+        end
+        is_tracing = is_tracing or false
+        os._IS_TRACING_PROCESS = is_tracing
+    end
+    return is_tracing
+end
+
 -- match files or directories
 --
 -- @param pattern   the search pattern
@@ -748,6 +765,11 @@ function os.execv(program, argv, opt)
     local ok = -1
     local proc = process.openv(filename, argv or {}, openopt)
     if proc ~= nil then
+
+        -- trace process
+        if os._is_tracing_process() then
+            utils.cprint("%s: ${color.dump.string}%s %s${clear}", proc, filename, argv and os.args(argv) or "")
+        end
 
         -- wait process
         local waitok, status = proc:wait(-1)

--- a/xmake/plugins/show/lists/envs.lua
+++ b/xmake/plugins/show/lists/envs.lua
@@ -36,7 +36,7 @@ function main()
                     XMAKE_RAMDIR         = {"Set the ramdisk directory.", os.getenv("XMAKE_RAMDIR")},
                     XMAKE_RCFILES        = {"Set the runtime configuration files.", path.joinenv(project.rcfiles())},
                     XMAKE_TMPDIR         = {"Set the temporary directory.", os.tmpdir()},
-                    XMAKE_PROFILE        = {"Start profiler, e.g. perf, trace.", os.getenv("XMAKE_PROFILE")},
+                    XMAKE_PROFILE        = {"Start profiler, e.g. perf, trace, stuck.", os.getenv("XMAKE_PROFILE")},
                     XMAKE_PKG_CACHEDIR   = {"Set the cache directory of packages.", os.getenv("XMAKE_PKG_CACHEDIR")},
                     XMAKE_PKG_INSTALLDIR = {"Set the install directory of packages.", os.getenv("XMAKE_PACKAGEDIR")}}
     local width = 24


### PR DESCRIPTION
test.lua

```lua
function main()
    io.read()
end
```

```console
$ XMAKE_PROFILE=stuck xmake l test.lua
<Ctrl+C>
stack traceback:
        [C]: in function 'base/io.file_read'
        @programdir/core/base/io.lua:177: in method '_read'
        @programdir/core/sandbox/modules/io.lua:90: in function <@programdir/core/sandbox/module
s/io.lua:89>
        (...tail calls...)
        /Users/ruki/share/test.lua:2: in function </Users/ruki/share/test.lua:1>
        (...tail calls...)
        @programdir/plugins/lua/main.lua:123: in function <@programdir/plugins/lua/main.lua:79>
        (...tail calls...)
        [C]: in function 'xpcall'
        @programdir/core/base/utils.lua:280: in function 'sandbox/modules/utils.trycall'
        (...tail calls...)
        @programdir/core/base/task.lua:519: in function 'base/task.run'
        @programdir/core/main.lua:278: in upvalue 'cotask'
        @programdir/core/base/scheduler.lua:371: in function <@programdir/core/base/scheduler.lu
a:368>
```

https://github.com/xmake-io/xmake/issues/2033