### PR TITLE
Fix unity build when batchsize is set

### DIFF
--- a/xmake/rules/c++/unity_build/unity_build.lua
+++ b/xmake/rules/c++/unity_build/unity_build.lua
@@ -83,7 +83,7 @@ function main(target, sourcebatch)
     local sourcefiles = {}
     local objectfiles = {}
     local dependfiles = {}
-    local sourcedir = path.join(target:autogendir({root = true}), "unity_build")
+    local sourcedir = path.join(target:autogendir({root = true}), target:plat(), "unity_build")
     for idx, sourcefile in pairs(sourcebatch.sourcefiles) do
         local sourcefile_unity
         local objectfile = sourcebatch.objectfiles[idx]
@@ -97,10 +97,11 @@ function main(target, sourcebatch)
             table.insert(objectfiles, objectfile)
             table.insert(dependfiles, dependfile)
         else
-            if batchsize and count > batchsize then
+            if batchsize and count >= batchsize then
                 id = id + 1
+                count = 0
             end
-            sourcefile_unity = path.join(sourcedir, "unity_" .. hash.uuid(tostring(id)):split("-", {plain = true})[1] .. path.extension(sourcefile))
+            sourcefile_unity = path.join(sourcedir, "unity_" .. tostring(id) .. path.extension(sourcefile))
             count = count + 1
         end
         if sourcefile_unity then


### PR DESCRIPTION
When batchsize was set, Unity build only batched X files and didn't batch the rest.
I also put unity build files in a platform-dependent folder, since there may be conflict between Windows and Linux path (\ and /) if used in the same folder.