### PR TITLE
move find_vulkansdk to sdk detection

### DIFF
--- a/xmake/modules/detect/packages/find_vulkansdk.lua
+++ b/xmake/modules/detect/packages/find_vulkansdk.lua
@@ -28,6 +28,6 @@ import("detect.sdks.find_vulkansdk")
 -- @return      see the return value of find_package()
 --
 function main(opt)
-
-    return find_vulkansdk()
+    opt = opt or {}
+    return find_vulkansdk({arch = opt.arch})
 end

--- a/xmake/modules/detect/packages/find_vulkansdk.lua
+++ b/xmake/modules/detect/packages/find_vulkansdk.lua
@@ -19,8 +19,7 @@
 --
 
 -- imports
-import("lib.detect.find_path")
-import("lib.detect.find_library")
+import("detect.sdks.find_vulkansdk")
 
 -- find vulkansdk
 --
@@ -30,30 +29,5 @@ import("lib.detect.find_library")
 --
 function main(opt)
 
-    -- init search paths
-    local paths =
-    {
-        "$(env VK_SDK_PATH)",
-        "$(env VULKAN_SDK)"
-    }
-
-    -- find library
-    local result = {links = {}, linkdirs = {}, includedirs = {}}
-    local libname = (opt.plat == "windows" and "vulkan-1" or "vulkan")
-    local libsuffix = ((opt.plat == "windows" and opt.arch == "x86") and "lib32" or "lib")
-    local binsuffix = ((opt.plat == "windows" and opt.arch == "x86") and "bin32" or "bin")
-    local linkinfo = find_library(libname, paths, {suffixes = libsuffix})
-    if linkinfo then
-        result.sdkdir = path.directory(linkinfo.linkdir)
-        result.bindir = path.join(result.sdkdir, binsuffix)
-        table.insert(result.linkdirs, linkinfo.linkdir)
-        table.insert(result.links, libname)
-    else
-        -- not found?
-        return
-    end
-
-    -- find include
-    table.insert(result.includedirs, find_path(path.join("vulkan", "vulkan.h"), paths, {suffixes = "include"}))
-    return result
+    return find_vulkansdk()
 end

--- a/xmake/modules/detect/sdks/find_vulkansdk.lua
+++ b/xmake/modules/detect/sdks/find_vulkansdk.lua
@@ -1,0 +1,100 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      xq114
+-- @file        find_vulkansdk.lua
+--
+
+-- imports
+import("lib.detect.find_file")
+import("lib.detect.find_path")
+import("lib.detect.find_library")
+import("lib.detect.find_programver")
+
+-- find vulkan sdk info executable
+function _find_vkinfo()
+
+    -- init search paths
+    local paths =
+    {
+        "$(env VK_SDK_PATH)",
+        "$(env VULKAN_SDK)"
+    }
+
+    -- find vulkan sdk info
+    local vkinfo
+    if is_host("windows") then
+        if is_arch("x86") then
+            vkinfo = find_file("vulkaninfoSDK.exe", paths, {suffixes = {"bin32"}})
+        else
+            vkinfo = find_file("vulkaninfoSDK.exe", paths, {suffixes = {"bin"}})
+        end
+    elseif is_host("linux") then
+        vkinfo = find_file("vulkaninfo", paths, {suffixes = {"bin"}})
+    end
+
+    return vkinfo
+end
+
+-- find vulkansdk
+--
+-- @param opt   the package options. e.g. see the options of find_package()
+--
+-- @return      see the return value of find_package()
+--
+function main(opt)
+
+    -- find vkinfo
+    local vkinfo = _find_vkinfo()
+    if not vkinfo then
+        -- not found?
+        return
+    end
+    local sdkdir = path.directory(path.directory(vkinfo))
+
+    -- find api version
+    local apiver = find_programver(vkinfo, {command = "--summary", parse = "Vulkan Instance Version: (%d+%.%d+%.%d+)"})
+
+    -- initialize result
+    local result = {sdkdir = sdkdir, apiversion = apiver, links = {}, linkdirs = {}, includedirs = {}}
+    local binsuffix = ((is_host("windows") and is_arch("x86")) and "bin32" or "bin")
+    result.bindir = path.join(result.sdkdir, binsuffix)
+
+    -- find library
+    local libname = (is_host("windows") and "vulkan-1" or "vulkan")
+    local libsuffix = ((is_host("windows") and is_arch("x86")) and "lib32" or "lib")
+    local linkinfo = find_library(libname, sdkdir, {suffixes = libsuffix})
+    if linkinfo then
+        table.insert(result.linkdirs, linkinfo.linkdir)
+        table.insert(result.links, libname)
+    else
+        -- not found?
+        return
+    end
+
+    -- find headers
+    local incdir = find_path(path.join("vulkan", "vulkan.h"), sdkdir, {suffixes = {"include"}})
+    if incdir then
+        table.insert(result.includedirs, incdir)
+    else
+        -- not found?
+        return
+    end
+
+    -- return
+    print(result)
+    return result
+end

--- a/xmake/rules/python/xmake.lua
+++ b/xmake/rules/python/xmake.lua
@@ -36,7 +36,7 @@ rule("python.library")
                 end
             end
         else
-            if target:is_plat("windows") then
+            if target:is_plat("windows", "mingw") then
                 target:set("extension", ".pyd")
             else
                 target:set("extension", ".so")


### PR DESCRIPTION
目前的find_package已经是deprecated了，未来需要将vulkansdk移动到xmake-repo中以便于搜索、添加依赖、添加环境变量，因此将find脚本移动到sdk中复用。