### PR TITLE
Call cygpath once at the beginning for msys2 pacman packages

### DIFF
--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -29,16 +29,14 @@ function _find_package_from_list(list, name, pacman, opt)
 
     -- mingw + pacman = cygpath available
     local cygpath = nil
-    local pathtomsys2 = ""
+    local pathtomsys2 = nil
     if is_subhost("msys") and opt.plat == "mingw" then
         cygpath = find_tool("cygpath")
         if not cygpath then
             return
         end
         pathtomsys = os.iorunv(cygpath.program, {"--windows", "/"})
-        if pathtomsys:endswith("\n") then
-            pathtomsys = pathtomsys:sub(1, -2)
-        end
+        pathtomsys = pathtomsys:trim()
     end
 
     -- iterate over each file path inside the pacman package
@@ -51,10 +49,10 @@ function _find_package_from_list(list, name, pacman, opt)
                 if is_subhost("msys") and opt.plat == "mingw" then 
                     hpath = path.join(pathtomsys, line)
                     if opt.arch == "x86_64" then
-                        local basehpath = path.join(pathtomsys, "/mingw64/include")
+                        local basehpath = path.join(pathtomsys, "mingw64/include")
                         table.insert(result.includedirs, basehpath)
                     else
-                        local basehpath = path.join(pathtomsys, "/mingw32/include")
+                        local basehpath = path.join(pathtomsys, "mingw32/include")
                         table.insert(result.includedirs, basehpath)
                     end
                 end
@@ -95,7 +93,7 @@ function _find_package_from_list(list, name, pacman, opt)
         result.version = version:split('-')[1]
     else
         result = nil
-    end   
+    end
     return result
 end
 

--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -29,7 +29,7 @@ function _find_package_from_list(list, name, pacman, opt)
 
     -- mingw + pacman = cygpath available
     local cygpath = nil
-    local pathtomsys2 = nil
+    local pathtomsys = nil
     if is_subhost("msys") and opt.plat == "mingw" then
         cygpath = find_tool("cygpath")
         if not cygpath then

--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -29,10 +29,15 @@ function _find_package_from_list(list, name, pacman, opt)
 
     -- mingw + pacman = cygpath available
     local cygpath = nil
+    local pathtomsys2 = ""
     if is_subhost("msys") and opt.plat == "mingw" then
         cygpath = find_tool("cygpath")
         if not cygpath then
             return
+        end
+        pathtomsys = os.iorunv(cygpath.program, {"--windows", "/"})
+        if pathtomsys:endswith("\n") then
+            pathtomsys = pathtomsys:sub(1, -2)
         end
     end
 
@@ -43,14 +48,13 @@ function _find_package_from_list(list, name, pacman, opt)
         if line:find("/include/", 1, true) and (line:endswith(".h") or line:endswith(".hpp")) then
             if not line:startswith("/usr/include/") then
                 local hpath = line
-                if is_subhost("msys") and opt.plat == "mingw" then
-                    hpath = os.iorunv(cygpath.program, {"--windows", line})
-
+                if is_subhost("msys") and opt.plat == "mingw" then 
+                    hpath = path.join(pathtomsys, line)
                     if opt.arch == "x86_64" then
-                        local basehpath = os.iorunv(cygpath.program, {"--windows", "/mingw64/include"})
+                        local basehpath = path.join(pathtomsys, "/mingw64/include")
                         table.insert(result.includedirs, basehpath)
                     else
-                        local basehpath = os.iorunv(cygpath.program, {"--windows", "/mingw32/include"})
+                        local basehpath = path.join(pathtomsys, "/mingw32/include")
                         table.insert(result.includedirs, basehpath)
                     end
                 end
@@ -58,7 +62,7 @@ function _find_package_from_list(list, name, pacman, opt)
             end
         -- remove lib and .a, .dll.a and .so to have the links
         elseif line:endswith(".dll.a") then -- only for mingw
-            local apath = os.iorunv(cygpath.program, {"--windows", line})
+            local apath = path.join(pathtomsys, line)
             apath = apath:trim()
             table.insert(result.linkdirs, path.directory(apath))
             table.insert(result.links, target.linkname(path.filename(apath), {plat = opt.plat}))
@@ -68,7 +72,7 @@ function _find_package_from_list(list, name, pacman, opt)
         elseif line:endswith(".a") then
             local apath = line
             if is_subhost("msys") and opt.plat == "mingw" then
-                apath = os.iorunv(cygpath.program, {"--windows", line})
+                apath = path.join(pathtomsys, line)
                 apath = apath:trim()
             end
             table.insert(result.linkdirs, path.directory(apath))
@@ -91,7 +95,7 @@ function _find_package_from_list(list, name, pacman, opt)
         result.version = version:split('-')[1]
     else
         result = nil
-    end
+    end   
     return result
 end
 


### PR DESCRIPTION
In the case of a pacman package under msys2 without .pc files, `cygpath` is called multiple times to obtain a good path. Calling `cygpath` is slow, and for a big package without .pc files like `boost`, it takes too much time to parse the package content.

With this change, `cygpath` is called once to obtain the correct msys2 base path, and then `path.join` is used. Reading a package like `boost` is now very fast.
