### PR TITLE
improve package.tools.meson

### DIFF
--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -56,7 +56,7 @@ function _get_configs(package, configs, opt)
     table.insert(configs, "--libdir=lib")
 
     -- set build type
-    table.insert(configs, "--buildtype=" .. (package:debug() and "debug" or "release"))
+    table.insert(configs, "-Dbuildtype=" .. (package:debug() and "debug" or "release"))
 
     -- add -fpic
     if package:is_plat("linux") and package:config("pic") then


### PR DESCRIPTION
https://github.com/xmake-io/xmake/blob/7d5a9b498a47c47554daee8839e4f9caac1dcc64/xmake/modules/package/tools/meson.lua#L155-L161

这里的pkgconf只会在系统找，不会在dep package里面找；因此不会设置PKG_CONFIG环境变量。

https://github.com/xmake-io/xmake-repo/runs/6622844238?check_suite_focus=true

> found pkg-config 'C:\\Strawberry\\perl\\bin\\pkg-config.BAT' but it is Strawberry Perl and thus broken. Ignoring...
> Found Pkg-config: NO

meson拒绝使用strawberry perl提供的pkgconfig，见
https://github.com/mesonbuild/meson/blob/bba588d8b03a9125bf5c4faaad31b70d39242b68/mesonbuild/dependencies/pkgconfig.py#L427-L431

xmake在拼接路径的时候把msvc的runenv放在最前面，各种package提供的env放在后面，而runenv里面又包括了系统的env（比如strawberry perl）最后导致meson找不到正确的pkg-config。

修改建议：

1. 找pkgconf的时候同时检查是否有package:dep("pkgconf"):exists()
2. 拼路径的时候按各种package提供的env-msvc独有的runenv-系统env方式拼接，这可以通过在获取msvc runenv的时候去除尾部系统env来完成