### PR TITLE
add shell utility registration

### DIFF
--- a/xmake/actions/update/main.lua
+++ b/xmake/actions/update/main.lua
@@ -115,7 +115,7 @@ function _uninstall()
             for _, type in ipairs({"AllUsersAllHosts", "CurrentUserAllHosts", "CurrentUserCurrentHost"}) do
                 local psshell = find_tool(shell)
                 if psshell then
-                    local outdata, errdata = try {function () return os.iorunv(shell, {"-c", "Write-Output $PROFILE." .. type}) end}
+                    local outdata, errdata = try {function () return os.iorunv(psshell.program, {"-c", "Write-Output $PROFILE." .. type}) end}
                     if outdata then
                         table.insert(profiles, outdata:trim())
                     end

--- a/xmake/actions/update/main.lua
+++ b/xmake/actions/update/main.lua
@@ -317,7 +317,7 @@ function _initialize_shell()
             if os.isfile(target) then
                 file = io.readfile(target)
                 file = file:gsub("# >>> xmake >>>.-# <<< xmake <<<", "")
-                if file ~= "" then
+                if file ~= "" and not file:endswith("\n") then
                     file = file .. "\n"
                 end
             end

--- a/xmake/actions/update/xmake.lua
+++ b/xmake/actions/update/xmake.lua
@@ -41,7 +41,7 @@ task("update")
                     {nil, "uninstall",   "k",   nil,    "Uninstall the current xmake program."                     }
                 ,   {                                                                                              }
                 ,   {'s', "scriptonly",  "k",   nil,    "Update scripts only."                                     }
-                ,   {'i', "init",        "k",   nil,    "Initialize xmake for shell interaction."                  }
+                ,   {nil, "integrate",   "k",   nil,    "Initialize xmake for shell interaction."                  }
                 ,   {'f', "force",       "k",   nil,    "Force to update and reinstall the given version."         }
                 ,   {nil, "xmakever",    "v",   nil,    "The given xmake version, or a git source (and branch). ",
                                                         "e.g.",

--- a/xmake/actions/update/xmake.lua
+++ b/xmake/actions/update/xmake.lua
@@ -40,7 +40,8 @@ task("update")
                 {
                     {nil, "uninstall",   "k",   nil,    "Uninstall the current xmake program."                     }
                 ,   {                                                                                              }
-                ,   {'s', "scriptonly",  "k",   nil,    "Update script only"                                       }
+                ,   {'s', "scriptonly",  "k",   nil,    "Update scripts only."                                     }
+                ,   {'i', "init",        "k",   nil,    "Initialize xmake for shell interaction."                  }
                 ,   {'f', "force",       "k",   nil,    "Force to update and reinstall the given version."         }
                 ,   {nil, "xmakever",    "v",   nil,    "The given xmake version, or a git source (and branch). ",
                                                         "e.g.",

--- a/xmake/actions/update/xmake.lua
+++ b/xmake/actions/update/xmake.lua
@@ -41,7 +41,7 @@ task("update")
                     {nil, "uninstall",   "k",   nil,    "Uninstall the current xmake program."                     }
                 ,   {                                                                                              }
                 ,   {'s', "scriptonly",  "k",   nil,    "Update scripts only."                                     }
-                ,   {nil, "integrate",   "k",   nil,    "Initialize xmake for shell interaction."                  }
+                ,   {nil, "integrate",   "k",   nil,    "Integrate xmake with default shell."                  }
                 ,   {'f', "force",       "k",   nil,    "Force to update and reinstall the given version."         }
                 ,   {nil, "xmakever",    "v",   nil,    "The given xmake version, or a git source (and branch). ",
                                                         "e.g.",

--- a/xmake/modules/detect/tools/find_powershell.lua
+++ b/xmake/modules/detect/tools/find_powershell.lua
@@ -1,0 +1,54 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      xq114
+-- @file        find_powershell.lua
+--
+
+-- imports
+import("lib.detect.find_program")
+import("lib.detect.find_programver")
+
+-- find powershell
+--
+-- @param opt   the argument options, e.g. {version = true}
+--
+-- @return      program, version
+--
+-- @code
+--
+-- local powershell = find_powershell()
+--
+-- @endcode
+--
+function main(opt)
+
+    -- init options
+    opt         = opt or {}
+    opt.command = opt.command or "--version"
+
+    -- find program
+    local program = find_program(opt.program or "powershell", opt)
+
+    -- find program version
+    local version = nil
+    if program and opt and opt.version then
+        version = find_programver(program, opt)
+    end
+
+    -- ok?
+    return program, version
+end

--- a/xmake/modules/detect/tools/find_pwsh.lua
+++ b/xmake/modules/detect/tools/find_pwsh.lua
@@ -1,0 +1,54 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      xq114
+-- @file        find_pwsh.lua
+--
+
+-- imports
+import("lib.detect.find_program")
+import("lib.detect.find_programver")
+
+-- find pwsh
+--
+-- @param opt   the argument options, e.g. {version = true}
+--
+-- @return      program, version
+--
+-- @code
+--
+-- local pwsh = find_pwsh()
+--
+-- @endcode
+--
+function main(opt)
+
+    -- init options
+    opt         = opt or {}
+    opt.command = opt.command or "--version"
+
+    -- find program
+    local program = find_program(opt.program or "pwsh", opt)
+
+    -- find program version
+    local version = nil
+    if program and opt and opt.version then
+        version = find_programver(program, opt)
+    end
+
+    -- ok?
+    return program, version
+end

--- a/xmake/modules/private/action/update/fetch_version.lua
+++ b/xmake/modules/private/action/update/fetch_version.lua
@@ -30,6 +30,7 @@ import("net.fasturl")
 local official_sources =
 {
     "https://github.com/xmake-io/xmake.git",
+    "git@github.com:xmake-io/xmake.git",
     "https://gitlab.com/tboox/xmake.git",
     "https://gitee.com/tboox/xmake.git"
 }

--- a/xmake/scripts/profile-unix.sh
+++ b/xmake/scripts/profile-unix.sh
@@ -1,0 +1,87 @@
+# parameter completions for *nix shell
+if [[ "$SHELL" = */zsh ]]; then
+  # zsh parameter completion for xmake
+  _xmake_zsh_complete() 
+  {
+    local completions=("$(XMAKE_SKIP_HISTORY=1 XMAKE_ROOT=y xmake lua private.utils.complete 0 nospace "$words")")
+    reply=( "${(ps:\n:)completions}" )
+  }
+  compctl -f -S "" -K _xmake_zsh_complete xmake
+elif [[ "$SHELL" = */bash ]]; then
+  # bash parameter completion for xmake
+  _xmake_bash_complete()
+  {
+    local word=${COMP_WORDS[COMP_CWORD]}
+    local completions
+    completions="$(XMAKE_SKIP_HISTORY=1 XMAKE_ROOT=y xmake lua private.utils.complete "${COMP_POINT}" "nospace-nokey" "${COMP_LINE}")"
+    if [ $? -ne 0 ]; then
+      completions=""
+    fi
+    COMPREPLY=( $(compgen -W "$completions") )
+  }
+  complete -o default -o nospace -F _xmake_bash_complete xmake
+fi
+# virtual environments for *nix shell
+function xrepo {
+    if [ $# -ge 2 ] && [ "$1" = "env" ]; then
+        local cmd="${2-x}"
+        case "$cmd" in
+            shell)
+                if test "${XMAKE_PROMPT_BACKUP}"; then
+                    PS1="${XMAKE_PROMPT_BACKUP}"
+                    source "${XMAKE_ENV_BACKUP}" || return 1
+                    unset XMAKE_PROMPT_BACKUP
+                    unset XMAKE_ENV_BACKUP
+                fi
+                xmake lua private.xrepo.action.env.info config || return 1
+                local prompt="$(xmake lua --quiet private.xrepo.action.env.info prompt)" || return 1
+                if [ -z "${prompt+x}" ]; then
+                    return 1
+                fi
+                local activateCommand="$(xmake lua private.xrepo.action.env.info script.bash)" || return 1
+                export XMAKE_ENV_BACKUP="$(xmake lua private.xrepo.action.env.info envfile)"
+                export XMAKE_PROMPT_BACKUP="${PS1}"
+                xmake lua private.xrepo.action.env.info backup.bash 1>"$XMAKE_ENV_BACKUP"
+                eval "$activateCommand"
+                PS1="${prompt} $PS1"
+                ;;
+            quit)
+                if test "${XMAKE_PROMPT_BACKUP}"; then
+                    PS1="${XMAKE_PROMPT_BACKUP}"
+                    source "${XMAKE_ENV_BACKUP}" || return 1
+                    unset XMAKE_PROMPT_BACKUP
+                    unset XMAKE_ENV_BACKUP
+                fi
+                ;;
+            -b|--bind)
+                if [ "$4" = "shell" ]; then
+                    local bnd="${3-x}"
+                    if test "${XMAKE_PROMPT_BACKUP}"; then
+                        PS1="${XMAKE_PROMPT_BACKUP}"
+                        source "${XMAKE_ENV_BACKUP}" || return 1
+                        unset XMAKE_PROMPT_BACKUP
+                        unset XMAKE_ENV_BACKUP
+                    fi
+                    xmake lua private.xrepo.action.env.info config $bnd || return 1
+                    local prompt="$(xmake lua --quiet private.xrepo.action.env.info prompt $bnd)" || return 1
+                    if [ -z "${prompt+x}" ]; then
+                        return 1
+                    fi
+                    local activateCommand="$(xmake lua --quiet private.xrepo.action.env.info script.bash $bnd)" || return 1
+                    export XMAKE_ENV_BACKUP="$(xmake lua private.xrepo.action.env.info envfile $bnd)"
+                    export XMAKE_PROMPT_BACKUP="${PS1}"
+                    xmake lua --quiet private.xrepo.action.env.info backup.bash $bnd 1>"$XMAKE_ENV_BACKUP"
+                    eval "$activateCommand"
+                    PS1="${prompt} $PS1"
+                else
+                    xmake lua private.xrepo "$@"
+                fi
+                ;;
+            *)
+                xmake lua private.xrepo "$@"
+                ;;
+        esac
+    else
+        xmake lua private.xrepo "$@"
+    fi
+}

--- a/xmake/scripts/profile-win.ps1
+++ b/xmake/scripts/profile-win.ps1
@@ -1,0 +1,14 @@
+# PowerShell parameter completion for xmake
+Register-ArgumentCompleter -Native -CommandName xmake -ScriptBlock {
+    param($commandName, $wordToComplete, $cursorPosition)
+    $complete = "$wordToComplete"
+    if (-not $commandName) {
+        $complete = $complete + " "
+    }
+    $oldenv = $env:XMAKE_SKIP_HISTORY
+    $env:XMAKE_SKIP_HISTORY = 1
+    xmake lua --root private.utils.complete "0" "nospace" "$complete" | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+    }
+    $env:XMAKE_SKIP_HISTORY = $oldenv
+}

--- a/xmake/toolchains/msvc/check.lua
+++ b/xmake/toolchains/msvc/check.lua
@@ -29,6 +29,9 @@ function _check_vsenv(toolchain)
 
     -- have been checked?
     local vs = toolchain:config("vs") or config.get("vs")
+    if vs then
+        vs = tostring(vs)
+    end
     local vcvars = toolchain:config("vcvars")
     if vs and vcvars then
         return vs


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/1817
https://github.com/xmake-io/xmake/issues/2054

- 增加了`xmake update --init`接口来初始化shell integration；
- 改进了`xmake update --uninstall`接口以卸载shell integration；
- 接受`set_toolchains("msvc", {vs=2019})`写法；
- 增加了从git ssh升级xmake的选项。

get.ps1和get.sh由于需要保持前向兼容，暂未进行更改，之后也可以切到xmake update接口来安装shell integration

已知问题：
`set_toolchains("msvc", {vs="2019"})`设置之后，运行xmake config会执行两次查找，输出
```
checking for platform ... windows
checking for architecture ... x64
checking for Microsoft Visual Studio (x64) version ... 2022
checking for Microsoft Visual Studio (x64) version ... 2019
```
这个行为很奇怪，为什么toolchain:on_check看起来被执行了两次？