### PR TITLE
fix vsxmake on windows

### DIFF
--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -472,11 +472,13 @@ function main(outputdir, vsinfo)
         target.headerfiles = table.imap(target.headerfiles, function(_, v) return path.relative(v, root) end)
         for _, f in ipairs(table.join(target.sourcefiles, target.headerfiles)) do
             local dir = path.directory(f)
+            local escaped_f = _escape(f)
             -- @see https://github.com/xmake-io/xmake/issues/2039
             dir = _strip_dotdirs(dir)
             target._paths[f] =
             {
-                path = _escape(f),
+                -- @see https://github.com/xmake-io/xmake/issues/2077
+                path = path.is_absolute(escaped_f) and escaped_f or "$(XmakeProjectDir)\\" .. escaped_f,
                 dir = _escape(dir)
             }
             while dir ~= "." do

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.c(filec)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.c(filec)
@@ -1,3 +1,3 @@
-    <ClCompile Include="$(XmakeProjectDir)\#path#">
+    <ClCompile Include="#path#">
       <Filter>#dir#</Filter>
     </ClCompile>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.cu(filecu)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.cu(filecu)
@@ -1,3 +1,3 @@
-    <CudaCompile Include="$(XmakeProjectDir)\#path#">
+    <CudaCompile Include="#path#">
       <Filter>#dir#</Filter>
     </CudaCompile>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.cxx(filecxx)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.cxx(filecxx)
@@ -1,3 +1,3 @@
-    <ClCompile Include="$(XmakeProjectDir)\#path#">
+    <ClCompile Include="#path#">
       <Filter>#dir#</Filter>
     </ClCompile>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.mpp(filempp)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.mpp(filempp)
@@ -1,3 +1,3 @@
-    <None Include="$(XmakeProjectDir)\#path#">
+    <None Include="#path#">
       <Filter>#dir#</Filter>
     </None>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.obj(fileobj)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.obj(fileobj)
@@ -1,3 +1,3 @@
-    <Object Include="$(XmakeProjectDir)\#path#">
+    <Object Include="#path#">
       <Filter>#dir#</Filter>
     </Object>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.rc(filerc)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.rc(filerc)
@@ -1,3 +1,3 @@
-    <ResourceCompile Include="$(XmakeProjectDir)\#path#">
+    <ResourceCompile Include="#path#">
       <Filter>#dir#</Filter>
     </ResourceCompile>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.ui(fileui)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/File.ui(fileui)
@@ -1,3 +1,3 @@
-    <None Include="$(XmakeProjectDir)\#path#">
+    <None Include="#path#">
       <Filter>#dir#</Filter>
     </None>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/Include.c(incc)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/Include.c(incc)
@@ -1,3 +1,3 @@
-    <ClInclude Include="$(XmakeProjectDir)\#path#">
+    <ClInclude Include="#path#">
       <Filter>#dir#</Filter>
     </ClInclude>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/Include.natvis(incnatvis)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj.filters/Include.natvis(incnatvis)
@@ -1,3 +1,3 @@
-    <Natvis Include="$(XmakeProjectDir)\#path#">
+    <Natvis Include="#path#">
       <Filter>#dir#</Filter>
     </Natvis>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.c(filec)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.c(filec)
@@ -1,3 +1,3 @@
-    <ClCompile Include="$(XmakeProjectDir)\#path#">
+    <ClCompile Include="#path#">
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.cu(filecu)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.cu(filecu)
@@ -1,1 +1,1 @@
-    <CudaCompile Include="$(XmakeProjectDir)\#path#" />
+    <CudaCompile Include="#path#" />

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.cxx(filecxx)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.cxx(filecxx)
@@ -1,3 +1,3 @@
-    <ClCompile Include="$(XmakeProjectDir)\#path#">
+    <ClCompile Include="#path#">
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.mpp(filempp)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.mpp(filempp)
@@ -1,1 +1,1 @@
-    <None Include="$(XmakeProjectDir)\#path#" />
+    <None Include="#path#" />

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.obj(fileobj)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.obj(fileobj)
@@ -1,1 +1,1 @@
-    <Object Include="$(XmakeProjectDir)\#path#" />
+    <Object Include="#path#" />

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.rc(filerc)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.rc(filerc)
@@ -1,1 +1,1 @@
-    <ResourceCompile Include="$(XmakeProjectDir)\#path#" />
+    <ResourceCompile Include="#path#" />

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.ui(fileui)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/File.ui(fileui)
@@ -1,1 +1,1 @@
-    <None Include="$(XmakeProjectDir)\#path#" />
+    <None Include="#path#" />

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/Include.c(incc)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/Include.c(incc)
@@ -1,1 +1,1 @@
-    <ClInclude Include="$(XmakeProjectDir)\#path#" />
+    <ClInclude Include="#path#" />

--- a/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/Include.natvis(incnatvis)
+++ b/xmake/plugins/project/vsxmake/vsproj/templates/vcxproj/Include.natvis(incnatvis)
@@ -1,3 +1,3 @@
-    <Natvis Include="$(XmakeProjectDir)\#path#">
+    <Natvis Include="#path#">
       <FileType>Document</FileType>
     </Natvis>


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/2077

这里提到项目中如果有在windows下不同盘符的文件，加入项目后无法正确生成vsxmake。这是一个bug，原因是vsxmake中将所有路径转成了相对路径，并且加前缀$(XmakeProjectDir)。然而在windows上，不同盘符文件之间无法使用相对路径相互引用。这一pr修复了这个bug。

这里另外一个问题是vsxmake的Filter使用的不对。直接使用vs的new project，源文件的filter都是`<Filter>Source Files</Filter>`，用cmake生成的项目，源文件的filter也是`<Filter>Source Files</Filter>`，只有xmake的vsxmake插件生成`<Filter>#dir#</Filter>`，这一行为非常怪异。这里是否需要更改一下？