### PR TITLE
Fix detection of target language for qt projects

### DIFF
--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -141,7 +141,8 @@ function main(target, opt)
     local languages = target:get("languages")
     local cxxlang = false
     for _, lang in ipairs(languages) do
-        if lang:startswith("cxx") or lang:startswith("c++") then
+        -- c++* or gnuc++*
+        if lang:find("cxx", 1, true) or lang:find("c++", 1, true) then
             cxxlang = true
             break
         end

--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -141,7 +141,7 @@ function main(target, opt)
     local languages = target:get("languages")
     local cxxlang = false
     for _, lang in ipairs(languages) do
-        if lang:startswith("xx") or lang:startswith("++") then
+        if lang:startswith("cxx") or lang:startswith("c++") then
             cxxlang = true
             break
         end


### PR DESCRIPTION
Stray change in 02fb7ef69e78a5d6a8e0066f8866684533836ac3 broke it such that language set via `set_languages()` wasn't detected and `-std=c++11` was appended after `-std` flag that came from `set_languages()` in `xmake.lua`.

To reproduce:
 1. `xmake create -tqt.quickapp`
 2. `vim xmake.lua` and add `set_languages("c++17")`
 3. `xmake --verbose` and look at `-std=` options