### PR TITLE
xrepo install: set "shared" config if kind is specified.

### DIFF
--- a/xmake/modules/private/xrepo/action/install.lua
+++ b/xmake/modules/private/xrepo/action/install.lua
@@ -250,9 +250,9 @@ function _install_packages(packages)
     if mode == "debug" then
         extra.debug = true
     end
-    if kind == "shared" then
+    if option.get("kind") then
         extra.configs = extra.configs or {}
-        extra.configs.shared = true
+        extra.configs.shared = kind == "shared"
     end
     local configs = option.get("configs")
     if configs then


### PR DESCRIPTION
Also refer to https://github.com/xmake-io/xmake-repo/pull/1502

This allow `xrepo install --kind static` to override package configs that set `shared=true` as default.