### PR TITLE
Fix issue#2954.

### DIFF
--- a/xmake/rules/c++/modules/modules_support/clang.lua
+++ b/xmake/rules/c++/modules/modules_support/clang.lua
@@ -379,6 +379,7 @@ function build_modules_for_batchjobs(target, batchjobs, objectfiles, modules, op
                         if not os.isdir(objectdir) then
                             os.mkdir(objectdir)
                         end
+                        bmifile = string.gsub(bmifile, ":", "-")
                         local args = { "-c", "-x", "c++-module", "--precompile", provide.sourcefile, "-o", bmifile}
                         os.vrunv(compinst:program(), table.join(compinst:compflags({target = target}), common_args, requiresflags or {}, args))
                         os.vrunv(compinst:program(), table.join(compinst:compflags({target = target}), common_args, requiresflags or {}, {bmifile}, {"-c", "-o", objectfile}))


### PR DESCRIPTION
Character `:` can not exist in path in windows system. So when using clang to build project that contains module partitions, the filename of bmifile it generates should not contains `:`
Change bmifile filename according to [https://clang.llvm.org/docs/StandardCPlusPlusModules.html#global-module-fragment.](https://clang.llvm.org/docs/StandardCPlusPlusModules.html#global-module-fragment.).

> The file name of BMIs should end with .pcm. The file name of the BMI of a primary module interface unit should be module_name.pcm. The file name of BMIs of module partition unit should be module_name-partition_name.pcm.