### PR TITLE
improve cuda detection

### DIFF
--- a/xmake/modules/detect/sdks/find_cuda.lua
+++ b/xmake/modules/detect/sdks/find_cuda.lua
@@ -78,8 +78,14 @@ function _find_cuda(sdkdir)
     end
 
     -- find cuda directory
-    if not sdkdir or not os.isdir(sdkdir) then
-        sdkdir = _find_sdkdir(sdkdir)
+    if not sdkdir then
+        sdkdir = _find_sdkdir()
+    elseif sdkdir:match("^[%d*]+%.[%d*]+$") then
+        local cudaversion = sdkdir
+        sdkdir = _find_sdkdir(cudaversion)
+        if not sdkdir then
+            raise("cuda version %s not found!", cudaversion)
+        end
     end
 
     -- not found?

--- a/xmake/modules/lib/detect/find_cudadevices.lua
+++ b/xmake/modules/lib/detect/find_cudadevices.lua
@@ -240,6 +240,8 @@ function _order_by_flops(devices)
     ,   [72] =     64
     ,   [75] =     64
     ,   [80] =     64
+    ,   [86] =    128
+    ,   [87] =    128
     }
 
     for _, dev in ipairs(devices) do

--- a/xmake/modules/private/detect/find_cudatool.lua
+++ b/xmake/modules/private/detect/find_cudatool.lua
@@ -45,23 +45,16 @@ function main(toolname, parse, opt)
     opt       = opt or {}
     opt.parse = opt.parse or parse
 
-    -- find program
+    -- always keep consistency with cuda cache 
+    local toolchains = find_cuda()
+    if toolchains and toolchains.bindir then
+        program = find_program(path.join(toolchains.bindir, opt.program or toolname), opt)
+    end
+
+    -- not found? attempt to find program only
     local program = nil
     if opt.program then
-        program = find_program(opt.program, opt)
-    end
-
-    -- not found? attempt to find program from cuda toolchains
-    if not program then
-        local toolchains = find_cuda()
-        if toolchains and toolchains.bindir then
-            program = find_program(path.join(toolchains.bindir, toolname), opt)
-        end
-    end
-
-    -- not found? attempt to find program from PATH
-    if not program then
-        program = find_program(toolname, opt)
+        program = find_program(opt.program or toolname, opt)
     end
 
     -- find program version

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -351,11 +351,10 @@ function main(outputdir, vsinfo)
     vsinfo.projectdir = project.directory()
     vsinfo.sln_projectfile = path.relative(project.rootfile(), vsinfo.solution_dir)
     local projectfile = path.filename(project.rootfile())
-    vsinfo.slnfile = path.filename(project.directory())
+    vsinfo.slnfile = project.name() or path.filename(project.directory())
     -- write only if not default
     if projectfile ~= "xmake.lua" then
         vsinfo.projectfile = projectfile
-        vsinfo.slnfile = path.basename(projectfile)
     end
 
     vsinfo.xmake_info = format("xmake version %s", xmake.version())


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/2053

修复：

- 改进CUDA sdk探测，支持按版本指定、按版本通配符指定，在指定失败时报错；
- 修复find_cudadevices对新GPU的排序；
- 改进vsxmake生成器，使文件名与vs生成器保持一致；

已知问题：

- find_cudadevices没有加锁，导致在运行xmake project -k vsxmake时会被其他选项干扰，无法正常进行探测

报错信息如下：
```
> xmake project -vD -k vsxmake
configure
{
    vs = 2022
    ccache = true
    host = windows
    theme = default
    mode = release
    buildir = build
    kind = static
    pkg_searchdirs = C:/Users/xq114/Downloads
    plat = windows
    cuda = C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6
    proxy_pac = nil
    ndk_stdcxx = true
    network = public
    arch = x64
}
using project kind vs2022
checking for release.x86 ...
checking for vswhere.exe ... C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe
checking for cl.exe ... C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\bin\HostX86\x86\cl.exe
checking for Microsoft Visual Studio (x86) version ... 2022
checkinfo: cannot runv(dmd.exe --version), No such file or directory
checking for dmd ... no
checkinfo: cannot runv(ldc2.exe --version), No such file or directory
checking for ldc2 ... no
checkinfo: cannot runv(gdc.exe --version), No such file or directory
checking for gdc ... no
checkinfo: cannot runv(zig.exe version), No such file or directory
checking for zig ... no
checkinfo: cannot runv(zig.exe version), No such file or directory
checking for zig ... no
checking for Cuda SDK directory ... C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6
checking for C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\bin\nvcc ... ok
checking for nvcc ... ok
checking for cuda devices
checking for link.exe ... C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\bin\HostX86\x86\link.exe
checking for the linker (ld) ... link.exe
checking for release.x64 ...
checking for vswhere.exe ... C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe
checking for cl.exe ... C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\bin\HostX64\x64\cl.exe
checking for Microsoft Visual Studio (x64) version ... 2022
checkinfo: cannot runv(dmd.exe --version), No such file or directory
checking for dmd ... no
checkinfo: cannot runv(ldc2.exe --version), No such file or directory
checking for ldc2 ... no
checkinfo: cannot runv(gdc.exe --version), No such file or directory
checking for gdc ... no
checkinfo: cannot runv(zig.exe version), No such file or directory
checking for zig ... no
checkinfo: cannot runv(zig.exe version), No such file or directory
checking for zig ... no
checking for Cuda SDK directory ... C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6
checking for C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\bin\nvcc ... ok
checking for nvcc ... ok
checking for cuda devices
> DEVICE #0
>     name = "NVIDIA GeForce RTX 3060 Laptop GPU"
>     totalGlobalMem = 6441926656
>     sharedMemPerBlock = 49152
>     regsPerBlock = 65536
>     warpSize = 32
>     memPitch = 2147483647
>     maxThreadsPerBlock = 1024
>     maxThreadsDim = (1024, 1024, 64)
>     maxGridSize = (2147483647, 65535, 65535)
>     clockRate = 1282000
>     totalConstMem = 65536
>     major = 8
>     minor = 6
>     textureAlignment = 512
>     texturePitchAlignment = 32
>     deviceOverlap = true
>     multiProcessorCount = 30
>     kernelExecTimeoutEnabled = true
>     integrated = false
>     canMapHostMemory = true
>     computeMode = 0
>     maxTexture1D = 131072
>     maxTexture1DMipmap = 32768
>     maxTexture1DLinear = 268435456
>     maxTexture2D = (131072, 65536)
>     maxTexture2DMipmap = (32768, 32768)
>     maxTexture2DLinear = (131072, 65000, 2097120)
>     maxTexture2DGather = (32768, 32768)
>     maxTexture3D = (16384, 16384, 16384)
>     maxTexture3DAlt = (8192, 8192, 32768)
>     maxTextureCubemap = 32768
>     maxTexture1DLayered = (32768, 2048)
>     maxTexture2DLayered = (32768, 32768, 2048)
>     maxTextureCubemapLayered = (32768, 2046)
>     maxSurface1D = 32768
>     maxSurface2D = (131072, 65536)
>     maxSurface3D = (16384, 16384, 16384)
>     maxSurface1DLayered = (32768, 2048)
>     maxSurface2DLayered = (32768, 32768, 2048)
>     maxSurfaceCubemap = 32768
>     maxSurfaceCubemapLayered = (32768, 2046)
>     surfaceAlignment = 512
>     concurrentKernels = true
>     ECCEnabled = false
>     pciBusID = 1
>     pciDeviceID = 0
>     pciDomainID = 0
>     tccDriver = false
>     asyncEngineCount = 5
>     unifiedAddressing = true
>     memoryClockRate = 6001000
>     memoryBusWidth = 192
>     l2CacheSize = 3145728
>     maxThreadsPerMultiProcessor = 1536
>     streamPrioritiesSupported = true
>     globalL1CacheSupported = true
>     localL1CacheSupported = true
>     sharedMemPerMultiprocessor = 102400
>     regsPerMultiprocessor = 65536
>     isMultiGpuBoard = false
>     multiGpuBoardGroupID = 0
>     singleToDoublePrecisionPerfRatio = 32
>     pageableMemoryAccess = false
>     concurrentManagedAccess = false
>     managedMemory = true
>     computePreemptionSupported = true
>     canUseHostPointerForRegisteredMem = false
>     cooperativeLaunch = true
>     cooperativeMultiDeviceLaunch = false
>     sharedMemPerBlockOptin = 101376
>     pageableMemoryAccessUsesHostPageTables = false
>     directManagedMemAccessFromHost = false
>     uuid = "cd152f31-1c94-edc0-5436-a1405616dfec"
>     luid = "df3f010000000000"
>     luidDeviceNodeMask = 1
> found device #0: NVIDIA GeForce RTX 3060 Laptop GPU with compute 8.6 capability
checking for C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\bin\nvcc ... ok
checking for nvcc ... C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\bin\nvcc
checking for the cuda compiler (cu) ... nvcc
checking for link.exe ... C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\bin\HostX64\x64\link.exe
checking for the linker (ld) ... link.exe
create ok!
warning: failed to find cuda devices: find_cudadevices.cpp
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol _cudaDeviceReset@0 referenced in function "void __cdecl check(enum cudaError)" (?check@@YAXW4cudaError@@@Z)
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol _cudaGetErrorName@4 referenced in function "void __cdecl check(enum cudaError)" (?check@@YAXW4cudaError@@@Z)
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol _cudaGetErrorString@4 referenced in function "void __cdecl check(enum cudaError)" (?check@@YAXW4cudaError@@@Z)
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol _cudaGetDeviceCount@4 referenced in function _main
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol _cudaGetDeviceProperties@8 referenced in function "void __cdecl print_device(int)" (?print_device@@YAXH@Z)
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol ___acrt_iob_func referenced in function _main
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol ___stdio_common_vfprintf referenced in function __vfprintf_l
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol _exit referenced in function 
"void __cdecl check(enum cudaError)" (?check@@YAXW4cudaError@@@Z)
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol @__security_check_cookie@4 referenced in function "void __cdecl print_device(int)" (?print_device@@YAXH@Z)
tmpxft_00003dfc_00000000-9_find_cudadevices.obj : error LNK2019: unresolved external symbol ___security_cookie referenced in function "void __cdecl print_device(int)" (?print_device@@YAXH@Z)
LINK : error LNK2001: unresolved external symbol _mainCRTStartup
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\bin\..\lib\x64\cudadevrt.lib : warning LNK4272: library machine 
type 'x64' conflicts with target machine type 'x86'
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\bin\..\lib\x64\cudart_static.lib : warning LNK4272: library machine type 'x64' conflicts with target machine type 'x86'
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\lib\x64\LIBCMT.lib : warning LNK4272: library machine type 'x64' conflicts with target machine type 'x86'
C:\Users\xq114\AppData\Local\Temp\.xmake\220214\_8C034AFB69B9405082284A2B38357750.exe : fatal error LNK1120: 11 unresolved externals
```