### PR TITLE
Removed ImportLibrary from link/linkdir for Windows cmake find_package

### DIFF
--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -216,11 +216,6 @@ function _find_package(cmake, name, opt)
                 end
 
                 values = line:match("<AdditionalDependencies>(.+)</AdditionalDependencies>")
-                if not values then
-                    -- we need also parse libraries from here
-                    -- https://github.com/xmake-io/xmake/issues/1822
-                    values = line:match("<ImportLibrary>(.+)</ImportLibrary>")
-                end
                 if values then
                     for _, library in ipairs(path.splitenv(values)) do
                         -- get libfiles


### PR DESCRIPTION
Remove ImportLibrary parsing from links/linkdir (it tries to add name_test.lib to links which causes failures)

Fixes #2746 

