### PR TITLE
change user_name to $USER

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -230,6 +230,7 @@ write_profile()
 install_profile()
 {
     if [ ! -d ~/.xmake ]; then mkdir ~/.xmake; fi
+    prefix=${prefix//$USER/\$USER}
     echo "export XMAKE_ROOTDIR=\"$prefix/bin\"" > ~/.xmake/profile
     echo 'export PATH="$XMAKE_ROOTDIR:$PATH"' >> ~/.xmake/profile
     if [ -f "$projectdir/scripts/register-completions.sh" ]; then


### PR DESCRIPTION
I often work in different dockers, and these dockers all have different usernames. So I changed the username of the ~/.xmake/profile file to $USER, in this condition, I can copy the xmake files to docker without making any changes：

```
old: export XMAKE_ROOTDIR = "/home/username/.local/bin"
new: export XMAKE_ROOTDIR = "/home/$USER/.local/bin"
```