### PR TITLE
update(rules/platform/linux/bpf): enforce -O2 when compiling BPF

### DIFF
--- a/xmake/rules/platform/linux/bpf/xmake.lua
+++ b/xmake/rules/platform/linux/bpf/xmake.lua
@@ -46,6 +46,7 @@ rule("platform.linux.bpf")
             targetarch = "__TARGET_ARCH_powerpc"
         end
         target:add("includedirs", path.directory(headerfile))
+        target:set("optimize", "faster")
         batchcmds:show_progress(opt.progress, "${color.build.object}compiling.bpf %s", sourcefile)
         batchcmds:mkdir(path.directory(objectfile))
         batchcmds:compile(sourcefile, objectfile, {configs = {force = {cxflags = {"-target bpf", "-g"}}, defines = targetarch}})

--- a/xmake/rules/platform/linux/bpf/xmake.lua
+++ b/xmake/rules/platform/linux/bpf/xmake.lua
@@ -46,10 +46,9 @@ rule("platform.linux.bpf")
             targetarch = "__TARGET_ARCH_powerpc"
         end
         target:add("includedirs", path.directory(headerfile))
-        target:set("optimize", "faster")
         batchcmds:show_progress(opt.progress, "${color.build.object}compiling.bpf %s", sourcefile)
         batchcmds:mkdir(path.directory(objectfile))
-        batchcmds:compile(sourcefile, objectfile, {configs = {force = {cxflags = {"-target bpf", "-g"}}, defines = targetarch}})
+        batchcmds:compile(sourcefile, objectfile, {configs = {force = {cxflags = {"-target bpf", "-g", "-O2"}}, defines = targetarch}})
         batchcmds:mkdir(path.directory(headerfile))
         batchcmds:execv("bpftool", {"gen", "skeleton", objectfile}, {stdout = headerfile})
         batchcmds:add_depfiles(sourcefile)


### PR DESCRIPTION
To avoid compiler optimizations messing up with generated IR and BPF instructions is paramount to enforce the optimization level to 2 disregarding the mode (whether it is set to debug or release etc.)



