### PR TITLE
fix: iphoneos repo build not target_minver flag

### DIFF
--- a/xmake/modules/package/tools/xmake.lua
+++ b/xmake/modules/package/tools/xmake.lua
@@ -63,6 +63,10 @@ function _get_configs(package, configs, opt)
         if appledev then
             table.insert(configs, "--appledev=" .. appledev)
         end
+        local target_minver = get_config("target_minver")
+        if target_minver then
+            table.insert(configs, "--target_minver=" .. target_minver)
+        end
     elseif package:is_plat("cross") then
         local cross = _get_config_from_toolchains(package, "cross") or get_config("cross")
         if cross then


### PR DESCRIPTION
```bash
# use --target_minver=12.0
xmake f -p iphoneos --target_minver=12.0 -vD -y -c
# but xmake repo build cmd not has target_minver flag
xmake f --diagnosis --verbose --yes -y -c --plat=iphoneos --arch=arm64 --mode=release --kind=static --cxflags=-fPIC --buildir=build_e7e40564
# use patch
xmake f --diagnosis --verbose --yes -y -c --plat=iphoneos --arch=arm64 --mode=release --kind=static --target_minver=12.0 --cxflags=-fPIC --buildir=build_e7e40564
```



