### PR TITLE
improve find cmake package

### DIFF
--- a/xmake/modules/package/manager/cmake/configurations.lua
+++ b/xmake/modules/package/manager/cmake/configurations.lua
@@ -22,10 +22,12 @@
 function main()
     return
     {
-        components = {description = "Set the cmake package components, e.g. {\"regex\", \"system\"}"},
-        moduledirs = {description = "Set the cmake modules directories."},
-        presets    = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
-        envs       = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
+        link_libraries = {description = "Set the cmake package dependencies, e.g. {\"abc::lib1\", \"abc::lib2\"}"},
+        search_mode    = {description = "Set the cmake package search mode, e.g. {\"config\", \"module\"}"},
+        components     = {description = "Set the cmake package components, e.g. {\"regex\", \"system\"}"},
+        moduledirs     = {description = "Set the cmake modules directories."},
+        presets        = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
+        envs           = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
     }
 end
 

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -52,11 +52,12 @@ function _find_package(cmake, name, opt)
         requirestr = requirestr .. " " .. configs.search_mode:upper()
     end
     -- use opt.components is for backward compatibility
+    local componentstr = ""
     local components = configs.components or opt.components
-    if components then
-        requirestr = requirestr .. " COMPONENTS"
+    if components and #components > 0 then
+        componentstr = "COMPONENTS"
         for _, component in ipairs(components) do
-            requirestr = requirestr .. " " .. component
+            componentstr = componentstr .. " " .. component
         end
     end
     local moduledirs = configs.moduledirs or opt.moduledirs
@@ -77,7 +78,7 @@ function _find_package(cmake, name, opt)
         end
     end
     local testname = "test_" .. name
-    cmakefile:print("find_package(%s REQUIRED)", requirestr)
+    cmakefile:print("find_package(%s REQUIRED %s)", requirestr, componentstr)
     cmakefile:print("if(%s_FOUND)", name)
     cmakefile:print("   add_executable(%s test.cpp)", testname)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
@@ -237,6 +238,12 @@ function _find_package(cmake, name, opt)
                             end
                         end
                     end
+                end
+
+                values = line:match("<PreprocessorDefinitions>%%%(PreprocessorDefinitions%);(.+)</PreprocessorDefinitions>")
+                if values then
+                    defines = defines or {}
+                    table.join2(defines, path.splitenv(values))
                 end
             end
         end


### PR DESCRIPTION
- Improve component string order, see https://cmake.org/cmake/help/latest/command/find_package.html#id8
- When I print `opt`, I can't find `link_libraries = "Houdini"` and `search_mode = "config"`. Only `envs` pass into configs.
```lua
add_requires("cmake::Houdini", {alias = "houdini", system = true, configs = {
    search_mode = "config",
    link_libraries = "Houdini",
    envs = {CMAKE_PREFIX_PATH = "C:\\Program Files\\Side Effects Software\\Houdini 19.5.493\\toolkit\\cmake"}
}})
```
How can I fix it?