### PR TITLE
Fix path for artifacts using remotedir in manifests.

### DIFF
--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -99,7 +99,7 @@ end
 
 -- Match to path like (string insides brackets is matched):
 --     /home/user/.xmake/packages[/f/foo/9adc96bd69124211aad7dd58a36f02ce]/v1.0
-local _PACKAGE_BUILDHASH_VERSION_PATTERN = "[\\/]%w[\\/][^\\/]+[\\/][^\\/]+[\\/]" .. string.rep('%x', 32)
+local _PACKAGE_BUILDHASH_VERSION_PATTERN = "[\\/]%w[\\/][^\\/]+[\\/]" .. string.rep('%x', 32) 
 
 function _fix_path_for_file(file, search_pattern)
     -- Replace path string before package pattern with local package install

--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -98,8 +98,8 @@ function _patch_pkgconfig(package)
 end
 
 -- Match to path like (string insides brackets is matched):
---     /home/user/.xmake/packages[/f/foo/9adc96bd69124211aad7dd58a36f02ce]/v1.0
-local _PACKAGE_BUILDHASH_VERSION_PATTERN = "[\\/]%w[\\/][^\\/]+[\\/]" .. string.rep('%x', 32) 
+--     /home/user/.xmake/packages[/f/foo/v0.1.0/9adc96bd69124211aad7dd58a36f02ce]/lib
+local _PACKAGE_VERSION_BUILDHASH_PATTERN = "[\\/]%w[\\/][^\\/]+[\\/][^\\/]+[\\/]" .. string.rep('%x', 32)
 
 function _fix_path_for_file(file, search_pattern)
     -- Replace path string before package pattern with local package install
@@ -114,7 +114,7 @@ function _fix_path_for_file(file, search_pattern)
     local prefix = core_package.installdir()
 
     io.gsub(file, search_pattern, function(whole_value, value)
-        local mat = value:match(_PACKAGE_BUILDHASH_VERSION_PATTERN)
+        local mat = value:match(_PACKAGE_VERSION_BUILDHASH_PATTERN)
         if not mat then
             return nil
         end
@@ -184,7 +184,7 @@ function _fix_paths_for_precompiled_package(package)
     local remote_prefix
     local local_prefix
     if remotedir then
-        local idx = remotedir:find(_PACKAGE_BUILDHASH_VERSION_PATTERN)
+        local idx = remotedir:find(_PACKAGE_VERSION_BUILDHASH_PATTERN)
         if idx then
             remote_prefix = remotedir:sub(1, idx)
             local_prefix = core_package.installdir()

--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -192,7 +192,7 @@ function _fix_paths_for_precompiled_package(package)
                 local_prefix = local_prefix .. path.sep()
             end
         else
-            cprint("WARNING no package buildhash pattern found in artifacts remotedir: %s", remotedir)
+            wprint("no package buildhash pattern found in artifacts remotedir: %s", remotedir)
         end
     end
 


### PR DESCRIPTION
实现 #2210 中的功能。

https://github.com/xmake-io/xmake/commit/b178f763015779488df34e75990667eccb82521a 使 export 得到的 `manifest.txt` 文件中包含如下信息：

```lua
    artifacts = {
        installdir = "/home/user/.xmake/packages/g/glog/v0.4.0/acdee252a14045cabf522b6a10d05b3e"
    },
```
仅将 `remotedir` 替换为 `package:installdir()` 不够。

例如 glog 的 cmake 文件会引用 unwind 的全路径，所以此处实现逻辑是抽出路径前缀进行替换。

若 `manifests.txt` 中没有 `remotedir` 则使用原先的处理逻辑。