### PR TITLE
Fix dependent packages loading when cross-compiling

### DIFF
--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -883,8 +883,18 @@ function _load_packages(requires, opt)
 
                     -- load dependent packages and do not load system/3rd packages for package/deps()
                     local packagedeps = {}
+
+                    -- make sure dependent packages are loaded with the same plat/arch
+                    local requires_extraconf = package:extraconf("deps") or {}
+                    local requires_extra = {}
+                    for _, depname in pairs(package:get("deps")) do
+                        requires_extra[depname] = requires_extraconf[depname] or {}
+                        requires_extra[depname].plat = requires_extra[depname].plat or package:plat()
+                        requires_extra[depname].arch = requires_extra[depname].arch or package:arch()
+                    end
+
                     local deps, plaindeps = _load_packages(package:get("deps"), {requirepath = requirepath,
-                                                        requires_extra = package:extraconf("deps") or {},
+                                                        requires_extra = requires_extra,
                                                         parentinfo = requireinfo,
                                                         nodeps = opt.nodeps,
                                                         system = false})


### PR DESCRIPTION
When configuring xmake for android from Linux with a binary package (plat=linux), its dependencies will by fetched for android.`

```lua
add_requires("nzsl~host, {binary = true})
add_requires("nzsl")
```
(nzsl depends on nazarautils)

I noticed this because xmake wanted me to reinstall the same binary package over and over again because its dependency hash didn't match.

I added a print here:
```lua
-- load all required packages
function _load_packages(requires, opt)

    -- no requires?
    if not requires or #requires == 0 then
        return {}
    end

    -- load packages
    local packages = {}
    local packages_nodeps = {}
    for _, requireitem in ipairs(load_requires(requires, opt.requires_extra, opt)) do

        -- load package
        local requireinfo = requireitem.info
        local requirepath = opt.requirepath and (opt.requirepath .. "." .. requireitem.name) or requireitem.name
        local package     = _load_package(requireitem.name, requireinfo, table.join(opt, {requirepath = requirepath}))
        print(package:name(), package:plat())
```

prints
```
nzsl linux
nazarautils android

...

nzsl android
nazarautils android
```

this PR fixes the issue by setting the plat/arch values of requires_extra for dependencies, I'm not sure it's the best fix but it works:

```
nzsl linux
nazarautils linux

...

nzsl android
nazarautils android
```
