### PR TITLE
Don't default to "master" when pulling

### DIFF
--- a/xmake/modules/devel/git/pull.lua
+++ b/xmake/modules/devel/git/pull.lua
@@ -59,7 +59,9 @@ function main(opt)
     table.insert(argv, opt.remote or "origin")
 
     -- set branch
-    table.insert(argv, opt.branch or "master")
+    if opt.branch then
+        table.insert(argv, opt.branch)
+    end
 
     -- set tags
     if opt.tags then


### PR DESCRIPTION
git automatically gets the default branch, which may not be master (as we are encouraged to change to "main").