### PR TITLE
improve xmake update integrate and cuda has_flags

### DIFF
--- a/xmake/actions/update/main.lua
+++ b/xmake/actions/update/main.lua
@@ -294,8 +294,8 @@ function _initialize_shell()
         local outdata, errdata = try {function () return os.iorunv(psshell.program, {"-c", "Write-Output $PROFILE.CurrentUserAllHosts"}) end}
         if outdata then
             target = outdata:trim()
-            command = "if (Test-Path -Path \"%s\" -PathType Leaf) {\n    . \"%s\"\n}"
             profile = path.join(os.programdir(), "scripts", "profile-win.ps1")
+            command = format("if (Test-Path -Path \"%s\" -PathType Leaf) {\n    . \"%s\"\n}", profile, profile)
         else
             raise("failed to get profile location from powershell!")
         end
@@ -306,8 +306,9 @@ function _initialize_shell()
         elseif shell:endswith("zsh") then target = "~/.zshrc"
         elseif shell:endswith("ksh") then target = "~/.kshrc"
         end
-        command = "[[ -s \"%s\" ]] && source \"%s\""
         profile = path.join(os.programdir(), "scripts", "profile-unix.sh")
+        command = format("export XMAKE_ROOTDIR=\"%s\"\nexport PATH=\"$XMAKE_ROOTDIR:$PATH\"\n", path.directory(os.programfile()))
+        command = command .. format("[[ -s \"%s\" ]] && source \"%s\"", profile, profile)
     end
 
     -- trace
@@ -324,7 +325,7 @@ function _initialize_shell()
                     file = file .. "\n"
                 end
             end
-            file = file .. "# >>> xmake >>>\n" .. format(command, profile, profile) .. "\n# <<< xmake <<<"
+            file = file .. "# >>> xmake >>>\n" .. command .. "\n# <<< xmake <<<"
             io.writefile(target, file)
             return true
         end,

--- a/xmake/modules/detect/tools/nvcc/has_flags.lua
+++ b/xmake/modules/detect/tools/nvcc/has_flags.lua
@@ -122,6 +122,15 @@ function _check_try_running(flags, opt, islinker)
         end
     end
 
+    -- add architecture flags if cross compiling
+    if not is_arch(os.arch()) then
+        if is_arch(".+64.*") then
+            table.insert(args, 1, "-m64")
+        else
+            table.insert(args, 1, "-m32")
+        end
+    end
+
     -- check flags
     return _try_running(opt.program, table.join(flags, args), opt)
 end


### PR DESCRIPTION
运行xmake show -l architectures可发现所有64位arch都带有64字样，所以用is_arch(".+64.*")就可以判断是否应该加-m64. 