### PR TITLE
Set ANDROID_PLATFORM with CMake

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -378,6 +378,7 @@ function _get_configs_for_android(package, configs, opt)
         table.insert(configs, "-DCMAKE_TOOLCHAIN_FILE=" .. path.join(ndk, "build/cmake/android.toolchain.cmake"))
         table.insert(configs, "-DANDROID_ABI=" .. package:arch())
         if ndk_sdkver then
+            table.insert(configs, "-DANDROID_PLATFORM=android-" .. ndk_sdkver)
             table.insert(configs, "-DANDROID_NATIVE_API_LEVEL=" .. ndk_sdkver)
         end
         if ndk_cxxstl then


### PR DESCRIPTION
It looks like some NDK/cmake combo ignore ANDROID_NATIVE_API_LEVEL, example:
```
C:\Program Files\xmake\winenv\bin\7z x -y 1.3.3.tar.gz -oC:\Users\lynix\AppData\Local\Temp\.xmake\230305\_99D323FC626E42008098079D3734FC00.tar

7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21

Scanning the drive for archives:
1 file, 857103 bytes (838 KiB)

Extracting archive: 1.3.3.tar.gz
--
Path = 1.3.3.tar.gz
Type = gzip
Headers Size = 10

Everything is Ok

Size:       5550080
Compressed: 857103
C:\Program Files\xmake\winenv\bin\7z x -y C:\Users\lynix\AppData\Local\Temp\.xmake\230305\_99D323FC626E42008098079D3734FC00.tar\1.3.3.tar -osource.tmp

7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21

Scanning the drive for archives:
1 file, 5550080 bytes (5420 KiB)

Extracting archive: C:\Users\lynix\AppData\Local\Temp\.xmake\230305\_99D323FC626E42008098079D3734FC00.tar\1.3.3.tar
--
Path = C:\Users\lynix\AppData\Local\Temp\.xmake\230305\_99D323FC626E42008098079D3734FC00.tar\1.3.3.tar
Type = tar
Physical Size = 5550080
Headers Size = 389632
Code Page = UTF-8

Everything is Ok

Folders: 70
Files: 674
Size:       4985908
Compressed: 5550080
patching C:\Users\lynix\AppData\Local\.xmake\repositories\xmake-repo\packages\l\libflac\patches\1.3.3\cmake.patch to libflac-1.3.3 ..
git apply --reject --ignore-whitespace C:\Users\lynix\AppData\Local\Temp\.xmake\230305\patches\libflac\1.3.3\cmake.patch
checking for xmake::libogg ... libogg v1.3.4
C:\Program Files\CMake\bin\cmake -DBUILD_CXXLIBS=OFF -DBUILD_DOCS=OFF -DBUILD_PROGRAMS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DBUILD_UTILS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=C:\Users\lynix\AppData\Local\.xmake\packages\l\libflac\1.3.3\7b816afb236f40cdb6e68a23e0c14e0b -DCMAKE_INSTALL_LIBDIR:PATH=lib -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE=E:\Android\Sdk\ndk\23.1.7779620\build\cmake\android.toolchain.cmake -DANDROID_ABI=armeabi-v7a -DANDROID_NATIVE_API_LEVEL=28 -DCMAKE_MAKE_PROGRAM=E:\Android\Sdk\ndk\23.1.7779620\prebuilt\windows-x86_64\bin\make.exe -DCMAKE_C_FLAGS=-IC:/Users/lynix/AppData/Local/.xmake/packages/l/libogg/v1.3.4/fbe972447d4144a789855d5a7b3a1f53/include -DCMAKE_CXX_FLAGS=-IC:/Users/lynix/AppData/Local/.xmake/packages/l/libogg/v1.3.4/fbe972447d4144a789855d5a7b3a1f53/include "-DCMAKE_EXE_LINKER_FLAGS=-LC:/Users/lynix/AppData/Local/.xmake/packages/l/libogg/v1.3.4/fbe972447d4144a789855d5a7b3a1f53/lib -logg" "-DCMAKE_SHARED_LINKER_FLAGS=-LC:/Users/lynix/AppData/Local/.xmake/packages/l/libogg/v1.3.4/fbe972447d4144a789855d5a7b3a1f53/lib -logg" -DCMAKE_POSITION_INDEPENDENT_CODE=ON C:\Users\lynix\AppData\Local\.xmake\cache\packages\2303\l\libflac\1.3.3\source
-- ANDROID_PLATFORM not set. Defaulting to minimum supported version 16.
-- Android: Targeting API '16' with architecture 'arm', ABI 'armeabi-v7a', and processor 'armv7-a'
```

so we can set ANDROID_PLATFORM instead, I kept ANDROID_NATIVE_API_LEVEL to be safe.

I set the "android-28" format as this is what seems to be expected: <https://android.googlesource.com/platform/ndk/+/master/build/cmake/android.toolchain.cmake#169>