### PR TITLE
fix link error on linux when use qt4

### DIFF
--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -39,7 +39,11 @@ function _link(target, linkdirs, framework, qt_sdkver)
         if qt_sdkver:ge("5.0") then
             framework = "Qt" .. qt_sdkver:major() .. framework:sub(3) .. (is_mode("debug") and debug_suffix or "")
         else -- for qt4.x, e.g. QtGui4.lib
-            framework = "Qt" .. framework:sub(3) .. (is_mode("debug") and debug_suffix or "") .. qt_sdkver:major()
+            if target:is_plat("windows") or target:is_plat("mingw") then
+                framework = "Qt" .. framework:sub(3) .. (is_mode("debug") and debug_suffix or "") .. qt_sdkver:major()
+            else 
+                framework = "Qt" .. framework:sub(3) .. (is_mode("debug") and debug_suffix or "") 
+            end
         end
         if target:is_plat("android") then --> -lQt5Core_armeabi/-lQt5CoreDebug_armeabi for 5.14.x
             local libinfo = find_library(framework .. "_" .. config.arch(), linkdirs)

--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -39,7 +39,7 @@ function _link(target, linkdirs, framework, qt_sdkver)
         if qt_sdkver:ge("5.0") then
             framework = "Qt" .. qt_sdkver:major() .. framework:sub(3) .. (is_mode("debug") and debug_suffix or "")
         else -- for qt4.x, e.g. QtGui4.lib
-            if target:is_plat("windows") or target:is_plat("mingw") then
+            if target:is_plat("windows", "mingw") then
                 framework = "Qt" .. framework:sub(3) .. (is_mode("debug") and debug_suffix or "") .. qt_sdkver:major()
             else 
                 framework = "Qt" .. framework:sub(3) .. (is_mode("debug") and debug_suffix or "") 


### PR DESCRIPTION
When compiling the qt4 program, I get the following error:

[ 75%]: linking.release testXmakeQt4
error: /usr/bin/ld: cannot find -lQtGui4
/usr/bin/ld: cannot find -lQtCore4
collect2: error: ld returned 1 exit status

this pr can fix it