### PR TITLE
fix vsxmake generator

### DIFF
--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -490,7 +490,7 @@ function main(outputdir, vsinfo)
                         dir_id = hash.uuid4(dir)
                     }
                 end
-                dir = path.directory(dir)
+                dir = path.directory(dir) or "."
             end
         end
         target._dirs = dirs


### PR DESCRIPTION
it looks like path.directory(dir) can return nil now 

fixes
```
error: @programdir\core\main.lua:280: @programdir\plugins\project\vsxmake\getinfo.lua:491: table index is nil
stack traceback:
    [@programdir\plugins\project\vsxmake\getinfo.lua:493]:
    [@programdir\plugins\project\vsxmake\vsxmake.lua:223]: in function '?'
    [@programdir\plugins\project\main.lua:79]: in function '_make'
    [@programdir\plugins\project\main.lua:89]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:280]:
    [@programdir\core\base\task.lua:519]: in function 'run'
    [@programdir\core\main.lua:278]: in function 'cotask'
    [@programdir\core\base\scheduler.lua:371]:
```