### PR TITLE
In project.clang, replace -isystem by -I only if it starts with.

### DIFF
--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -45,9 +45,9 @@ function _translate_arguments(arguments)
             arg = arg .. ".exe"
         end
         if arg:startswith("-isystem-after", 1, true) then
-            arg = "-I" .. arg:sub(15, -1)
+            arg = "-I" .. arg:sub(15)
         elseif arg:startswith("-isystem", 1, true) then
-            arg = "-I" .. arg:sub(9, -1)
+            arg = "-I" .. arg:sub(9)
         elseif arg:find("[%-/]external:I") then
             arg = arg:gsub("[%-/]external:I", "-I")
         elseif arg:find("[%-/]external:W") or arg:find("[%-/]experimental:external") then

--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -44,7 +44,7 @@ function _translate_arguments(arguments)
         if idx == 1 and is_host("windows") and path.extension(arg) == "" then
             arg = arg .. ".exe"
         end
-        if arg:find("-isystem", 1, true) then
+        if arg:startswith("-isystem", 1, true) then
             arg = arg:replace("-isystem", "-I")
         elseif arg:find("[%-/]external:I") then
             arg = arg:gsub("[%-/]external:I", "-I")

--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -45,7 +45,7 @@ function _translate_arguments(arguments)
             arg = arg .. ".exe"
         end
         if arg:startswith("-isystem-after", 1, true) then
-            arg = "-I" .. arg:sub(13, -1)
+            arg = "-I" .. arg:sub(15, -1)
         elseif arg:startswith("-isystem", 1, true) then
             arg = "-I" .. arg:sub(9, -1)
         elseif arg:find("[%-/]external:I") then

--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -44,8 +44,10 @@ function _translate_arguments(arguments)
         if idx == 1 and is_host("windows") and path.extension(arg) == "" then
             arg = arg .. ".exe"
         end
-        if arg:startswith("-isystem", 1, true) then
-            arg = arg:replace("-isystem", "-I")
+        if arg:startswith("-isystem-after", 1, true) then
+            arg = "-I" .. arg:sub(13, -1)
+        elseif arg:startswith("-isystem", 1, true) then
+            arg = "-I" .. arg:sub(9, -1)
         elseif arg:find("[%-/]external:I") then
             arg = arg:gsub("[%-/]external:I", "-I")
         elseif arg:find("[%-/]external:W") or arg:find("[%-/]experimental:external") then


### PR DESCRIPTION
I wasn't able to use the clang flag `-stdlib++-isystem` and make a compile_commands.json with xmake because during the flags translation, it replaces all `-isystem` by `-I` (so i had `-stdlib++-I` in the compile_commands.json).

Now, it replaces the flags when it starts with `-isystem`

I also prevent code if `-isystem-after` flag is used or if `-isystem` if present in the path following `-isystem` flag.