### PR TITLE
Json output in auto complete module

### DIFF
--- a/xmake/modules/private/utils/complete.lua
+++ b/xmake/modules/private/utils/complete.lua
@@ -22,10 +22,12 @@
 import("core.base.option")
 import("core.base.task")
 import("core.base.cli")
+import("core.base.json")
 
 local raw_words = {}
 local raw_config
 local position = 0
+local no_json = false
 local use_spaces = true
 local no_key = false
 local reenter = false
@@ -40,6 +42,16 @@ function _print_candidate(is_complate, ...)
             print("")
         end
     end
+end
+
+function _print_candidates(is_complate, candidates)
+    if to_json then 
+        printf("%s", json.encode(candidates))
+    else
+        for _, v in ipairs(candidates) do
+            _print_candidate(is_complate, "%s", v.value)
+        end
+    end 
 end
 
 function _find_candidates(candidates, find)
@@ -291,6 +303,9 @@ function main(pos, config, ...)
     end
     if raw_config:find("debug", 1, true) then
         debug = true
+    end
+    if raw_config:find("json", 1, true) then
+        to_json = true
     end
 
     local word = table.concat(raw_words, " ") or ""

--- a/xmake/modules/private/utils/complete.lua
+++ b/xmake/modules/private/utils/complete.lua
@@ -32,11 +32,10 @@ local use_spaces = true
 local no_key = false
 local reenter = false
 
-function _print_candidate(is_complate, ...)
-    local candidate = format(...)
-    if candidate and #candidate ~= 0 then
-        printf(candidate)
-        if use_spaces and is_complate then
+function _print_candidate(candidate)
+    if candidate.value and #candidate.value ~= 0 then
+        printf(candidate.value)
+        if use_spaces and candidate.is_complete then
             print(" ")
         else
             print("")
@@ -44,12 +43,12 @@ function _print_candidate(is_complate, ...)
     end
 end
 
-function _print_candidates(is_complate, candidates)
+function _print_candidates(candidates)
     if to_json then 
-        printf("%s", json.encode(candidates))
+        print(json.encode(candidates))
     else
         for _, v in ipairs(candidates) do
-            _print_candidate(is_complate, "%s", v.value)
+            _print_candidate(v)
         end
     end 
 end
@@ -89,9 +88,9 @@ end
 function _complete_task(tasks, name)
     local found_candidates = {}
     for i, v in ipairs(_find_candidates((table.keys(tasks)), name)) do
-        table.insert(found_candidates, { value = v, description = tasks[v].description })
+        table.insert(found_candidates, { value = v, is_complete = true, description = tasks[v].description })
     end
-    _print_candidates(has_candidate, found_candidates)
+    _print_candidates(found_candidates)
     return #found_candidates > 0 
 end
 

--- a/xmake/modules/private/utils/complete.lua
+++ b/xmake/modules/private/utils/complete.lua
@@ -87,12 +87,12 @@ function _find_candidates(candidates, find)
 end
 
 function _complete_task(tasks, name)
-    local has_candidate = false
-    for _, v in ipairs(_find_candidates((table.keys(tasks)), name)) do
-        _print_candidate(true, "%s", v)
-        has_candidate = true
+    local found_candidates = {}
+    for i, v in ipairs(_find_candidates((table.keys(tasks)), name)) do
+        table.insert(found_candidates, { value = v, description = tasks[v].description })
     end
-    return has_candidate
+    _print_candidates(has_candidate, found_candidates)
+    return #found_candidates > 0 
 end
 
 -- complete values of kv


### PR DESCRIPTION
Feature request : #3192 

Output auto complete in JSON for shells that support it.

Here is an example for Nu shell : 
```
# in config.nu

# Xmake completer
let xmake_completer = {|spans| 
  XMAKE_SKIP_HISTORY=1 XMAKE_ROOT=y xmake lua 'private.utils.complete' 0 'nospace,json' $spans | from json | sort-by value
}

let-env config = {
# ...
completions: {
    case_sensitive: false # set to true to enable case-sensitive completions
    quick: true  # set this to false to prevent auto-selecting completions when only one remains
    partial: true  # set this to false to prevent partial filling of the prompt
    algorithm: "prefix"  # prefix or fuzzy
    external: {
      enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up my be very slow
      max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
      completer: $xmake_completer
    }
  }
# ...
}
```
<img width="568" alt="image" src="https://user-images.githubusercontent.com/6421451/209029917-bda4206d-c336-417d-bb08-2be966318884.png">

