### PR TITLE
add a extra function for python.library

### DIFF
--- a/xmake/rules/python/xmake.lua
+++ b/xmake/rules/python/xmake.lua
@@ -40,4 +40,13 @@ rule("python.library")
             end
         end
     end)
+    after_build(function(target)
+        local targetfile = target:targetfile()
+        os.cp(targetfile, path.join("./", path.filename(targetfile)))
+        local setuptools = target:extraconf("rules", "python.library", "setuptools")
+        if setuptools then
+          print("python setup.py develop")
+          os.run("python setup.py develop")
+        end
+    end)
 


### PR DESCRIPTION
我给 rule("python.library") 增加了一个额外小功能，会将生成好的包复制到项目根目录，如果 {setuptools=true} 还会执行 python setup.py develop 更新 python 包索引。这样好处在于写 c++ 时，有 xmake + vscode-clangd 提供 intellisense, 写 python 时，python-vscode 提供 intellisense，不会出现一堆黄色或者红色波浪线烦人的问题。
我用这种方式完成了一个小 demo，请见 https://gitee.com/rolfma/py11-mixed 。#2293

