### PR TITLE
env file should take priority

### DIFF
--- a/xmake/modules/private/xrepo/action/env.lua
+++ b/xmake/modules/private/xrepo/action/env.lua
@@ -298,10 +298,8 @@ function _package_getenvs(opt)
         packages = boundenv or option.get("program")
     end
     if os.isfile(os.projectfile()) or has_envfile then
-        if not os.isfile(os.projectfile()) then
-            _enter_project({enteronly = true})
-        end
         if has_envfile then
+            _enter_project({enteronly = true})
             table.insert(project.rcfiles(), boundenv)
         end
         task.run("config", {target = "all"}, {disable_dump = true})


### PR DESCRIPTION
修复了当前目录存在xmake.lua时无法激活全局环境的bug