### PR TITLE
fix target run with single arguments

### DIFF
--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -54,7 +54,8 @@ function _do_run_target(target)
     end
 
     -- get run arguments
-    local args = option.get("arguments") or target:get("runargs")
+    local args = {}
+    table.join2(args, option.get("arguments") or target:get("runargs"))
 
     -- debugging?
     if option.get("debug") then

--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -54,8 +54,7 @@ function _do_run_target(target)
     end
 
     -- get run arguments
-    local args = {}
-    table.join2(args, option.get("arguments") or target:get("runargs"))
+    local args = table.wrap(option.get("arguments") or target:get("runargs"))
 
     -- debugging?
     if option.get("debug") then


### PR DESCRIPTION
When `set_runargs` only set single arguments, args type is string, os.execv only accepts the table type.
```lua
set_runargs("-xxx")
```

```
xmake r
❗ error: ...mdir\core\sandbox\modules\import\core\base\scheduler.lua:56: invalid argv type(string) for process.openv
```