### PR TITLE
match github name mangling

### DIFF
--- a/xmake/modules/private/action/require/impl/actions/download.lua
+++ b/xmake/modules/private/action/require/impl/actions/download.lua
@@ -28,7 +28,7 @@ import("core.package.package", {alias = "core_package"})
 import("lib.detect.find_file")
 import("lib.detect.find_directory")
 import("private.action.require.impl.utils.filter")
-import("private.action.require.impl..utils.url_filename")
+import("private.action.require.impl.utils.url_filename")
 import("net.http")
 import("net.proxy")
 import("devel.git")
@@ -156,6 +156,13 @@ function _download(package, url, sourcedir, opt)
             local localfile
             local searchnames = {package:name() .. "-" .. package:version_str() .. archive.extension(url),
                                  packagefile}
+
+            -- match github name mangling https://github.com/xmake-io/xmake/issues/1343
+            local github_name = url_filename.github_filename(url)
+            if github_name then
+                table.insert(searchnames, github_name)
+            end
+
             for _, searchname in ipairs(searchnames) do
                 localfile = find_file(searchname, core_package.searchdirs())
                 if localfile then

--- a/xmake/modules/private/action/require/impl/utils/url_filename.lua
+++ b/xmake/modules/private/action/require/impl/utils/url_filename.lua
@@ -18,8 +18,27 @@
 -- @file        url_filename.lua
 --
 
--- get filename from url
-function main(url)
+-- get raw filename
+function raw_filename(url)
     local urlpath = url:split('?', {plain = true})[1]
     return path.filename(urlpath)
+end
+
+-- get filename from github name mangling
+function github_filename(url)
+    if url:find("^https://github.com/[^/]-/[^/]-/archive/") then
+        local reponame = url:match("^https://github.com/[^/]-/([^/]-)/archive/")
+        local filename = raw_filename(url)
+        if filename:find("^v%d") then
+            filename = filename:match("^v(.+)")
+        end
+        if reponame and filename then
+            return reponame .. "-" .. filename
+        end
+    end
+end
+
+-- get filename from url
+function main(url)
+    return raw_filename(url)
 end


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/1343

目前xmake-repo大部分package都来自github，而github下载的文件与xmake搜索的文件名不同，这个问题使得pkg_searchdirs使用起来非常麻烦。目前要解决下载的网络问题有三种途径：1. 内置github_mirror.lua（非常不稳定），2. 手动下载/从其他地方（例如助教在课程网站分发等）获取文件包（目前需要设置xmake+点一下下载+手动改名，比较麻烦），3. 挂梯子并设置HTTPS_PROXY环境变量（需要记忆环境变量的设置命令，更加麻烦），没有一个能比较好地解决网络问题。

这个patch提供了github下载的文件名转化规则。应用之后，对目前xmake-repo中的所有包，未来xmake-repo中99.9%以上的包，第二种方法将仅需要设置`xmake g --pkg_searchdir=C:\Users\uname\Downloads`，就可以做到点一下下载就能找到。VSCode内置了Ctrl+点击url自动下载，连打开浏览器都不需要了，更不需要定位+改名等一系列复杂操作（改一个文件简单，改一堆require会把人逼疯的）

关于gitlab等其他仓库的问题：gitlab没有name mangling问题，gitee目前还没有主要host在gitee的常用package。即使以后需要加入gitee，当前的架构也是非常容易实现的，并不会显得杂乱。