### PR TITLE
Fix .zip decompression when unzip is not installed

### DIFF
--- a/xmake/modules/utils/archive/extract.lua
+++ b/xmake/modules/utils/archive/extract.lua
@@ -415,7 +415,7 @@ function main(archivefile, outputdir, opt)
         extractors =
         {
             -- tar supports .zip on macOS but does not on Linux
-            [".zip"]        = is_host("macosx") and {_extract_using_unzip, _extract_using_tar, _extract_using_7z} or {_extract_using_unzip, _extract_using_7z},
+            [".zip"]        = is_host("macosx") and {_extract_using_unzip, _extract_using_tar, _extract_using_7z} or {_extract_using_unzip, _extract_using_7z}
         ,   [".7z"]         = {_extract_using_7z}
         ,   [".gz"]         = {_extract_using_gzip, _extract_using_tar, _extract_using_7z}
         ,   [".xz"]         = {_extract_using_xz, _extract_using_tar, _extract_using_7z}

--- a/xmake/modules/utils/archive/extract.lua
+++ b/xmake/modules/utils/archive/extract.lua
@@ -399,7 +399,7 @@ function main(archivefile, outputdir, opt)
         -- tar/windows can not extract .bz2 ...
         extractors =
         {
-            [".zip"]        = {_extract_using_7z, _extract_using_unzip, _extract_using_tar}
+            [".zip"]        = {_extract_using_7z, _extract_using_unzip}
         ,   [".7z"]         = {_extract_using_7z}
         ,   [".gz"]         = {_extract_using_7z, _extract_using_gzip, _extract_using_tar}
         ,   [".xz"]         = {_extract_using_7z, _extract_using_xz, _extract_using_tar}
@@ -414,7 +414,7 @@ function main(archivefile, outputdir, opt)
     else
         extractors =
         {
-            [".zip"]        = {_extract_using_unzip, _extract_using_tar, _extract_using_7z}
+            [".zip"]        = {_extract_using_unzip, _extract_using_7z}
         ,   [".7z"]         = {_extract_using_7z}
         ,   [".gz"]         = {_extract_using_gzip, _extract_using_tar, _extract_using_7z}
         ,   [".xz"]         = {_extract_using_xz, _extract_using_tar, _extract_using_7z}

--- a/xmake/modules/utils/archive/extract.lua
+++ b/xmake/modules/utils/archive/extract.lua
@@ -399,7 +399,7 @@ function main(archivefile, outputdir, opt)
         -- tar/windows can not extract .bz2 ...
         extractors =
         {
-            [".zip"]        = {_extract_using_7z, _extract_using_unzip}
+            [".zip"]        = {_extract_using_7z, _extract_using_unzip, _extract_using_tar}
         ,   [".7z"]         = {_extract_using_7z}
         ,   [".gz"]         = {_extract_using_7z, _extract_using_gzip, _extract_using_tar}
         ,   [".xz"]         = {_extract_using_7z, _extract_using_xz, _extract_using_tar}
@@ -414,7 +414,8 @@ function main(archivefile, outputdir, opt)
     else
         extractors =
         {
-            [".zip"]        = {_extract_using_unzip, _extract_using_7z}
+            -- tar supports .zip on macOS but does not on Linux
+            [".zip"]        = is_host("macosx") and {_extract_using_unzip, _extract_using_tar, _extract_using_7z} or {_extract_using_unzip, _extract_using_7z},
         ,   [".7z"]         = {_extract_using_7z}
         ,   [".gz"]         = {_extract_using_gzip, _extract_using_tar, _extract_using_7z}
         ,   [".xz"]         = {_extract_using_xz, _extract_using_tar, _extract_using_7z}

--- a/xmake/modules/utils/archive/extract.lua
+++ b/xmake/modules/utils/archive/extract.lua
@@ -421,7 +421,7 @@ function main(archivefile, outputdir, opt)
         extractors =
         {
             -- tar supports .zip on macOS but does not on Linux
-            [".zip"]        = is_host("macosx") and {_extract_using_unzip, _extract_using_tar, _extract_using_7z} or {_extract_using_unzip, _extract_using_tar, _extract_using_7z}
+            [".zip"]        = is_host("macosx") and {_extract_using_unzip, _extract_using_tar, _extract_using_7z} or {_extract_using_unzip, _extract_using_7z}
         ,   [".7z"]         = {_extract_using_7z}
         ,   [".gz"]         = {_extract_using_gzip, _extract_using_tar, _extract_using_7z}
         ,   [".xz"]         = {_extract_using_xz, _extract_using_tar, _extract_using_7z}

--- a/xmake/modules/utils/archive/extract.lua
+++ b/xmake/modules/utils/archive/extract.lua
@@ -371,7 +371,13 @@ end
 -- extract archive file using extractors
 function _extract(archivefile, outputdir, extension, extractors, opt)
     for _, extract in ipairs(extractors) do
-        if extract(archivefile, outputdir, extension, opt) then
+        local ok = try
+        {
+            function ()
+                return extract(archivefile, outputdir, extension, opt)
+            end
+        }
+        if ok then
             return true
         end
     end
@@ -415,7 +421,7 @@ function main(archivefile, outputdir, opt)
         extractors =
         {
             -- tar supports .zip on macOS but does not on Linux
-            [".zip"]        = is_host("macosx") and {_extract_using_unzip, _extract_using_tar, _extract_using_7z} or {_extract_using_unzip, _extract_using_7z}
+            [".zip"]        = is_host("macosx") and {_extract_using_unzip, _extract_using_tar, _extract_using_7z} or {_extract_using_unzip, _extract_using_tar, _extract_using_7z}
         ,   [".7z"]         = {_extract_using_7z}
         ,   [".gz"]         = {_extract_using_gzip, _extract_using_tar, _extract_using_7z}
         ,   [".xz"]         = {_extract_using_xz, _extract_using_tar, _extract_using_7z}

--- a/xmake/modules/utils/archive/extract.lua
+++ b/xmake/modules/utils/archive/extract.lua
@@ -371,12 +371,7 @@ end
 -- extract archive file using extractors
 function _extract(archivefile, outputdir, extension, extractors, opt)
     for _, extract in ipairs(extractors) do
-        local ok = try
-        {
-            function ()
-                return extract(archivefile, outputdir, extension, opt)
-            end
-        }
+        local ok = try {function () return extract(archivefile, outputdir, extension, opt) end}
         if ok then
             return true
         end


### PR DESCRIPTION
tar doesn't handle .zip:
```
/usr/bin/tar -xf v5.2.3.zip -C source.tmp
/usr/bin/tar: This does not look like a tar archive
/usr/bin/tar: Skipping to next header
/usr/bin/tar: Exiting with failure status due to previous errors
error: @programdir/core/sandbox/modules/os.lua:372: execv(/usr/bin/tar -xf v5.2.3.zip -C source.tmp) failed(2)
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:897]:
    [@programdir/core/sandbox/modules/os.lua:372]:
    [@programdir/core/sandbox/modules/os.lua:285]: in function 'vrunv'
    [@programdir/modules/utils/archive/extract.lua:90]: in function 'extract'
    [@programdir/modules/utils/archive/extract.lua:374]:
    [...modules/private/action/require/impl/actions/download.lua:177]: in function '_download'
    [...modules/private/action/require/impl/actions/download.lua:289]:

  => download https://github.com/assimp/assimp/archive/v5.2.3.zip .. failed
```