### PR TITLE
Stabilize vs and vsxmake project generation

### DIFF
--- a/xmake/core/project/project.lua
+++ b/xmake/core/project/project.lua
@@ -896,7 +896,8 @@ end
 function project.ordertargets()
     local ordertargets = project._memcache():get("ordertargets")
     if not ordertargets then
-        local targets = project.targets()
+        local targets = table.values(project.targets())
+        table.sort(targets, function (a,b) return a:name() < b:name() end)
         ordertargets = {}
         local targetrefs = {}
         for _, t in pairs(targets) do

--- a/xmake/core/project/project.lua
+++ b/xmake/core/project/project.lua
@@ -896,11 +896,12 @@ end
 function project.ordertargets()
     local ordertargets = project._memcache():get("ordertargets")
     if not ordertargets then
-        local targets = table.values(project.targets())
-        table.sort(targets, function (a,b) return a:name() < b:name() end)
+        local targets = project.targets()
+        local sorted_targets = table.values(targets)
+        table.sort(sorted_targets, function (a,b) return a:name() < b:name() end)
         ordertargets = {}
         local targetrefs = {}
-        for _, t in pairs(targets) do
+        for _, t in ipairs(sorted_targets) do
             instance_deps.sort_deps(targets, ordertargets, targetrefs, t)
         end
         project._memcache():set("ordertargets", ordertargets)

--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -980,7 +980,9 @@ function _instance:pkgenvs()
                 end
             end
         end
-        for _, pkg in pkgs:keys() do
+        local orderedpkgs = pkgs:to_array()
+        table.sort(orderedpkgs, function (a, b) return a:name() < b:name() end)
+        for _, pkg in ipairs(orderedpkgs) do
             local envs = pkg:get("envs")
             if envs then
                 for name, values in pairs(envs) do

--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -953,6 +953,7 @@ function _instance:orderpkgs(opt)
                 end
             end
         end
+        table.sort(packages, function (a, b) return a:name() < b:name() end)
         self:_memcache():set(cachekey, packages)
     end
     return packages

--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -335,8 +335,9 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
         end
     end
     for k, v in pairs(addrunenvs) do
+        table.sort(v)
         if k:upper() == "PATH" then
-            runenvs[k] = _translate_path(v, vcxprojdir) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
+            runenvs[k] = _translate_path(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
         else
             runenvs[k] = path.joinenv(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
         end
@@ -345,11 +346,12 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
         if #v == 1 then
             v = v[1]
             if path.is_absolute(v) and v:startswith(project.directory()) then
-                runenvs[k] = _translate_path(v, vcxprojdir)
+                runenvs[k] = _translate_path(v)
             else
                 runenvs[k] = v[1]
             end
         else
+            table.sort(v)
             runenvs[k] = path.joinenv(v)
         end
     end
@@ -357,6 +359,8 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
     for k, v in pairs(runenvs) do
         table.insert(runenvstr, k .. "=" .. v)
     end
+    table.sort(runenvstr)
+
     targetinfo.runenvs = table.concat(runenvstr, "\n")
 
     -- use mfc? save the mfc runtime kind
@@ -555,9 +559,11 @@ function make(outputdir, vsinfo)
 
     -- init modes
     vsinfo.modes = _make_vsinfo_modes()
+    table.sort(vsinfo.modes)
 
     -- init archs
     vsinfo.archs = _make_vsinfo_archs()
+    table.sort(vsinfo.archs)
 
     -- load targets
     local targets = {}
@@ -635,6 +641,10 @@ function make(outputdir, vsinfo)
                 -- save all sourcefiles and headerfiles
                 _target.sourcefiles = table.unique(table.join(_target.sourcefiles or {}, (target:sourcefiles())))
                 _target.headerfiles = table.unique(table.join(_target.headerfiles or {}, (target:headerfiles())))
+
+                -- sort them to stabilize generation
+                table.sort(_target.sourcefiles)
+                table.sort(_target.headerfiles)
 
                 -- save file groups
                 _target.filegroups = target:get("filegroups")

--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -335,7 +335,6 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
         end
     end
     for k, v in pairs(addrunenvs) do
-        table.sort(v)
         if k:upper() == "PATH" then
             runenvs[k] = _translate_path(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
         else
@@ -351,7 +350,6 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
                 runenvs[k] = v[1]
             end
         else
-            table.sort(v)
             runenvs[k] = path.joinenv(v)
         end
     end

--- a/xmake/plugins/project/vstudio/impl/vs201x_solution.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_solution.lua
@@ -37,7 +37,7 @@ function _make_projects(slnfile, vsinfo)
     local targets = {}
     local default_targets = {}
     local vctool = "8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942"
-    for targetname, target in pairs(project.ordertargets()) do
+    for _, target in ipairs(project.ordertargets()) do
         -- we need set startup project for default or binary target
         -- @see https://github.com/xmake-io/xmake/issues/1249
         if target:get("default") == true then
@@ -104,7 +104,7 @@ function _make_global(slnfile, vsinfo)
 
     -- add project configuration platforms
     slnfile:enter("GlobalSection(ProjectConfigurationPlatforms) = postSolution")
-    for targetname, target in pairs(project.ordertargets()) do
+    for _, target in ipairs(project.ordertargets()) do
         for _, mode in ipairs(vsinfo.modes) do
             for _, arch in ipairs(vsinfo.archs) do
                 local vs_arch = vsutils.vsarch(arch)

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -1330,12 +1330,19 @@ function _make_source_files(vcxprojfile, vsinfo, target)
             end
         end
 
-        -- make source files
+        -- order source file infos
+        local ordered_sourceinfos = {}
         for sourcefile, sourceinfo in pairs(sourceinfos) do
-            if #sourceinfo == #target.info then
-                _make_source_file_forall(vcxprojfile, vsinfo, target, sourcefile, sourceinfo)
+            table.insert(ordered_sourceinfos, { file = sourcefile, info = sourceinfo })
+        end
+        table.sort(ordered_sourceinfos, function (a, b) return a.file < b.file end)
+
+        -- make source files
+        for _, source in ipairs(ordered_sourceinfos) do
+            if #source.info == #target.info then
+                _make_source_file_forall(vcxprojfile, vsinfo, target, source.file, source.info)
             else
-                _make_source_file_forspec(vcxprojfile, vsinfo, target, sourcefile, sourceinfo)
+                _make_source_file_forspec(vcxprojfile, vsinfo, target, source.file, source.info)
             end
         end
 

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -172,7 +172,6 @@ function _make_targetinfo(mode, arch, target)
         end
     end
     for k, v in pairs(addrunenvs) do
-        table.sort(v)
         if k:upper() == "PATH" then
             runenvs[k] = _make_dirs(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
         else
@@ -188,7 +187,6 @@ function _make_targetinfo(mode, arch, target)
                 runenvs[k] = v[1]
             end
         else
-            table.sort(v)
             runenvs[k] = path.joinenv(v)
         end
     end


### PR DESCRIPTION
vs and vsxmake file generation isn't stable because of the hashtables used internally by xmake, this can be a problem for people saving those files on git, and also because vsxmake saves files only if changes are made (_writefileifneeded).

Changing a .sln/.vcxproj file triggers visual studio to ask if a reload is needed, stabilizing generation prevents this (at least for vsxmake as vs generator currently always write those files).

I made generation stable by changing the generators but had to change `project.ordertargets()` and `target:orderpkgs()` to make them stable between xmake runs as well.