### PR TITLE
Improve package installation error messages

### DIFF
--- a/xmake/modules/private/action/require/impl/install_packages.lua
+++ b/xmake/modules/private/action/require/impl/install_packages.lua
@@ -695,7 +695,7 @@ function main(requires, opt)
 
     local has_errors = false
 
-    -- exists unknwon packages?
+    -- exists unknown packages?
     if #packages_unknown > 0 then
         cprint("${bright color.warning}note: ${clear}the following packages were not found in any repository (check if they are spelled correctly):")
         for _, instance in ipairs(packages_unknown) do
@@ -706,7 +706,7 @@ function main(requires, opt)
 
     -- exists unsupported packages?
     if #packages_unsupported > 0 then
-        cprint("${bright color.warning}note: ${clear}the following packages are unsupported for $(plat)/$(arch):")
+        cprint("${bright color.warning}note: ${clear}the following packages are unsupported on $(plat)/$(arch):")
         for _, instance in ipairs(packages_unsupported) do
             print("  -> %s %s", instance:displayname(), instance:version_str() or "")
         end
@@ -715,7 +715,7 @@ function main(requires, opt)
 
     -- exists not found packages?
     if #packages_not_found > 0 then
-        cprint("${bright color.warning}note: ${clear}the following packages were not found for $(plat)/$(arch):")
+        cprint("${bright color.warning}note: ${clear}the following packages were not found on your system, try again after installing them:")
         for _, instance in ipairs(packages_not_found) do
             print("  -> %s %s", instance:displayname(), instance:version_str() or "")
         end

--- a/xmake/modules/private/action/require/impl/install_packages.lua
+++ b/xmake/modules/private/action/require/impl/install_packages.lua
@@ -678,7 +678,7 @@ function main(requires, opt)
                 end
                 table.insert(packages_install, instance)
             elseif not instance:is_optional() then
-                if not instance:exists() and not instance:repo() then
+                if not instance:exists() and instance:is_system() then
                     table.insert(packages_unknown, instance)
                 else
                     table.insert(packages_unsupported, instance)


### PR DESCRIPTION
```lua
add_rules("mode.debug", "mode.release")
add_requires("libcurle") -- mispelled libcurl
add_requires("util-linux") -- isn't available on Windows
add_requires("openssl", { system = true }) -- isn't present on the system

target("xmake-nonexistantpkg")
    set_kind("binary")
    add_files("src/*.cpp")
```

=>
```
C:\Projets\Perso\Tests\xmake-nonexistantpkg>xmake
checking for platform ... windows
checking for architecture ... x64
checking for Microsoft Visual Studio (x64) version ... 2022
note: the following packages were not found in any repository (check if they are spelled correctly):
  -> libcurle
note: the following packages are unsupported on windows/x64:
  -> util-linux 2.36.2
note: the following packages were not found on your system, try again after installing them:
  -> openssl 1.1.1o
```

~~One issue I have is that I can't detect this case:~~ (fixed)
```lua
package("test")
package_end()

add_requires("test") -- local package that xmake can't install
add_requires("libcurle") -- mispelled libcurl
```

```
note: the following packages were not found in any repository (check if they are spelled correctly):
  -> test
  -> libcurle
```

I don't know how to detect `test`, a locally defined package vs a non-existing package