### PR TITLE
Fix package:parents_add overwriting if another instance of the package…

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -390,9 +390,14 @@ end
 
 -- add parents
 function _instance:parents_add(...)
+    self._PARENTS = self._PARENTS or {}
     for _, parent in ipairs({...}) do
-        self._PARENTS = self._PARENTS or {}
-        self._PARENTS[parent:name()] = parent
+        local parentpkgs = self._PARENTS[parent:name()]
+        if not parentpkgs then
+            parentpkgs = {}
+            self._PARENTS[parent:name()] = parentpkgs
+        end
+        table.insert(parentpkgs, parent)
     end
 end
 

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -904,8 +904,10 @@ function _get_parents_str(package)
     local parents = package:parents()
     if parents then
         local parentnames = {}
-        for _, parent in pairs(parents) do
-            table.insert(parentnames, parent:displayname())
+        for _, parentpkgs in pairs(parents) do
+            for _, parent in ipairs(parentpkgs) do
+                table.insert(parentnames, parent:displayname())
+            end
         end
         if #parentnames == 0 then
             return
@@ -1062,23 +1064,25 @@ function should_install(package, opt)
     end
     if package:parents() then
         -- if all the packages that depend on it already exist, then there is no need to install it
-        for _, parent in pairs(package:parents()) do
-            if should_install(parent, opt) and not parent:exists() then
-                return true
-            end
-
-            -- if the existing parent package is already using it,
-            -- then even if it is an optional package, you must make sure to install it
-            --
-            -- @see https://github.com/xmake-io/xmake/issues/1460
-            --
-            if parent:exists() and not option.get("force") and _must_depend_on(parent, package) then
-                -- mark this package as non-optional because parent package need it
-                local requireinfo = package:requireinfo()
-                if requireinfo.optional then
-                    requireinfo.optional = nil
+        for _, parentpkgs in pairs(package:parents()) do
+            for _, parent in ipairs(parentpkgs) do
+                if should_install(parent, opt) and not parent:exists() then
+                    return true
                 end
-                return true
+
+                -- if the existing parent package is already using it,
+                -- then even if it is an optional package, you must make sure to install it
+                --
+                -- @see https://github.com/xmake-io/xmake/issues/1460
+                --
+                if parent:exists() and not option.get("force") and _must_depend_on(parent, package) then
+                    -- mark this package as non-optional because parent package need it
+                    local requireinfo = package:requireinfo()
+                    if requireinfo.optional then
+                        requireinfo.optional = nil
+                    end
+                    return true
+                end
             end
         end
     else


### PR DESCRIPTION
This fixes #3065

Without this fix:
```
note: install or modify (m) these packages (pass -y to skip confirm)?
in nazara-engine-repo:
  -> nazarautils 2022.11.15 [from:nzsl]
  -> nzsl 2022.11.05 [shared:y, debug:y, with_symbols:y]
in xmake-repo:
  -> assimp v5.2.3 
  -> 7z 21.02 [from:aqt]
  -> qt5base 5.15.2 [debug:y, from:qt5widgets,qt5core,qt5gui]
  -> qt5core 5.15.2 [debug:y, from:qt5widgets,nodeeditor,qt5gui]
  -> qt5gui 5.15.2 [debug:y, from:qt5widgets,nodeeditor]
  -> qt5widgets 5.15.2 [debug:y, from:nodeeditor]
  -> nodeeditor 2.2.2 [debug:y]
  -> chipmunk2d 7.0.3 
  -> dr_wav 0.12.19 
  -> efsw 1.1.0 [from:nzsl]
  -> entt v3.10.1 
  -> fmt 9.1.0 [from:nzsl]
  -> frozen 1.1.1 [from:nzsl]
  -> kiwisolver 1.4.4 
  -> libsdl 2.24.0 
  -> minimp3 2021.05.29 
  -> ordered_map v1.0.0 [from:nzsl]
  -> stb 2021.09.10 
  -> newtondynamics3 v3.14d 
  -> nlohmann_json v3.11.2 [private, from:nzsl]
in local-repo:
  -> python 3.10.6 [binary, from:ninja,libxcb,meson,aqt]
  -> aqt latest [from:qt5base]
please input: y (y/n/m)
```

With this fix:
```
note: install or modify (m) these packages (pass -y to skip confirm)?
in nazara-engine-repo:
  -> nazarautils 2022.11.15 [from:nzsl]
  -> nzsl 2022.11.05 [debug:y, shared:y, with_symbols:y]
in xmake-repo:
  -> assimp v5.2.3
  -> 7z 21.02 [from:aqt]
  -> openssl 1.1.1-q [from:python,python#1]
  -> ca-certificates 20220604 [from:python,python#1]
  -> qt5base 5.15.2 [debug:y, from:qt5core,qt5gui,qt5widgets]
  -> qt5core 5.15.2 [debug:y, from:qt5widgets,qt5gui,nodeeditor]
  -> qt5gui 5.15.2 [debug:y, from:qt5widgets,nodeeditor]
  -> qt5widgets 5.15.2 [debug:y, from:nodeeditor]
  -> nodeeditor 2.2.2 [debug:y]
  -> chipmunk2d 7.0.3
  -> dr_wav 0.12.19
  -> efsw 1.1.0 [from:nzsl]
  -> entt v3.10.1
  -> fmt 9.1.0 [from:nzsl]
  -> frozen 1.1.1 [from:nzsl]
  -> kiwisolver 1.4.4
  -> libsdl 2.24.0
  -> minimp3 2021.05.29
  -> ordered_map v1.0.0 [from:nzsl]
  -> stb 2021.09.10
  -> newtondynamics3 v3.14d
  -> nlohmann_json v3.11.2 [private, from:nzsl]
in local-repo:
  -> python 3.10.6 [binary, from:meson,libxcb,ninja,aqt]
  -> aqt latest [from:qt5base]
please input: y (y/n/m)
```

```
  -> openssl 1.1.1-q [from:python,python#1]
  -> ca-certificates 20220604 [from:python,python#1]
```

This is because there are two python packages (because of the `kind = "binary"` config), which depends on openssl, but the second one overwrite the first:
```
package(openssl - table: 0x193d7c0):parents_add(python - table: 0x10a41c0)
...
package(openssl - table: 0x193d7c0):parents_add(python - table: 0x1aa6b50)
```

so when openssl checks if it should install, it fails because it think it doesn't need to install because of libxcb which is already installed:
```
_should_install_package(openssl - table: 0x7f8a71661ea0)
should_install(openssl)
should_install(openssl) checking parent python
should_install(python)
should_install(python) checking parent xcb-proto
should_install(xcb-proto)
should_install(xcb-proto) checking parent libxcb
should_install(libxcb)
 _compatible_with_previous_librarydeps(libxcb)
   - yes (no any dependencies)
should_install(libxcb) - no (_compatible_with_previous_librarydeps returned true)
should_install(xcb-proto) parent:exists = true
should_install(xcb-proto) option.get("force") = nil
should_install(xcb-proto) _must_depend_on(libxcb, xcb-proto) = false
should_install(xcb-proto) - nil (end of function)
should_install(python) parent:exists = false
should_install(python) option.get("force") = nil
should_install(python) _must_depend_on(xcb-proto, python) = false
should_install(python) - nil (end of function)
should_install(openssl) parent:exists = false
should_install(openssl) option.get("force") = nil
should_install(openssl) _must_depend_on(python, openssl) = false
should_install(openssl) - nil (end of function)
_should_install_package(openssl - table: 0x7f8a71661ea0) = false
```

Maybe there's a better way to fix this, but this is a way [that works](https://github.com/NazaraEngine/NazaraEngine/actions/runs/3481712422/jobs/5823151464) (engine fails to build - I still have to figure that out - but packages are installed, which failed before).