### PR TITLE
Rust: fix command to install cxxbridge

### DIFF
--- a/xmake/rules/rust/build/cxxbridge.lua
+++ b/xmake/rules/rust/build/cxxbridge.lua
@@ -23,7 +23,7 @@ import("core.base.option")
 import("lib.detect.find_tool")
 
 function main(target, batchcmds, sourcefile, opt)
-    local cxxbridge = assert(find_tool("cxxbridge"), "cxxbridge not found, please run `cargo install cxxbridge` to install it first!")
+    local cxxbridge = assert(find_tool("cxxbridge"), "cxxbridge not found, please run `cargo install cxxbridge-cmd` to install it first!")
 
     -- get c/c++ source file for cxxbridge
     local headerfile = path.join(target:autogendir(), "rules", "cxxbridge", path.basename(sourcefile) .. ".rs.h")


### PR DESCRIPTION
The rust package is called cxxbridge-cmd: https://crates.io/crates/cxxbridge-cmd