### PR TITLE
Clang-Format plugin

### DIFF
--- a/xmake/plugins/format/main.lua
+++ b/xmake/plugins/format/main.lua
@@ -59,8 +59,8 @@ function main()
     if option.get("create-style") then
         table.insert(argv, "--style=" .. option.get("create-style"))
         table.insert(argv, "--dump-config")
-        local outdata, errdata = os.iorunv(clang_format.program, argv)
-        io.writefile(".clang-format", outdata, {curdir = project.directory()})
+        local projectdir = project.directory()
+        os.execv(clang_format.program, argv, {stdout = path.join(projectdir, ".clang-format"), curdir = projectdir})
         return
     end 
 
@@ -70,7 +70,7 @@ function main()
     end
 
     -- inplace flag
-    table.insert(argv,"-i")
+    table.insert(argv, "-i")
     -- set file to format
     if option.get("file") then
         table.insert(argv, option.get("file"))

--- a/xmake/plugins/format/main.lua
+++ b/xmake/plugins/format/main.lua
@@ -69,5 +69,16 @@ function main()
         table.insert(argv, "--style=" .. option.get("style"))
     end
 
+    -- inplace flag
+    table.insert(argv,"-i")
+    -- set file to format
+    if option.get("file") then
+        table.insert(argv, option.get("file"))
+    end
+
+    -- format files
+    os.vrunv(clang_format.program, argv, {curdir = project.directory()})
+    cprint("${color.success}formatting complete")
+
     os.setenvs(oldenvs)
 end

--- a/xmake/plugins/format/main.lua
+++ b/xmake/plugins/format/main.lua
@@ -53,13 +53,12 @@ function main()
     end
     assert(clang_format, "clang-format not found!")
 
-    local argv = {}
-
     -- create style file
+    local argv = {}
+    local projectdir = project.directory()
     if option.get("create-style") then
         table.insert(argv, "--style=" .. option.get("create-style"))
         table.insert(argv, "--dump-config")
-        local projectdir = project.directory()
         os.execv(clang_format.program, argv, {stdout = path.join(projectdir, ".clang-format"), curdir = projectdir})
         return
     end 
@@ -71,13 +70,14 @@ function main()
 
     -- inplace flag
     table.insert(argv, "-i")
+    
     -- set file to format
     if option.get("file") then
         table.insert(argv, option.get("file"))
     end
 
     -- format files
-    os.vrunv(clang_format.program, argv, {curdir = project.directory()})
+    os.vrunv(clang_format.program, argv, {curdir = projectdir})
     cprint("${color.success}formatting complete")
 
     os.setenvs(oldenvs)

--- a/xmake/plugins/format/main.lua
+++ b/xmake/plugins/format/main.lua
@@ -1,0 +1,73 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      ruki
+-- @file        main.lua
+--
+
+-- imports
+import("core.base.option")
+import("core.project.config")
+import("core.project.project")
+import("lib.detect.find_tool")
+import("private.action.require.impl.packagenv")
+import("private.action.require.impl.install_packages")
+
+-- main
+function main()
+
+    -- load configuration
+    config.load()
+
+    -- enter the environments of doxygen
+    local oldenvs = packagenv.enter("llvm")
+
+    -- find clang-format
+    local packages = {}
+    local clang_format = find_tool("clang-format")
+    if not clang_format then
+        table.join2(packages, install_packages("llvm"))
+    end
+
+    -- enter the environments of installed packages
+    for _, instance in ipairs(packages) do
+        instance:envs_enter()
+    end
+
+    -- we need force to detect and flush detect cache after loading all environments
+    if not clang_format then
+        clang_format = find_tool("clang-format", {force = true})
+    end
+    assert(clang_format, "clang-format not found!")
+
+    local argv = {}
+
+    -- create style file
+    if option.get("create-style") then
+        table.insert(argv, "--style=" .. option.get("create-style"))
+        table.insert(argv, "--dump-config")
+        local outdata, errdata = os.iorunv(clang_format.program, argv)
+        io.writefile(".clang-format", outdata, {curdir = project.directory()})
+        return
+    end 
+
+    -- set style file
+    if option.get("style") then
+        table.insert(argv, "--style=" .. option.get("style"))
+    end
+
+    os.setenvs(oldenvs)
+end

--- a/xmake/plugins/format/main.lua
+++ b/xmake/plugins/format/main.lua
@@ -56,12 +56,12 @@ function main()
     -- create style file
     local argv = {}
     local projectdir = project.directory()
-    if option.get("create-style") then
-        table.insert(argv, "--style=" .. option.get("create-style"))
+    if option.get("create") then
+        table.insert(argv, "--style=" .. (option.get("style") or "Google"))
         table.insert(argv, "--dump-config")
         os.execv(clang_format.program, argv, {stdout = path.join(projectdir, ".clang-format"), curdir = projectdir})
         return
-    end 
+    end
 
     -- set style file
     if option.get("style") then
@@ -70,7 +70,7 @@ function main()
 
     -- inplace flag
     table.insert(argv, "-i")
-    
+
     -- set file to format
     if option.get("file") then
         table.insert(argv, option.get("file"))

--- a/xmake/plugins/format/xmake.lua
+++ b/xmake/plugins/format/xmake.lua
@@ -37,7 +37,7 @@ task("format")
                 options = {
                     {'s', "style",  "kv", nil,      "Set the path of .clang-format file, a coding style"..
                                                     "(LLVM, Google, Chromium, Mozilla, WebKit) or key value string" },
-                   {nil, "create-style", "kv", nil,    "Create a .clang-format file from a coding style" },
+                    {nil, "create-style", "kv", nil,    "Create a .clang-format file from a coding style" },
                     {'f', "file", "v", "*.cpp *.h *.hpp", "Set file path or glob pattern"}
                 }
             }

--- a/xmake/plugins/format/xmake.lua
+++ b/xmake/plugins/format/xmake.lua
@@ -30,17 +30,14 @@ task("format")
     -- set menu
     set_menu {
                 -- usage
-                usage = "xmake format [options] [arguments]"
-
+                usage = "xmake format [options] [arguments]",
                 -- description
-            ,   description = "Format the current project."
-
+                description = "Format the current project.",
                 -- options
-            ,   options =
-                {
-                    {'s', "style",  "kv", nil,      "Set the path of.clang-format file, a coding style"..
-                                                    "(LLVM, Google, Chromium, Mozilla, WebKit) or key value string" }
-                ,   {nil, "create-style", "kv", nil,    "Create a .clang-format file from a coding style" },
+                options = {
+                    {'s', "style",  "kv", nil,      "Set the path of .clang-format file, a coding style"..
+                                                    "(LLVM, Google, Chromium, Mozilla, WebKit) or key value string" },
+                   {nil, "create-style", "kv", nil,    "Create a .clang-format file from a coding style" },
                     {'f', "file", "v", "*.cpp *.h *.hpp", "Set file path or glob pattern"}
                 }
             }

--- a/xmake/plugins/format/xmake.lua
+++ b/xmake/plugins/format/xmake.lua
@@ -1,0 +1,48 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      ruki
+-- @file        format.lua
+--
+
+-- define task
+task("format")
+
+    -- set category
+    set_category("plugin")
+
+    -- on run
+    on_run("main")
+
+    -- set menu
+    set_menu {
+                -- usage
+                usage = "xmake format [options] [arguments]"
+
+                -- description
+            ,   description = "Format the current project."
+
+                -- options
+            ,   options =
+                {
+                    {'s', "style",  "kv", nil,      "Set the path of.clang-format file, a coding style"..
+                                                    "(LLVM, Google, Chromium, Mozilla, WebKit) or key value string" }
+                ,   {nil, "create-style", "kv", nil,    "Create a .clang-format file from a coding style" }
+                }
+            }
+
+
+

--- a/xmake/plugins/format/xmake.lua
+++ b/xmake/plugins/format/xmake.lua
@@ -40,7 +40,8 @@ task("format")
                 {
                     {'s', "style",  "kv", nil,      "Set the path of.clang-format file, a coding style"..
                                                     "(LLVM, Google, Chromium, Mozilla, WebKit) or key value string" }
-                ,   {nil, "create-style", "kv", nil,    "Create a .clang-format file from a coding style" }
+                ,   {nil, "create-style", "kv", nil,    "Create a .clang-format file from a coding style" },
+                    {'f', "file", "v", "*.cpp *.h *.hpp", "Set file path or glob pattern"}
                 }
             }
 

--- a/xmake/plugins/format/xmake.lua
+++ b/xmake/plugins/format/xmake.lua
@@ -18,26 +18,16 @@
 -- @file        format.lua
 --
 
--- define task
 task("format")
-
-    -- set category
     set_category("plugin")
-
-    -- on run
     on_run("main")
-
-    -- set menu
     set_menu {
-                -- usage
                 usage = "xmake format [options] [arguments]",
-                -- description
                 description = "Format the current project.",
-                -- options
                 options = {
                     {'s', "style",  "kv", nil,      "Set the path of .clang-format file, a coding style"..
                                                     "(LLVM, Google, Chromium, Mozilla, WebKit) or key value string" },
-                    {nil, "create-style", "kv", nil,    "Create a .clang-format file from a coding style" },
+                    {nil, "create", "k", nil,       "Create a .clang-format file from a coding style" },
                     {'f', "file", "v", "*.cpp *.h *.hpp", "Set file path or glob pattern"}
                 }
             }


### PR DESCRIPTION
This is a new plugin based on clang-format and llvm package.

It can be used like this:
```
xmake format --create-style=Google   # Create a .clang-format file
xmake format --style=Google # Format with a style (but no clang-format file is created)
xmake format --style="{BasedOnStyle: llvm, IndentWidth: 8}"
xmake format --style=path/to/.clang-format
xmake format
```