### PR TITLE
Strict compatibility for package linkdeps

### DIFF
--- a/xmake/actions/package/local/main.lua
+++ b/xmake/actions/package/local/main.lua
@@ -26,16 +26,16 @@ import("core.project.config")
 import("core.project.project")
 import("core.base.bit")
 
--- get link deps
-function _get_linkdeps(target)
-    local linkdeps = {}
+-- get library deps
+function _get_librarydeps(target)
+    local librarydeps = {}
     for _, depname in ipairs(target:get("deps")) do
         local dep = project.target(depname)
         if not ((target:is_binary() or target:is_shared()) and dep:is_static()) then
-            table.insert(linkdeps, dep:name())
+            table.insert(librarydeps, dep:name())
         end
     end
-    return linkdeps
+    return librarydeps
 end
 
 -- package binary
@@ -55,7 +55,7 @@ function _package_binary(target)
     -- generate xmake.lua
     local file = io.open(path.join(packagedir, "xmake.lua"), "w")
     if file then
-        local deps = _get_linkdeps(target)
+        local deps = _get_librarydeps(target)
         file:print("package(\"%s\")", packagename)
         local homepage = option.get("homepage")
         if homepage then
@@ -129,7 +129,7 @@ function _package_library(target)
     -- generate xmake.lua
     local file = io.open(path.join(packagedir, "xmake.lua"), "w")
     if file then
-        local deps = _get_linkdeps(target)
+        local deps = _get_librarydeps(target)
         file:print("package(\"%s\")", packagename)
         local homepage = option.get("homepage")
         if homepage then
@@ -193,7 +193,7 @@ function _package_headeronly(target)
     -- generate xmake.lua
     local file = io.open(path.join(packagedir, "xmake.lua"), "w")
     if file then
-        local deps = _get_linkdeps(target)
+        local deps = _get_librarydeps(target)
         file:print("package(\"%s\")", packagename)
         local homepage = option.get("homepage")
         if homepage then

--- a/xmake/actions/package/remote/main.lua
+++ b/xmake/actions/package/remote/main.lua
@@ -26,16 +26,16 @@ import("core.project.config")
 import("core.project.project")
 import("core.base.bit")
 
--- get link deps
-function _get_linkdeps(target)
-    local linkdeps = {}
+-- get library deps
+function _get_librarydeps(target)
+    local librarydeps = {}
     for _, depname in ipairs(target:get("deps")) do
         local dep = project.target(depname)
         if not ((target:is_binary() or target:is_shared()) and dep:is_static()) then
-            table.insert(linkdeps, dep:name())
+            table.insert(librarydeps, dep:name())
         end
     end
-    return linkdeps
+    return librarydeps
 end
 
 -- package remote
@@ -48,7 +48,7 @@ function _package_remote(target)
     -- generate xmake.lua
     local file = io.open(path.join(packagedir, "xmake.lua"), "w")
     if file then
-        local deps = _get_linkdeps(target)
+        local deps = _get_librarydeps(target)
         file:print("package(\"%s\")", packagename)
         if target:is_binary() then
             file:print("    set_kind(\"binary\")")

--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -768,6 +768,17 @@ function _instance:manifest_save()
         end
     end
 
+    -- save deps
+    if self:deps() then
+        manifest.deps = {}
+        for name, dep in pairs(self:deps()) do
+            manifest.deps[name] = {
+                version = dep:version_str(),
+                buildhash = dep:buildhash()
+            }
+        end
+    end
+
     -- save variables
     local vars = {}
     local apis = language.apis()

--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -364,9 +364,9 @@ function _instance:plaindeps()
     return self._PLAINDEPS
 end
 
--- get link deps
-function _instance:linkdeps()
-    return self._LINKDEPS
+-- get library deps with correct link order
+function _instance:librarydeps()
+    return self._LIBRARYDEPS
 end
 
 -- get parents
@@ -758,12 +758,12 @@ function _instance:manifest_save()
     manifest.configs     = self:configs()
     manifest.envs        = self:envs()
 
-    -- save enabled link deps
-    if self:linkdeps() then
-        manifest.linkdeps = {}
-        for _, dep in ipairs(self:linkdeps()) do
+    -- save enabled library deps
+    if self:librarydeps() then
+        manifest.librarydeps = {}
+        for _, dep in ipairs(self:librarydeps()) do
             if dep:exists() then
-                table.insert(manifest.linkdeps, dep:name())
+                table.insert(manifest.librarydeps, dep:name())
             end
         end
     end
@@ -1600,16 +1600,16 @@ function _instance:exists()
     return self._FETCHINFO ~= nil
 end
 
--- fetch link info of dependencies
-function _instance:fetch_linkdeps()
+-- fetch library dependencies
+function _instance:fetch_librarydeps()
     local fetchinfo = self:fetch()
     if not fetchinfo then
         return
     end
     fetchinfo = table.copy(fetchinfo) -- avoid the cached fetchinfo be modified
-    local linkdeps = self:linkdeps()
-    if linkdeps then
-        for _, dep in ipairs(linkdeps) do
+    local librarydeps = self:librarydeps()
+    if librarydeps then
+        for _, dep in ipairs(librarydeps) do
             local depinfo = dep:fetch()
             if depinfo then
                 for name, values in pairs(depinfo) do
@@ -1756,7 +1756,7 @@ end
 -- generate building configs for has_xxx/check_xxx
 function _instance:_generate_build_configs(configs, opt)
     opt = opt or {}
-    configs = table.join(self:fetch_linkdeps(), configs)
+    configs = table.join(self:fetch_librarydeps(), configs)
     if self:is_plat("windows") then
         local ld = self:build_getenv("ld")
         local vs_runtime = self:config("vs_runtime")

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -71,9 +71,10 @@ function policy.policies()
             ["package.include_external_headers"] = {description = "Use includes as external headers.", type = "boolean"},
             -- inherit the configs from the external command arguments, e.g. toolchains, `xmake f --toolchain=`
             ["package.inherit_external_configs"] = {description = "Inherit the configs from the external command arguments.", default = true, type = "boolean"},
-            -- set version compatibility, if false, then new versions are always incompatible with older versions,
-            -- all packages that depend on it will generate a new buildhash, @see https://github.com/xmake-io/xmake/issues/2719
-            ["package.version_compatibility"]    = {description = "Set package version compatibility.", default = true, type = "boolean"},
+            -- set strict compatibility for package dependencies
+            -- if true, then any updates to linked dependencies, such as buildhash changes due to version changes,
+            -- will force the installed packages to be recompiled and installed. @see https://github.com/xmake-io/xmake/issues/2719
+            ["package.linkdeps.strict_compatibility"] = {description = "Set strict compatibility for package dependencies.", type = "boolean"},
         }
         policy._POLICIES = policies
     end

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -70,7 +70,10 @@ function policy.policies()
             -- use includes as external header files? e.g. -isystem ..
             ["package.include_external_headers"] = {description = "Use includes as external headers.", type = "boolean"},
             -- inherit the configs from the external command arguments, e.g. toolchains, `xmake f --toolchain=`
-            ["package.inherit_external_configs"] = {description = "Inherit the configs from the external command arguments.", default = true, type = "boolean"}
+            ["package.inherit_external_configs"] = {description = "Inherit the configs from the external command arguments.", default = true, type = "boolean"},
+            -- set version compatibility, if false, then new versions are always incompatible with older versions,
+            -- all packages that depend on it will generate a new buildhash, @see https://github.com/xmake-io/xmake/issues/2719
+            ["package.version_compatibility"]    = {description = "Set package version compatibility.", default = true, type = "boolean"},
         }
         policy._POLICIES = policies
     end

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -74,7 +74,7 @@ function policy.policies()
             -- set strict compatibility for package dependencies
             -- if true, then any updates to linked dependencies, such as buildhash changes due to version changes,
             -- will force the installed packages to be recompiled and installed. @see https://github.com/xmake-io/xmake/issues/2719
-            ["package.linkdeps.strict_compatibility"] = {description = "Set strict compatibility for package dependencies.", type = "boolean"},
+            ["package.librarydeps.strict_compatibility"] = {description = "Set strict compatibility for package dependencies.", type = "boolean"},
         }
         policy._POLICIES = policies
     end

--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -49,7 +49,7 @@ function _patch_pkgconfig(package)
     vprint("patching %s ..", pcfile)
 
     -- fetch package
-    local fetchinfo = package:fetch_linkdeps()
+    local fetchinfo = package:fetch_librarydeps()
     if not fetchinfo then
         return
     end

--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -274,7 +274,8 @@ function main(package)
             else
 
                 -- build and install package to the install directory
-                if option.get("force") or not package:manifest_load() then
+                local force_reinstall = package:data("force_reinstall") or option.get("force")
+                if force_reinstall or not package:manifest_load() then
 
                     -- clean install directory first
                     os.tryrm(package:installdir())

--- a/xmake/modules/private/action/require/impl/install_packages.lua
+++ b/xmake/modules/private/action/require/impl/install_packages.lua
@@ -76,10 +76,10 @@ function _replace_package(packages, instance, extinstance)
                 break
             end
         end
-        local linkdeps = rawinstance._LINKDEPS
-        for depidx, dep in ipairs(linkdeps) do
+        local librarydeps = rawinstance._LIBRARYDEPS
+        for depidx, dep in ipairs(librarydeps) do
             if dep == instance then
-                linkdeps[depidx] = extinstance
+                librarydeps[depidx] = extinstance
                 break
             end
         end

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -947,6 +947,7 @@ function _must_depend_on(package, dep)
 end
 
 -- compatible with all previous link dependencies?
+-- @see https://github.com/xmake-io/xmake/issues/2719
 function _compatible_with_previous_linkdeps(package)
 
     -- check strict compatibility for linkdeps?

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -1018,6 +1018,9 @@ function _compatible_with_previous_linkdeps(package, opt)
     if not is_compatible and #compatible_tips > 0 then
         package:data_set("linkdeps.compatible_tips", compatible_tips)
     end
+    if not is_compatible then
+        package:data_set("force_reinstall", true)
+    end
     return is_compatible
 end
 

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -948,7 +948,13 @@ end
 
 -- compatible with all previous link dependencies?
 -- @see https://github.com/xmake-io/xmake/issues/2719
-function _compatible_with_previous_linkdeps(package)
+function _compatible_with_previous_linkdeps(package, opt)
+
+    -- skip to check compatibility?
+    opt = opt or {}
+    if opt.check_compatibility == false then
+        return true
+    end
 
     -- check strict compatibility for linkdeps?
     local strict_compatibility = project.policy("package.linkdeps.strict_compatibility")
@@ -957,6 +963,12 @@ function _compatible_with_previous_linkdeps(package)
     end
     if not strict_compatibility then
         return true
+    end
+
+    -- has been checked?
+    local compatible_checked = package:data("linkdeps.compatible_checked")
+    if compatible_checked then
+        return
     end
 
     -- compute the buildhash for previous linkdeps
@@ -1015,11 +1027,11 @@ function cachedir()
 end
 
 -- this package should be install?
-function should_install(package)
+function should_install(package, opt)
     if package:is_template() then
         return false
     end
-    if package:exists() and _compatible_with_previous_linkdeps(package) then
+    if package:exists() and _compatible_with_previous_linkdeps(package, opt) then
         return false
     end
     -- we need not install it if this package need only be fetched
@@ -1034,7 +1046,7 @@ function should_install(package)
     if package:parents() then
         -- if all the packages that depend on it already exist, then there is no need to install it
         for _, parent in pairs(package:parents()) do
-            if should_install(parent) and not parent:exists() then
+            if should_install(parent, opt) and not parent:exists() then
                 return true
             end
 

--- a/xmake/modules/private/action/require/impl/register_packages.lua
+++ b/xmake/modules/private/action/require/impl/register_packages.lua
@@ -88,7 +88,7 @@ function _register_required_package(instance, required_package)
         _register_required_package_base(instance, required_package)
         _register_required_package_libs(instance, required_package)
         _register_required_package_envs(instance, envs)
-        for _, dep in ipairs(instance:linkdeps()) do
+        for _, dep in ipairs(instance:librarydeps()) do
             if instance:is_library() then
                 _register_required_package_libs(dep, required_package, true)
             end

--- a/xmake/modules/private/action/require/install.lua
+++ b/xmake/modules/private/action/require/install.lua
@@ -35,7 +35,7 @@ function _check_missing_packages(packages)
     local packages_missing = {}
     local optional_missing = {}
     for _, instance in ipairs(packages) do
-        if package.should_install(instance) or (instance:is_fetchonly() and not instance:exists()) then
+        if package.should_install(instance, {check_compatibility = false}) or (instance:is_fetchonly() and not instance:exists()) then
             if instance:is_optional() then
                 optional_missing[instance:name()] = instance
             else


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/2719


we can use `set_policy("package.librarydeps.strict_compatibility, true)` to limit package compatibility in package().

```lua
package("libpng")
    add_deps("zlib")
    set_policy("package.librarydeps.strict_compatibility, true)
```

Or we can also use `set_policy("package.librarydeps.strict_compatibility, true)` to limit all packages compatibility in project xmake.lua

```lua
set_policy("package.librarydeps.strict_compatibility, true)
add_requires("libpng")
```

for example:

I updated zlib 1.2.11 => 1.2.12 in package()

### Dependency compatibility is not strictly tested by default

```console
$ xmake f -c
do nothing
```

### Enable strict compatibility for librarydeps

```console
$ xmake f -c --policies=package.librarydeps.strict_compatibility
note: install or modify (m) these packages (pass -y to skip confirm)?
in local-repo:
  -> libpng v1.6.37 [deps:*zlib]
please input: y (y/n/m)
```