### PR TITLE
Enable PIC if only specifying toolchain.

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -421,6 +421,10 @@ function _get_configs_for_cross(package, configs, opt)
     -- https://github.com/xmake-io/xmake/issues/2170
     if not package:is_plat(os.subhost()) then
         envs.CMAKE_SYSTEM_NAME     = "Linux"
+    else
+        if package:config("pic") ~= false then
+            table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+        end
     end
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037


### PR DESCRIPTION
从 cmake [文档](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#toolchain-features) 来看

> Some toolchain features have built-in handling in CMake, and do not require compile-tests. For example, [POSITION_INDEPENDENT_CODE](https://cmake.org/cmake/help/latest/prop_tgt/POSITION_INDEPENDENT_CODE.html#prop_tgt:POSITION_INDEPENDENT_CODE) allows specifying that a target should be built as position-independent code, if the compiler supports that feature.

若 `pic=tru`e 应该可以对所有平台设置 `-DCMAKE_POSITION_INDEPENDENT_CODE=ON`。

我不知道以前踩过什么坑，所以这里以影响范围最小的方式修改。缺点是多了一处 `pic` 处理代码。

autoconf 那边我没找到类似的处理代码，所以此处没做修改。