### PR TITLE
Fix sandbox_lib_detect_find_path._find function.

### DIFF
--- a/xmake/core/sandbox/modules/import/lib/detect/find_path.lua
+++ b/xmake/core/sandbox/modules/import/lib/detect/find_path.lua
@@ -37,7 +37,18 @@ function sandbox_lib_detect_find_path._find(filedir, name)
         local filepath = results[1]
         if filepath then
             -- we need translate name first, https://github.com/xmake-io/xmake-repo/issues/1315
-            local p = filepath:find(path.pattern(path.translate(name)))
+	    local to_search = path.pattern(path.translate(name))
+
+	    -- need to find the last occurrence of substring to_search within filepath
+            local last_index = 0
+	    local idx = 0
+            while true do
+              idx = filepath:find(to_search, idx+1)
+              if idx == nil then break end
+              last_index = idx
+            end
+           
+            local p = filepath:find(to_search, last_index)
             if p then
                 filepath = path.translate(filepath:sub(1, p - 1))
                 if os.isdir(filepath) then

--- a/xmake/core/sandbox/modules/import/lib/detect/find_path.lua
+++ b/xmake/core/sandbox/modules/import/lib/detect/find_path.lua
@@ -37,18 +37,7 @@ function sandbox_lib_detect_find_path._find(filedir, name)
         local filepath = results[1]
         if filepath then
             -- we need translate name first, https://github.com/xmake-io/xmake-repo/issues/1315
-	    local to_search = path.pattern(path.translate(name))
-
-	    -- need to find the last occurrence of substring to_search within filepath
-            local last_index = 0
-	    local idx = 0
-            while true do
-              idx = filepath:find(to_search, idx+1)
-              if idx == nil then break end
-              last_index = idx
-            end
-           
-            local p = filepath:find(to_search, last_index)
+	    local p = filepath:lastof(path.pattern(path.translate(name)))
             if p then
                 filepath = path.translate(filepath:sub(1, p - 1))
                 if os.isdir(filepath) then


### PR DESCRIPTION
Function sandbox_lib_detect_find_path._find currently searches the first occurrence of substring path.pattern(path.translate(name)) within filepath. This behavior breaks in case one wants, e.g., to find packages named libsomething. The correct behavior would be to find the last occurrence of substring path.pattern(path.translate(name)) within filepath. Hence this patch.
