### PR TITLE
fix the armcclink process bug that command string num may over window…

### DIFF
--- a/xmake/modules/core/tools/armlink.lua
+++ b/xmake/modules/core/tools/armlink.lua
@@ -50,7 +50,15 @@ end
 
 -- make the link arguments list
 function linkargv(self, objectfiles, targetkind, targetfile, flags)
-    return self:program(), table.join("-o", targetfile, objectfiles, flags)
+    local argv = table.join("-o", targetfile, objectfiles, flags)
+    if is_host("windows") then
+        argv = winos.cmdargv(argv, {escape = true})
+        if #argv > 0 and argv[1] and argv[1]:startswith("@") then
+            argv[1] = argv[1]:replace("@", "", {plain = true})
+            table.insert(argv, 1, "--via")
+        end
+    end
+    return self:program(), argv
 end
 
 -- link the target file


### PR DESCRIPTION
关联问题： armcc link过程报runv(xxxx) failed(-1073740949) #2952 
修复armlink.lua 在link过程中可能会由于命令行字符串超过winows限制导致链接失败问题，通过armlink命令转txt文本传入形式实现。