### PR TITLE
add intel one api toolkits detection

### DIFF
--- a/xmake/modules/detect/sdks/find_iccenv.lua
+++ b/xmake/modules/detect/sdks/find_iccenv.lua
@@ -102,10 +102,10 @@ function _find_intel_on_windows(opt)
     -- find iclvars_bat.bat
     local paths = {"$(env ICPP_COMPILER20)"}
     local iclvars_bat = find_file("bin/iclvars.bat", paths)
-    -- look for setvars.bat which is new in 2021
     if not iclvars_bat then
-        paths = {"$(env ICPP_COMPILER21)"}
-        iclvars_bat = find_file("../../../setvars.bat", paths)
+        -- find setvars.bat in intel oneapi toolkits rootdir
+        paths = {"$(env ONEAPI_ROOT)"}
+        iclvars_bat = find_file("setvars.bat", paths)
     end
     if iclvars_bat then
 

--- a/xmake/modules/detect/sdks/find_iccenv.lua
+++ b/xmake/modules/detect/sdks/find_iccenv.lua
@@ -102,10 +102,20 @@ function _find_intel_on_windows(opt)
     -- find iclvars_bat.bat
     local paths = {"$(env ICPP_COMPILER20)"}
     local iclvars_bat = find_file("bin/iclvars.bat", paths)
+    -- look for setvars.bat which is new in 2021
     if not iclvars_bat then
         -- find setvars.bat in intel oneapi toolkits rootdir
         paths = {"$(env ONEAPI_ROOT)"}
         iclvars_bat = find_file("setvars.bat", paths)
+    end
+    if not iclvars_bat then
+        -- find setvars.bat using ICPP_COMPILER.*
+        paths = {
+            "$(env ICPP_COMPILER21)",
+            "$(env ICPP_COMPILER22)",
+            "$(env ICPP_COMPILER23)"
+        }
+        iclvars_bat = find_file("../../../setvars.bat", paths)
     end
     if iclvars_bat then
 

--- a/xmake/modules/detect/sdks/find_ifortenv.lua
+++ b/xmake/modules/detect/sdks/find_ifortenv.lua
@@ -102,10 +102,20 @@ function _find_intel_on_windows(opt)
     -- find ifortvars_bat.bat
     local paths = {"$(env IFORT_COMPILER20)"}
     local ifortvars_bat = find_file("bin/ifortvars.bat", paths)
+    -- look for setvars.bat which is new in 2021
     if not ifortvars_bat then
         -- find setvars.bat in intel oneapi toolkits rootdir
         paths = {"$(env ONEAPI_ROOT)"}
         ifortvars_bat = find_file("setvars.bat", paths)
+    end
+    if not ifortvars_bat then
+        -- find setvars.bat use IFORT_COMPILER.*
+        paths = {
+            "$(env IFORT_COMPILER21)",
+            "$(env IFORT_COMPILER22)",
+            "${env IFORT_COMPILER23)"
+        }
+        ifortvars_bat = find_file("../../../setvars.bat", paths)
     end
 
     if ifortvars_bat then

--- a/xmake/modules/detect/sdks/find_ifortenv.lua
+++ b/xmake/modules/detect/sdks/find_ifortenv.lua
@@ -102,10 +102,10 @@ function _find_intel_on_windows(opt)
     -- find ifortvars_bat.bat
     local paths = {"$(env IFORT_COMPILER20)"}
     local ifortvars_bat = find_file("bin/ifortvars.bat", paths)
-    -- look for setvars.bat which is new in 2021
     if not ifortvars_bat then
-        paths = {"$(env IFORT_COMPILER21)"}
-        ifortvars_bat = find_file("../../../setvars.bat", paths)
+        -- find setvars.bat in intel oneapi toolkits rootdir
+        paths = {"$(env ONEAPI_ROOT)"}
+        ifortvars_bat = find_file("setvars.bat", paths)
     end
 
     if ifortvars_bat then


### PR DESCRIPTION
fix #3206

Use ONEAPI_ROOT environment variable for intel ONEAPI toolkits detection. The 2023 version ifort sets IFORT_COMPILER23 environment variable, so I think it's not appropriate to continue using these environment variables.