### PR TITLE
fix: xrepo install config file stuck in work dir.

### DIFF
--- a/xmake/modules/private/xrepo/action/install.lua
+++ b/xmake/modules/private/xrepo/action/install.lua
@@ -102,10 +102,10 @@ function _install_packages(packages)
     local workdir = path.join(os.tmpdir(), "xrepo", "working")
     if not os.isdir(workdir) then
         os.mkdir(workdir)
-        os.cd(workdir)
+        old_dir = os.cd(workdir)
         os.vrunv("xmake", {"create", "-P", "."})
     else
-        os.cd(workdir)
+        old_dir = os.cd(workdir)
     end
 
     -- is package configuration file? e.g. xrepo install xxx.lua
@@ -116,10 +116,19 @@ function _install_packages(packages)
     local filemode = false
     if type(packages) == "string" or #packages == 1 then
         local packagefile = table.unwrap(packages)
+        if not packagefile:startswith("/") then
+            packagefile = path.join(old_dir, packagefile)
+        end
         if type(packagefile) == "string" and packagefile:endswith(".lua") and os.isfile(packagefile) then
             assert(os.isfile("xmake.lua"), "xmake.lua not found!")
+            os.cp("xmake.lua", "xmake.lua.bak")
             os.cp(packagefile, "xmake.lua")
             filemode = true
+        end
+        if not filemode then
+            if os.isfile("xmake.lua.bak") then
+                os.cp("xmake.lua.bak", "xmake.lua")
+            end
         end
     end
 


### PR DESCRIPTION
尝试使用 `xrepo install ./pkgconfig.lua` 从脚本中指定安装包的配置，遇到如下两个问题：

1. 相对路径被识别为包名进行处理，导致无法找到包
2. 一旦执行过以上命令，之后 `xrepo` 所有命令都会安装 `pkgconfig.lua` 中指定的包

本 PR 只是一个 workaround。由于不熟悉 lua，并未判断 windows 上的绝对路径，也不清楚是否有更好的解决办法。