### PR TITLE
remove `-fbuiltin-module-map` in the (windows)mingw environment make the compilation work

### DIFF
--- a/xmake/rules/c++/modules/modules_support/clang.lua
+++ b/xmake/rules/c++/modules/modules_support/clang.lua
@@ -489,7 +489,11 @@ function get_builtinmodulemapflag(target)
     if builtinmodulemapflag == nil then
         local compinst = target:compiler("cxx")
         if compinst:has_flags("-fbuiltin-module-map", "cxxflags", {flagskey = "clang_builtin_module_map"}) then
-            builtinmodulemapflag = "-fbuiltin-module-map"
+            if is_plat("windows", "mingw") then
+                builtinmodulemapflag = ""
+            else
+                builtinmodulemapflag = "-fbuiltin-module-map"
+            end
         end
         assert(builtinmodulemapflag, "compiler(clang): does not support c++ module!")
         _g.builtinmodulemapflag = builtinmodulemapflag or false

--- a/xmake/rules/c++/modules/modules_support/clang.lua
+++ b/xmake/rules/c++/modules/modules_support/clang.lua
@@ -487,15 +487,15 @@ end
 function get_builtinmodulemapflag(target)
     local builtinmodulemapflag = _g.builtinmodulemapflag
     if builtinmodulemapflag == nil then
-        local compinst = target:compiler("cxx")
-        if compinst:has_flags("-fbuiltin-module-map", "cxxflags", {flagskey = "clang_builtin_module_map"}) then
-            if target:is_plat("windows", "mingw") then
-                builtinmodulemapflag = ""
-            else
+        -- this flag seems clang on mingw doesn't distribute it
+        -- @see https://github.com/xmake-io/xmake/pull/2833
+        if not target:is_plat("mingw") then
+            local compinst = target:compiler("cxx")
+            if compinst:has_flags("-fbuiltin-module-map", "cxxflags", {flagskey = "clang_builtin_module_map"}) then
                 builtinmodulemapflag = "-fbuiltin-module-map"
             end
+            assert(builtinmodulemapflag, "compiler(clang): does not support c++ module!")
         end
-        assert(builtinmodulemapflag, "compiler(clang): does not support c++ module!")
         _g.builtinmodulemapflag = builtinmodulemapflag or false
     end
     return builtinmodulemapflag or nil

--- a/xmake/rules/c++/modules/modules_support/clang.lua
+++ b/xmake/rules/c++/modules/modules_support/clang.lua
@@ -489,7 +489,7 @@ function get_builtinmodulemapflag(target)
     if builtinmodulemapflag == nil then
         local compinst = target:compiler("cxx")
         if compinst:has_flags("-fbuiltin-module-map", "cxxflags", {flagskey = "clang_builtin_module_map"}) then
-            if is_plat("windows", "mingw") then
+            if target:is_plat("windows", "mingw") then
                 builtinmodulemapflag = ""
             else
                 builtinmodulemapflag = "-fbuiltin-module-map"


### PR DESCRIPTION
There is no builtin module for clang in the mingw environment, so remove `-fbuiltin-module-map` in the mingw environment will make the compilation work.

