### PR TITLE
fix(find_package): update for cmake config mode

### DIFF
--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -72,17 +72,17 @@ function _find_package(cmake, name, opt)
     end
     cmakefile:print("find_package(%s REQUIRED)", requirestr)
     cmakefile:print("if(%s_FOUND)", name)
-    cmakefile:print("   add_executable(%s test.cpp)", name)
+    cmakefile:print("   add_executable(%s test.cpp)", "test_"..name)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        name, name, name)
+        "test_"..name, name, name)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        name, name:upper(), name:upper())
+        "test_"..name, name:upper(), name:upper())
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_CXX_INCLUDE_DIRS})",
-        name, name)
-    cmakefile:print("   target_link_libraries(%s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        name, name, name, name)
-    cmakefile:print("   target_link_libraries(%s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        name, name:upper(), name:upper(), name:upper())
+        "test_"..name, name)
+    cmakefile:print("   target_link_libraries(%s %s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
+        "test_"..name, name, name, name, name)
+    cmakefile:print("   target_link_libraries(%s %s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
+        "test_"..name, name:upper(), name:upper(), name:upper(), name:upper())
     cmakefile:print("endif(%s_FOUND)", name)
     cmakefile:close()
 
@@ -97,7 +97,7 @@ function _find_package(cmake, name, opt)
     local defines
     local includedirs
     local ldflags
-    local flagsfile = path.join(workdir, "CMakeFiles", name .. ".dir", "flags.make")
+    local flagsfile = path.join(workdir, "CMakeFiles", "test_"..name .. ".dir", "flags.make")
     if os.isfile(flagsfile) then
         local flagsdata = io.readfile(flagsfile)
         if flagsdata then
@@ -137,10 +137,11 @@ function _find_package(cmake, name, opt)
     end
 
     -- parse links and linkdirs for macosx/linux
-    local linkfile = path.join(workdir, "CMakeFiles", name .. ".dir", "link.txt")
+    local linkfile = path.join(workdir, "CMakeFiles", "test_"..name .. ".dir", "link.txt")
     if os.isfile(linkfile) then
         local linkdata = io.readfile(linkfile)
         if linkdata then
+            print(flagsdata)
             if option.get("diagnosis") then
                 vprint(linkdata)
             end
@@ -188,7 +189,7 @@ function _find_package(cmake, name, opt)
     end
 
     -- pares includedirs and links/linkdirs for windows
-    local vcprojfile = path.join(workdir, name .. ".vcxproj")
+    local vcprojfile = path.join(workdir, "test_"..name .. ".vcxproj")
     if os.isfile(vcprojfile) then
         local vcprojdata = io.readfile(vcprojfile)
         if vcprojdata then

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -71,19 +71,20 @@ function _find_package(cmake, name, opt)
             end
         end
     end
+    local testname = "test_" .. name
     cmakefile:print("find_package(%s REQUIRED)", requirestr)
     cmakefile:print("if(%s_FOUND)", name)
-    cmakefile:print("   add_executable(%s test.cpp)", "test_" .. name)
+    cmakefile:print("   add_executable(%s test.cpp)", testname)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        "test_" .. name, name, name)
+        testname, name, name)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        "test_" .. name, name:upper(), name:upper())
+        testname, name:upper(), name:upper())
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_CXX_INCLUDE_DIRS})",
-        "test_" .. name, name)
+        testname, name)
     cmakefile:print("   target_link_libraries(%s %s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        "test_" .. name, name, name, name, name)
+        testname, name, name, name, name)
     cmakefile:print("   target_link_libraries(%s %s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        "test_" .. name, name:upper(), name:upper(), name:upper(), name:upper())
+        testname, name:upper(), name:upper(), name:upper(), name:upper())
     cmakefile:print("endif(%s_FOUND)", name)
     cmakefile:close()
 
@@ -98,7 +99,7 @@ function _find_package(cmake, name, opt)
     local defines
     local includedirs
     local ldflags
-    local flagsfile = path.join(workdir, "CMakeFiles", "test_" .. name .. ".dir", "flags.make")
+    local flagsfile = path.join(workdir, "CMakeFiles", testname .. ".dir", "flags.make")
     if os.isfile(flagsfile) then
         local flagsdata = io.readfile(flagsfile)
         if flagsdata then
@@ -138,7 +139,7 @@ function _find_package(cmake, name, opt)
     end
 
     -- parse links and linkdirs for macosx/linux
-    local linkfile = path.join(workdir, "CMakeFiles", "test_" .. name .. ".dir", "link.txt")
+    local linkfile = path.join(workdir, "CMakeFiles", testname .. ".dir", "link.txt")
     if os.isfile(linkfile) then
         local linkdata = io.readfile(linkfile)
         if linkdata then
@@ -190,7 +191,7 @@ function _find_package(cmake, name, opt)
     end
 
     -- pares includedirs and links/linkdirs for windows
-    local vcprojfile = path.join(workdir, "test_" .. name .. ".vcxproj")
+    local vcprojfile = path.join(workdir, testname .. ".vcxproj")
     if os.isfile(vcprojfile) then
         local vcprojdata = io.readfile(vcprojfile)
         if vcprojdata then

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -1,3 +1,4 @@
+
 --!A cross-platform build utility based on Lua
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,17 +73,17 @@ function _find_package(cmake, name, opt)
     end
     cmakefile:print("find_package(%s REQUIRED)", requirestr)
     cmakefile:print("if(%s_FOUND)", name)
-    cmakefile:print("   add_executable(%s test.cpp)", "test_"..name)
+    cmakefile:print("   add_executable(%s test.cpp)", "test_" .. name)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        "test_"..name, name, name)
+        "test_" .. name, name, name)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        "test_"..name, name:upper(), name:upper())
+        "test_" .. name, name:upper(), name:upper())
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_CXX_INCLUDE_DIRS})",
-        "test_"..name, name)
+        "test_" .. name, name)
     cmakefile:print("   target_link_libraries(%s %s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        "test_"..name, name, name, name, name)
+        "test_" .. name, name, name, name, name)
     cmakefile:print("   target_link_libraries(%s %s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        "test_"..name, name:upper(), name:upper(), name:upper(), name:upper())
+        "test_" .. name, name:upper(), name:upper(), name:upper(), name:upper())
     cmakefile:print("endif(%s_FOUND)", name)
     cmakefile:close()
 
@@ -97,7 +98,7 @@ function _find_package(cmake, name, opt)
     local defines
     local includedirs
     local ldflags
-    local flagsfile = path.join(workdir, "CMakeFiles", "test_"..name .. ".dir", "flags.make")
+    local flagsfile = path.join(workdir, "CMakeFiles", "test_" .. name .. ".dir", "flags.make")
     if os.isfile(flagsfile) then
         local flagsdata = io.readfile(flagsfile)
         if flagsdata then
@@ -137,7 +138,7 @@ function _find_package(cmake, name, opt)
     end
 
     -- parse links and linkdirs for macosx/linux
-    local linkfile = path.join(workdir, "CMakeFiles", "test_"..name .. ".dir", "link.txt")
+    local linkfile = path.join(workdir, "CMakeFiles", "test_" .. name .. ".dir", "link.txt")
     if os.isfile(linkfile) then
         local linkdata = io.readfile(linkfile)
         if linkdata then
@@ -189,7 +190,7 @@ function _find_package(cmake, name, opt)
     end
 
     -- pares includedirs and links/linkdirs for windows
-    local vcprojfile = path.join(workdir, "test_"..name .. ".vcxproj")
+    local vcprojfile = path.join(workdir, "test_" .. name .. ".vcxproj")
     if os.isfile(vcprojfile) then
         local vcprojdata = io.readfile(vcprojfile)
         if vcprojdata then

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -1,4 +1,3 @@
-
 --!A cross-platform build utility based on Lua
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
1. distinguish names to avoid add_executable and find_package conflict error
2. add lib_name in target_link_libraries, for cmake find_package config mode(xxx-config.cmake)