### PR TITLE
do not add targetdir to custom venvs

### DIFF
--- a/xmake/modules/private/xrepo/action/env.lua
+++ b/xmake/modules/private/xrepo/action/env.lua
@@ -330,7 +330,9 @@ function _package_getenvs(opt)
         for _, instance in ipairs(package.load_packages(requires, {requires_extra = requires_extra})) do
             _package_addenvs(envs, instance)
         end
-        _target_addenvs(envs)
+        if not has_envfile then
+            _target_addenvs(envs)
+        end
     elseif packages then
         _enter_project()
         packages = packages:split(',', {plain = true})


### PR DESCRIPTION
目前使用`xrepo env -b xxx shell`也会把当前目录的构建文件夹加入环境，这个pr修复这一行为