### PR TITLE
update find_vulkansdk.lua

### DIFF
--- a/xmake/modules/detect/sdks/find_vulkansdk.lua
+++ b/xmake/modules/detect/sdks/find_vulkansdk.lua
@@ -47,7 +47,7 @@ function main(opt)
     local libname = (is_host("windows") and "vulkan-1" or "vulkan")
     local libsuffix = ((is_host("windows") and arch == "x86") and "lib32" or "lib")
 
-    if not is_host("windows") then
+    if is_host("linux") then
         -- we attempt to find vulkan from /usr, e.g. /usr/include/vulkan/vulkan.h
         table.insert(paths, "/usr");
         table.insert(paths, "/usr/local")

--- a/xmake/modules/detect/sdks/find_vulkansdk.lua
+++ b/xmake/modules/detect/sdks/find_vulkansdk.lua
@@ -41,17 +41,16 @@ function main(opt)
     {
         "$(env VK_SDK_PATH)",
         "$(env VULKAN_SDK)"
-    }
-    local arch = opt.arch or config.arch() or os.arch()
-    local binsuffix = ((is_host("windows") and arch == "x86") and "bin32" or "bin")
-    local libname = (is_host("windows") and "vulkan-1" or "vulkan")
-    local libsuffix = ((is_host("windows") and arch == "x86") and "lib32" or "lib")
-
+    }    
     if is_host("linux") then
         -- we attempt to find vulkan from /usr, e.g. /usr/include/vulkan/vulkan.h
         table.insert(paths, "/usr");
         table.insert(paths, "/usr/local")
     end
+    local arch = opt.arch or config.arch() or os.arch()
+    local binsuffix = ((is_host("windows") and arch == "x86") and "bin32" or "bin")
+    local libname = (is_host("windows") and "vulkan-1" or "vulkan")
+    local libsuffix = ((is_host("windows") and arch == "x86") and "lib32" or "lib")
 
     -- find library
     local result = {links = {}, linkdirs = {}, includedirs = {}}

--- a/xmake/modules/detect/sdks/find_vulkansdk.lua
+++ b/xmake/modules/detect/sdks/find_vulkansdk.lua
@@ -47,6 +47,12 @@ function main(opt)
     local libname = (is_host("windows") and "vulkan-1" or "vulkan")
     local libsuffix = ((is_host("windows") and arch == "x86") and "lib32" or "lib")
 
+    if not is_host("windows") then
+        -- we attempt to find vulkan from /usr, e.g. /usr/include/vulkan/vulkan.h
+        table.insert(paths, "/usr");
+        table.insert(paths, "/usr/local")
+    end
+
     -- find library
     local result = {links = {}, linkdirs = {}, includedirs = {}}
     local linkinfo = find_library(libname, paths, {suffixes = {libsuffix}})


### PR DESCRIPTION
linux will not generate the two environment variables($VK_SDK_PATH, $VULKAN_SDK) when you install Vulkan from the system package manager(e.g. archlinux), so you should find the Vulkan path from /usr and /usr/local

