### PR TITLE
Improve package rules loader

### DIFF
--- a/xmake/core/project/package.lua
+++ b/xmake/core/project/package.lua
@@ -249,10 +249,17 @@ function _instance:rules()
         local installdir = self:installdir()
         local rulesdir = path.join(installdir, "rules")
         if os.isdir(rulesdir) then
-            local files = os.match(path.join(rulesdir, "**.lua"))
+            local files = os.filedirs(path.join(rulesdir, "*"))
             if files then
                 for _, filepath in ipairs(files) do
-                    local results, errors = rule._load(filepath)
+                    local results, errors
+                    if filepath:endswith(".lua") then
+                        results, errors = rule._load(filepath)
+                    elseif os.isdir(filepath) and os.isfile(path.join(filepath, "xmake.lua")) then
+                        results, errors = rule._load(path.join(filepath, "xmake.lua"))
+                    else
+                        os.raise("unknown rule %s: %s", os.isdir(filepath) and "directory" or "file", filepath)
+                    end
                     if results then
                         table.join2(ruleinfos, results)
                     else


### PR DESCRIPTION
When xmake loads rules in packages, xmake loads every lua files in all directories present in the folder "rules" of the package, whereas xmakre core rule aren't loaded like that.

I changed the way they are loaded by loading top level lua files and xxx/xmake.lua in the rules folder. In case there is a folder without xmake.lua or a files which is not a lua file, it raises an error : 

```
- my-package
  - rules
    - my-rule
      - utils.lua
      - xmake.lua -- rule loaded
    - my-rule2.lua -- rule loaded
    - not-a-rule -- raise an error
      - test.png
    - not-a-rule.jpg -- raise an error
```