### PR TITLE
xmake tool: allow package to override mode/kind

### DIFF
--- a/xmake/modules/package/tools/xmake.lua
+++ b/xmake/modules/package/tools/xmake.lua
@@ -45,8 +45,12 @@ function _get_configs(package, configs)
     local ldflags  = table.join(table.wrap(package:config("ldflags")),  get_config("ldflags"))
     table.insert(configs, "--plat=" .. package:plat())
     table.insert(configs, "--arch=" .. package:arch())
-    table.insert(configs, "--mode=" .. (package:is_debug() and "debug" or "release"))
-    table.insert(configs, "--kind=" .. (package:config("shared") and "shared" or "static"))
+    if configs.mode == nil then
+        table.insert(configs, "--mode=" .. (package:is_debug() and "debug" or "release"))
+    end
+    if configs.kind == nil then
+        table.insert(configs, "--kind=" .. (package:config("shared") and "shared" or "static"))
+    end
     if package:is_plat("windows") then
         local vs_runtime = package:config("vs_runtime")
         if vs_runtime then


### PR DESCRIPTION
example:
```lua
	on_install(function (package)
		local configs = {}
		configs.fs_watcher = package:config("fs_watcher") or false
		configs.with_nzslc = package:config("with_nzslc") or false
		configs.erronwarn = false
		if package:is_debug() then
			configs.mode = "debug"
		elseif package:config("symbols") then
			configs.mode = "releasedbg"
		else
			configs.mode = "release"
		end
		import("package.tools.xmake").install(package, configs)
	end)
```