### PR TITLE
make standalone  = false

### DIFF
--- a/xmake/core/platform/platform.lua
+++ b/xmake/core/platform/platform.lua
@@ -254,6 +254,7 @@ function _instance:check()
             idx = idx + 1
             table.insert(toolchains_valid, toolchain:name())
         end
+        standalone = true
     end
     if #toolchains == 0 then
         return false, "toolchains not found!"


### PR DESCRIPTION
standalone make ifort toolchain removed while check is ok
看不懂，后面的工具链(standalone)，为啥会因为前面的工具链是独立的就被移除