### PR TITLE
Fix runenvs with vs and vsxmake projects

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -316,9 +316,9 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
     end
     for k, v in pairs(addrunenvs) do
         if k:upper() == "PATH" then
-            runenvs[k] = _make_dirs(v, vcxprojdir) .. "$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
+            runenvs[k] = _make_dirs(v, vcxprojdir) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
         else
-            runenvs[k] = path.joinenv(v) .. "$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
+            runenvs[k] = path.joinenv(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
         end
     end
     for k, v in pairs(setrunenvs) do

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -190,9 +190,9 @@ function _make_targetinfo(mode, arch, target)
     end
     for k, v in pairs(addrunenvs) do
         if k:upper() == "PATH" then
-            runenvs[k] = _make_dirs(v) .. "$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
+            runenvs[k] = _make_dirs(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
         else
-            runenvs[k] = path.joinenv(v) .. "$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
+            runenvs[k] = path.joinenv(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
         end
     end
     for k, v in pairs(setrunenvs) do


### PR DESCRIPTION
https://github.com/xmake-io/xmake/commit/0b8b054bcd07172fc2b84919d5a4181c8ab80ce6 broke VS runenvs because of the missing `;` between package paths and PATH.

example:
```xml
<LocalDebuggerEnvironment>PATH=[..];C:\Users\Lynix\AppData\Local\.xmake\packages\l\libsdl\2.0.16\0df26eb4e55848f2a35d09c79be5b9a2\bin$([System.Environment]::GetEnvironmentVariable('PATH'));%(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
```

Notice there's no separation between libsdl dir and PATH, this PR fixes that.