### PR TITLE
vstudio project: fix /GR- handling

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -408,7 +408,7 @@ function _make_source_options_cl(vcxprojfile, flags, condition)
     end
 
     -- make ExternalTemplatesDiagnostics
-    if flagstr:find("[%-/]external:templates-") then
+    if flagstr:find("[%-/]external:templates%-") then
         vcxprojfile:print("<ExternalTemplatesDiagnostics%s>true</ExternalTemplatesDiagnostics>", condition)
     else
         vcxprojfile:print("<ExternalTemplatesDiagnostics%s>false</ExternalTemplatesDiagnostics>", condition)
@@ -457,8 +457,15 @@ function _make_source_options_cl(vcxprojfile, flags, condition)
         vcxprojfile:print("<RuntimeLibrary%s>MultiThreaded</RuntimeLibrary>", condition)
     end
 
+    -- make RuntimeTypeInfo
+    if flagstr:find("[%-/]GR%-") then
+        vcxprojfile:print("<RuntimeTypeInfo%s>false</RuntimeTypeInfo>", condition)
+    elseif flagstr:find("[%-/]GR") then
+        vcxprojfile:print("<RuntimeTypeInfo%s>true</RuntimeTypeInfo>", condition)
+    end
+
     -- handle multi processor compilation
-    if flagstr:find("[%-/]Gm-") or not flagstr:find("[%-/]Gm") then
+    if flagstr:find("[%-/]Gm%-") or not flagstr:find("[%-/]Gm") then
         vcxprojfile:print("<MinimalRebuild%s>false</MinimalRebuild>", condition)
         if not flagstr:find("[%-/]MP1") then
             vcxprojfile:print("<MultiProcessorCompilation%s>true</MultiProcessorCompilation>", condition)
@@ -484,7 +491,7 @@ function _make_source_options_cl(vcxprojfile, flags, condition)
     -- make AdditionalOptions
     local excludes = {
         "Od", "Os", "O0", "O1", "O2", "Ot", "Ox", "W0", "W1", "W2", "W3", "W4", "WX", "Wall", "Zi", "ZI", "Z7", "MT", "MTd", "MD", "MDd", "TP",
-        "Fd", "fp", "I", "D", "Gm-", "Gm", "MP", "external:W0", "external:W1", "external:W2", "external:W3", "external:W4", "external:templates-?", "external:I",
+        "Fd", "fp", "I", "D", "Gm%-", "Gm", "GR%-", "GR", "MP", "external:W0", "external:W1", "external:W2", "external:W3", "external:W4", "external:templates%-?", "external:I",
         "std:c11", "std:c17", "std:c%+%+11", "std:c%+%+14", "std:c%+%+17", "std:c%+%+20", "std:c%+%+latest", "nologo", "wd(%d+)"
     }
     local additional_flags = _exclude_flags(flags, excludes)


### PR DESCRIPTION
- Fixes /GR- handling

`/GR-` was matched against `/Gm-` because the `-` was not escaped.