### PR TITLE
Fix ps1 install script

### DIFF
--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -148,7 +148,7 @@ param (
             }
 
             if ($content) {
-                $content = [System.Text.RegularExpressions.Regex]::Replace($content, "\n*(# PowerShell parameter completion shim for xmake)?\s*Register-ArgumentCompleter -Native -CommandName xmake -ScriptBlock\s*{.+?\n}\s*", "`n", [System.Text.RegularExpressions.RegexOptions]::Singleline)
+                $content = $content -replace "`n# >>> xmake >>>`n[\S\s]*?`n# <<< xmake <<<`n", ""
             }
             try {
                 $appendcontent = (Invoke-Webrequest 'https://xmake.io/assets/scripts/pscompletions.text' -UseBasicParsing).Content

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -157,7 +157,7 @@ param (
                     "https://fastly.jsdelivr.net/gh/xmake-io/xmake@$v/scripts/register-completions.ps1"
                 }
                 $appendcontent = (Invoke-Webrequest $url -UseBasicParsing).Content
-                if ($appendcontent -is [bytep[]]) {
+                if ($appendcontent -is [byte[]]) {
                     $appendcontent = [System.Text.Encoding]::UTF8.GetString($appendcontent)
                 }
             } catch {

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -151,7 +151,12 @@ param (
                 $content = $content -replace "`n# >>> xmake >>>`n[\S\s]*?`n# <<< xmake <<<`n", ""
             }
             try {
-                $appendcontent = (Invoke-Webrequest 'https://xmake.io/assets/scripts/pscompletions.text' -UseBasicParsing).Content
+                $url = if ($v -is [version]) {
+                    "https://fastly.jsdelivr.net/gh/xmake-io/xmake@v$v/scripts/register-completions.ps1"
+                } else {
+                    "https://fastly.jsdelivr.net/gh/xmake-io/xmake@$v/scripts/register-completions.ps1"
+                }
+                $appendcontent = (Invoke-Webrequest $url -UseBasicParsing).Content
             } catch {
                 writeErrorTip 'Download failed!'
                 writeErrorTip 'Check your network or... the news of S3 break'

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -157,6 +157,9 @@ param (
                     "https://fastly.jsdelivr.net/gh/xmake-io/xmake@$v/scripts/register-completions.ps1"
                 }
                 $appendcontent = (Invoke-Webrequest $url -UseBasicParsing).Content
+                if ($appendcontent -is [bytep[]]) {
+                    $appendcontent = [System.Text.Encoding]::UTF8.GetString($appendcontent)
+                }
             } catch {
                 writeErrorTip 'Download failed!'
                 writeErrorTip 'Check your network or... the news of S3 break'


### PR DESCRIPTION
- Remove old completion
- Use latest completion from xmake-io/xmake repo (https://github.com/xmake-io/xmake-docs/blob/master/assets/scripts/pscompletions.text is never updated)
