### PR TITLE
Fix paths for precompiled package on linux.

### DIFF
--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -19,9 +19,9 @@
 --
 
 -- imports
-import("core.base.global")
 import("core.base.option")
 import("core.base.tty")
+import("core.package.package", {alias = "core_package"})
 import("core.project.target")
 import("lib.detect.find_file")
 import("private.action.require.impl.actions.test")
@@ -100,12 +100,15 @@ end
 -- fix paths for the precompiled package
 -- @see https://github.com/xmake-io/xmake/issues/1671
 function _fix_paths_for_precompiled_package(package)
-    local buildhash_pattern = string.rep('%x', 32)
     -- Matches to path like (string inside brackets is matched):
     --     /home/user/.xmake[/pacakges/f/foo/9adc96bd69124211aad7dd58a36f02ce/]v1.0
-    -- Replaces path string before "packages" with global configured directory.
+    -- Replaces path string before "packages" with local pacakge install
+    -- directory.
+    -- Note: It's possible that package A references files package B, thus we
+    -- need to match against all possible package install paths.
+    local buildhash_pattern = string.rep('%x', 32)
     local match_pattern = "[\\/]packages[\\/]%w[\\/][^\\/]+[\\/][^\\/]+[\\/]" .. buildhash_pattern .. "[\\/]"
-    local prefix = global.directory()
+    local prefix = path.directory(core_package.installdir())
 
     local filepaths = {path.join(package:installdir(), "**.cmake|include/**")}
     for _, filepath in ipairs(filepaths) do

--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -100,11 +100,11 @@ end
 -- fix paths for the precompiled package
 -- @see https://github.com/xmake-io/xmake/issues/1671
 function _fix_paths_for_precompiled_package(package)
-    -- Matches to path like (string inside brackets is matched):
+    -- Match to path like (string insides brackets is matched):
     --     /home/user/.xmake[/pacakges/f/foo/9adc96bd69124211aad7dd58a36f02ce/]v1.0
-    -- Replaces path string before "packages" with local pacakge install
+    -- Replace path string before "packages" with local pacakge install
     -- directory.
-    -- Note: It's possible that package A references files package B, thus we
+    -- Note: It's possible that package A references files in package B, thus we
     -- need to match against all possible package install paths.
     local buildhash_pattern = string.rep('%x', 32)
     local match_pattern = "[\\/]packages[\\/]%w[\\/][^\\/]+[\\/][^\\/]+[\\/]" .. buildhash_pattern .. "[\\/]"

--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -101,8 +101,8 @@ end
 -- @see https://github.com/xmake-io/xmake/issues/1671
 function _fix_paths_for_precompiled_package(package)
     -- Match to path like (string insides brackets is matched):
-    --     /home/user/.xmake[/pacakges/f/foo/9adc96bd69124211aad7dd58a36f02ce/]v1.0
-    -- Replace path string before "packages" with local pacakge install
+    --     /home/user/.xmake[/packages/f/foo/9adc96bd69124211aad7dd58a36f02ce/]v1.0
+    -- Replace path string before "packages" with local package install
     -- directory.
     -- Note: It's possible that package A references files in package B, thus we
     -- need to match against all possible package install paths.
@@ -121,7 +121,7 @@ function _fix_paths_for_precompiled_package(package)
                     if #splitinfo == 2 then
                         result = path.join(prefix, mat, splitinfo[2])
                     elseif #splitinfo == 1 then
-                        if value:sub(1, #mat) == mat then
+                        if value:startswith(mat) then
                             -- path begins with matched pattern: [/packages/f/foo/buildhash/]v1.0
                             result = path.join(prefix, value)
                         else


### PR DESCRIPTION
参考 https://github.com/xmake-io/xmake/issues/1671

因为一个包可能引用另一个包的文件，所以这个修复里没有匹配 buildhash 和 name。