### PR TITLE
[New Feature] Provide auto-completions for Fish Shell (#3419)

### DIFF
--- a/scripts/register-completions.fish
+++ b/scripts/register-completions.fish
@@ -1,47 +1,49 @@
 #!/usr/bin/env fish
-# XMake 的 Fish Shell 自动补全
+# XMake Fish Shell Auto-Completion
+#
+# NOTE: Comments are transalted from Simplified Chinese by ChatGPT
 
-# 补全钩子函数
+# Completion hook function
 function _xmake_fish_complete
-    # 读取当前命令行
+    # Read the current command line
     set -l raw_cmd (commandline)
     set -l words (commandline -o)
-    # 获取当前令牌
+    # Get the current token
     set -l token (commandline -ot)
 
-    # 调用 XMake 内置补全来获得可用结果
+    # Call XMake built-in completion to get available results
     set -l result (MAKE_SKIP_HISTORY=1 XMAKE_ROOT=y xmake lua private.utils.complete 0 nospace "$raw_cmd")
     if test (count $result) -lt 1
-        # 当没有可用的补全项时，直接结束函数
-        # 否则后续 contains 命令会触发错误
+        # When there are no available completions, the function ends immediately
+        # Otherwise, the subsequent `contains` command will trigger an error
         return 1
     end
 
-    # 结果是否有多个可选项？
-    # 当有多个可选项时，用户当前令牌必定不完整
+    # Are there multiple selectable results?
+    # When there are multiple options, the user's current token is definitely incomplete
     test (count $result) -gt 1
     set -l is_multiple_choice $status
-    # 唯一的可选项是否与当前光标下的令牌（可能为空）完全相同？
-    # 相同表示用户已经执行了补全过程
-    # 可选项输出重复，不是当前光标位置的补全
+    # Is the only selectable option identical to the current token under the cursor (which may be empty)?
+    # Identical means the user has already completed the process
+    # Repeated option outputs are not completions at the current cursor position
     contains -- $token $result
     set -l is_token_incomplete $status
-    # 唯一的可选项是不是与命令行的最后一个可见令牌完全相同？
-    # 在每一个令牌位不带前缀触发补全时，当前令牌为空字符串
-    # 命令行令牌化数组的最后一项为光标的上一个令牌
-    # 主要应对空格后无前缀触发补全的场景
+    # Is the only selectable option identical to the last visible token of the command line array?
+    # When completing without a prefix in every token position, the current token is an empty string
+    # The last item of the command line tokenized array is the token before the cursor
+    # This is mainly used to handle completions triggered after a space without a prefix
     contains -- $words[-1] $result
     set -l not_token_completed $status
 
     test \( $is_token_incomplete -eq 1 \) -a \( $not_token_completed -eq 1 \)
     test \( $is_multiple_choice -eq 0 \) -o \( $status -eq 0 \)
     if test $status -eq 0
-        # 当不全列表不只有一项的时候，或者当前令牌与补全列表的唯一令牌不同
-        # 用户必然没有写全令牌，需要为用户提供补全
-        for item in $result 
-            # 每个结果独占一行，对于 "-a" 参数而言需要分别 echo 出去
-            # 尽管结果本身带有换行，但 "-a" 仍会将它视为一个整体，
-            # 不执行分词视为多个参数
+        # When the completion list has more than one item, or the current token is different from the unique token in the completion list
+        # The user must not have completed the token and needs to be provided with completion options
+        for item in $result
+            # Each result takes up a separate line, and for the "-a" parameter, it needs to be echoed separately
+            # Although the result itself has a newline, "-a" still treats it as a whole,
+            # Without tokenizing it as multiple parameters
             if not string match -- '*error*' "$item" > /dev/null
                 echo $item
             end
@@ -49,5 +51,5 @@ function _xmake_fish_complete
     end
 end
 
-# 补全代理
+# Completion proxy
 complete -c xmake -f -a "(_xmake_fish_complete)"

--- a/scripts/register-completions.fish
+++ b/scripts/register-completions.fish
@@ -1,0 +1,53 @@
+#!/usr/bin/env fish
+# XMake 的 Fish Shell 自动补全
+
+# 补全钩子函数
+function _xmake_fish_complete
+    # 读取当前命令行
+    set -l raw_cmd (commandline)
+    set -l words (commandline -o)
+    # 获取当前令牌
+    set -l token (commandline -ot)
+
+    # 调用 XMake 内置补全来获得可用结果
+    set -l result (MAKE_SKIP_HISTORY=1 XMAKE_ROOT=y xmake lua private.utils.complete 0 nospace "$raw_cmd")
+    if test (count $result) -lt 1
+        # 当没有可用的补全项时，直接结束函数
+        # 否则后续 contains 命令会触发错误
+        return 1
+    end
+
+    # 结果是否有多个可选项？
+    # 当有多个可选项时，用户当前令牌必定不完整
+    test (count $result) -gt 1
+    set -l is_multiple_choice $status
+    # 唯一的可选项是否与当前光标下的令牌（可能为空）完全相同？
+    # 相同表示用户已经执行了补全过程
+    # 可选项输出重复，不是当前光标位置的补全
+    contains -- $token $result
+    set -l is_token_incomplete $status
+    # 唯一的可选项是不是与命令行的最后一个可见令牌完全相同？
+    # 在每一个令牌位不带前缀触发补全时，当前令牌为空字符串
+    # 命令行令牌化数组的最后一项为光标的上一个令牌
+    # 主要应对空格后无前缀触发补全的场景
+    contains -- $words[-1] $result
+    set -l not_token_completed $status
+
+    test \( $is_token_incomplete -eq 1 \) -a \( $not_token_completed -eq 1 \)
+    test \( $is_multiple_choice -eq 0 \) -o \( $status -eq 0 \)
+    if test $status -eq 0
+        # 当不全列表不只有一项的时候，或者当前令牌与补全列表的唯一令牌不同
+        # 用户必然没有写全令牌，需要为用户提供补全
+        for item in $result 
+            # 每个结果独占一行，对于 "-a" 参数而言需要分别 echo 出去
+            # 尽管结果本身带有换行，但 "-a" 仍会将它视为一个整体，
+            # 不执行分词视为多个参数
+            if not string match -- '*error*' "$item" > /dev/null
+                echo $item
+            end
+        end
+    end
+end
+
+# 补全代理
+complete -c xmake -f -a "(_xmake_fish_complete)"


### PR DESCRIPTION
Related issue #3419 .

## What's new?

- Provide `scripts/register-completions.fish`, which can enable auto-completions for Fish users.

## Usage

1. Download `scripts/register-completions.fish` to your local device.
2. Place it under `$XDG_CONFIG_HOME/fish/completions/` directory and rename it to `xmake.fish`
   > Which `$XDG_CONFIG_HOME` usually refers to `$HOME/.config`
3. Restart your shell (maybe `source` is acceptable for current shell session?), this auto-completion configuration will loaded by Fish on startup.
4. Try any commands related to `xmake`! You'll be satisfied!

## Screenshots

![Xmake_in_Fish](https://user-images.githubusercontent.com/49941141/222337257-121ba45f-2e48-4316-90c0-2ef8f77dfa7e.gif)

## Shame

1. XMake supports both "long format" (e.g. `build`, `package`, `global`) and "short format" (e.g. `b`, `p`, `g`) subcommands, but currently we only auto-complete "long format" for you.
2. XMake supports both "long style" (e.g. `--quiet`, `--yes`, `--verbose`) and "GNU style" (e.g. `-q`, `-y`, `-v`) options, but currently we only auto-complete "long style" for you.
3. There are "common options" for XMake, which can be used without any subcommands. But currently the script (and maybe XMake "auto-complete" Lua script core itself?) can't auto-complete them for you. You have to specify one subcommand before adding `--` prefix to see auto-complete for these options.
4. Some options of XMake require arguments, but currently we can't auto-complete these arguments for you, such as those available for `xmake config -p`.
5. Fish Shell support adding descriptions for auto-complete choices, but currently we can't provide them. Please refer to XMake Documentations for subcommands/options descriptions.