### PR TITLE
fix typo in find_ifortenv.lua

### DIFF
--- a/xmake/modules/detect/sdks/find_ifortenv.lua
+++ b/xmake/modules/detect/sdks/find_ifortenv.lua
@@ -113,7 +113,7 @@ function _find_intel_on_windows(opt)
         paths = {
             "$(env IFORT_COMPILER21)",
             "$(env IFORT_COMPILER22)",
-            "${env IFORT_COMPILER23)"
+            "$(env IFORT_COMPILER23)"
         }
         ifortvars_bat = find_file("../../../setvars.bat", paths)
     end


### PR DESCRIPTION
之前测试的时候没错，不知道为啥提交的时候打错了一个符号，非常抱歉，
