### PR TITLE
Simplify switching compiler for cmake.

### DIFF
--- a/xmake/toolchains/clang/xmake.lua
+++ b/xmake/toolchains/clang/xmake.lua
@@ -32,7 +32,7 @@ toolchain("clang" .. suffix)
     set_kind("standalone")
 
     set_toolset("cc", "clang" .. suffix)
-    set_toolset("cxx", "clang" .. suffix, "clang++" .. suffix)
+    set_toolset("cxx", "clang++" .. suffix, "clang" .. suffix)
     set_toolset("ld", "clang++" .. suffix, "clang" .. suffix)
     set_toolset("sh", "clang++" .. suffix, "clang" .. suffix)
     set_toolset("ar", "ar")

--- a/xmake/toolchains/gcc/xmake.lua
+++ b/xmake/toolchains/gcc/xmake.lua
@@ -35,7 +35,7 @@ toolchain("gcc" .. suffix)
 
     -- set toolset
     set_toolset("cc", "gcc" .. suffix)
-    set_toolset("cxx", "gcc" .. suffix, "g++" .. suffix)
+    set_toolset("cxx", "g++" .. suffix, "gcc" .. suffix)
     set_toolset("ld", "g++" .. suffix, "gcc" .. suffix)
     set_toolset("sh", "g++" .. suffix, "gcc" .. suffix)
     set_toolset("ar", "ar")


### PR DESCRIPTION
指定 `--toolchain` 的情况下，编译 HDF5 库遇到问题。

原因是设置 `CMAKE_SYSTEM_NAME` 变量使 CMake 认为在进行交叉编译，因此 `TRY_RUN` 不会在 build host 执行，必须用户自行指定。

这个 PR 并不期望被合并，autoconf 那边并未修改，toolchain 中 cxx 编译器也做了修改。

只是想看下对于同系统切换编译器，是否可以将切换编译器的工作交给所选用的构建工具，避免走交叉编译的代码逻辑。
对于非交叉编译来说，这样做可能更加简单可靠。

我暂时会用这个 PR 中的修改测试一段时间，看会遇到什么问题。

相关 issue #2170

相关讨论 #2099 