### PR TITLE
fix generated cmakelists when using `set_languages("c++latest")`

### DIFF
--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -450,6 +450,7 @@ function _add_target_languages(cmakelists, target)
     ,   cxx14 = "cxx_std_14"
     ,   cxx17 = "cxx_std_17"
     ,   cxx20 = "cxx_std_20"
+    ,   cxxlatest = "cxx_std_23"
     }
     local languages = target:get("languages")
     if languages then

--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -450,7 +450,7 @@ function _add_target_languages(cmakelists, target)
     ,   cxx14 = "cxx_std_14"
     ,   cxx17 = "cxx_std_17"
     ,   cxx20 = "cxx_std_20"
-    ,   cxxlatest = "cxx_std_23"
+    ,   cxx23 = "cxx_std_23"
     }
     local languages = target:get("languages")
     if languages then


### PR DESCRIPTION
According to [CMAKE_CXX_KNOWN_FEATURES](https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html), the corresponding value for `set_languages("c++latest")` should be `cxx_std_23`. This value is new in version 3.20.
