### PR TITLE
Allow package on_fetch to return false to disable xmake find

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1430,7 +1430,7 @@ function _instance:_fetch_tool(opt)
         fetchinfo = on_fetch(self, {force = opt.force,
                                     system = opt.system,
                                     require_version = opt.require_version})
-        if opt.require_version and opt.require_version:find(".", 1, true) then
+        if fetchinfo and opt.require_version and opt.require_version:find(".", 1, true) then
             local version = type(fetchinfo) == "table" and fetchinfo.version
             if not (version and (version == opt.require_version or semver.satisfies(version, opt.require_version))) then
                 fetchinfo = nil
@@ -1479,8 +1479,8 @@ function _instance:_fetch_library(opt)
                                     system = opt.system,
                                     external = opt.external,
                                     require_version = opt.require_version})
-        if opt.require_version and opt.require_version:find(".", 1, true) then
-            local version = fetchinfo and fetchinfo.version
+        if fetchinfo and opt.require_version and opt.require_version:find(".", 1, true) then
+            local version = fetchinfo.version
             if not (version and (version == opt.require_version or semver.satisfies(version, opt.require_version))) then
                 fetchinfo = nil
             end


### PR DESCRIPTION
This PR allows package on_fetch to returns false to disable xmake default find behavior, this is required for package such as python which cannot otherwise tell xmake to not try to find it using find_python.

See https://github.com/xmake-io/xmake-repo/pull/1627