### PR TITLE
Add name to fetch info.

### DIFF
--- a/xmake/modules/private/action/require/fetch.lua
+++ b/xmake/modules/private/action/require/fetch.lua
@@ -51,6 +51,7 @@ function main(requires_raw)
     local nodeps = not (fetchmodes and fetchmodes:has("deps"))
     for _, instance in irpairs(package.load_packages(requires, {requires_extra = requires_extra, nodeps = nodeps})) do
         local fetchinfo = instance:fetch({external = (fetchmodes and fetchmodes:has("external") or false)})
+        fetchinfo.name = instance:name()
         if fetchinfo then
             table.insert(fetchinfos, fetchinfo)
         end


### PR DESCRIPTION
xrepo-cmake 需要解析 `xrepo fetch pkg.lua` 来设置 cmake 变量。在单个 `pkg.lua` 文件中包含多个 package 时，输出的 json 数组难以辨别来自哪个 package，这样就难以为每个 package 分别设置 `pkg_INCLUDE_DIR`, `pkg_LINK_DIR` 等变量。

例如如下 pkg.lua

```lua
local gflags_config = {system = false, configs = {mt = true}}
local libunwind_config = {system = false}

add_requires("glog", {system = false, configs = {unwind = true, gflags = true}})
add_requireconfs("glog.libunwind", libunwind_config)
add_requireconfs("glog.gflags", gflags_config)
-- 如果写 add_requireconfs("glog.*", gflags_config) 会有报错，所以通用配置不能在这里指定

add_requires("gflags", gflags_config)
-- 注释掉减少一点输出
--add_requires("libunwind", libunwind_config)
```

加上该 PR 之后 `xrepo fetch --json pkg.lua` 输出如下（增加了 name 字段）：

```json
[
  {
    "links": [
      "gflags"
    ],
    "libfiles": [
      "/home/cyf/.xmake/packages/g/gflags/v2.2.2/0f545414272c459b907061d5e923ed20/lib/libgflags.a"
    ],
    "version": "v2.2.2",
    "linkdirs": [
      "/home/cyf/.xmake/packages/g/gflags/v2.2.2/0f545414272c459b907061d5e923ed20/lib"
    ],
    "syslinks": "pthread",
    "name": "gflags",
    "license": "BSD-3-Clause",
    "static": true,
    "includedirs": [
      "/home/cyf/.xmake/packages/g/gflags/v2.2.2/0f545414272c459b907061d5e923ed20/include"
    ]
  },
  {
    "version": "v0.5.0",
    "linkdirs": [
      "/home/cyf/.xmake/packages/g/glog/v0.5.0/3958b855fc6d4ea7a2c7b93502baf38a/lib"
    ],
    "name": "glog",
    "license": "BSD-3-Clause",
    "libfiles": [
      "/home/cyf/.xmake/packages/g/glog/v0.5.0/3958b855fc6d4ea7a2c7b93502baf38a/lib/libglog.a"
    ],
    "links": [
      "glog"
    ],
    "static": true,
    "includedirs": [
      "/home/cyf/.xmake/packages/g/glog/v0.5.0/3958b855fc6d4ea7a2c7b93502baf38a/include"
    ]
  }
]
```

若该 PR 会影响到其他功能，可以 close。我转开个 feature request。