### PR TITLE
xmake run: Improve error message when target doesn't exist

### DIFF
--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -99,7 +99,7 @@ function _find_matching_target_names(targetname)
     targetname = targetname:lower()
     local matching_targetnames = {}
     for _, target in ipairs(project.ordertargets()) do
-        if target:name():lower():find(targetname) then
+        if target:name():lower():find(targetname, 1, true) then
             table.insert(matching_targetnames, target:name())
         end
     end
@@ -165,7 +165,7 @@ function _check_targets(targetname, group_pattern)
         local target = project.target(targetname)
         if not target then
             -- check if the name is part of other target to help
-            local possible_targetnames =_find_matching_target_names(targetname)
+            local possible_targetnames = _find_matching_target_names(targetname)
 
             local err = targetname .. " is not a valid target name for this project"
             if #possible_targetnames > 0 then

--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -148,7 +148,24 @@ function _check_targets(targetname, group_pattern)
     -- get targets
     local targets = {}
     if targetname then
-        local target = assert(project.target(targetname), "%s not found!", targetname)
+        local target = project.target(targetname)
+        if not target then
+            -- check if the name is part of other target to help
+            local possible_targetnames = {}
+            for _, target in ipairs(project.ordertargets()) do
+                if target:name():lower():find(targetname:lower()) then
+                    table.insert(possible_targetnames, target:name())
+                end
+            end
+
+            local err = targetname .. " is not a valid target name for this project"
+            if #possible_targetnames > 0 then
+                err = err .. "\ndid you mean:\n - " .. table.concat(possible_targetnames, '\n - ')
+            end
+
+            raise(err)
+        end
+
         table.insert(targets, target)
     else
         for _, target in ipairs(project.ordertargets()) do

--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -94,6 +94,20 @@ function _add_target_pkgenvs(target, targets_added)
     end
 end
 
+-- find target names matching a specific name
+function _find_matching_target_names(targetname)
+    targetname = targetname:lower()
+    local matching_targetnames = {}
+    for _, target in ipairs(project.ordertargets()) do
+        if target:name():lower():find(targetname) then
+            table.insert(matching_targetnames, target:name())
+        end
+    end
+
+    table.sort(matching_targetnames)
+    return matching_targetnames
+end
+
 -- run the given target
 function _run(target)
 
@@ -151,16 +165,11 @@ function _check_targets(targetname, group_pattern)
         local target = project.target(targetname)
         if not target then
             -- check if the name is part of other target to help
-            local possible_targetnames = {}
-            for _, target in ipairs(project.ordertargets()) do
-                if target:name():lower():find(targetname:lower()) then
-                    table.insert(possible_targetnames, target:name())
-                end
-            end
+            local possible_targetnames =_find_matching_target_names(targetname)
 
             local err = targetname .. " is not a valid target name for this project"
             if #possible_targetnames > 0 then
-                err = err .. "\ndid you mean:\n - " .. table.concat(possible_targetnames, '\n - ')
+                err = err .. "\nlist of valid target names close to your input:\n - " .. table.concat(possible_targetnames, '\n - ')
             end
 
             raise(err)


### PR DESCRIPTION
examples:
```
lynix@SirDesktop:/mnt/c/Projets/Perso/Burgwar/BurgWar$ xmake.exe run BurgWa
error: BurgWa is not a valid target name for this project
did you mean:
 - BurgWarMapEditor
 - BurgWarServer
 - BurgWar
 - BurgWarMapTool
```

```
lynix@SirDesktop:/mnt/c/Projets/Perso/Burgwar/BurgWar$ xmake.exe run maptool
error: maptool is not a valid target name for this project
did you mean:
 - BurgWarMapTool
```