### PR TITLE
revert cuda devlink

### DIFF
--- a/xmake/rules/cuda/devlink/xmake.lua
+++ b/xmake/rules/cuda/devlink/xmake.lua
@@ -42,9 +42,9 @@ rule("cuda.build.devlink")
             return
         end
 
-        -- only for binary/shared on non-windows platforms
+        -- only for binary/shared by default
         -- https://github.com/xmake-io/xmake/issues/1976
-        if not (devlink == true or target:is_plat("windows") or target:is_binary() or target:is_shared()) then
+        if not (devlink == true or target:is_binary() or target:is_shared()) then
             return
         end
 


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/1976

回退了windows的修改；但关于非cuda binary链接 cuda 静态库的检测不知道在哪里添加