### PR TITLE
improve mingw-w64 env

### DIFF
--- a/xmake/scripts/xrepo/envs/mingw-w64.lua
+++ b/xmake/scripts/xrepo/envs/mingw-w64.lua
@@ -1,1 +1,1 @@
-add_requires("llvm-mingw")
+add_requires("mingw-w64")


### PR DESCRIPTION
llvm-mingw里面的gcc实际上是clang，和原始的mingw-w64不完全一样，这里应当有所区分