### PR TITLE
fix xmake doxygen bug，add doxygen to function _generate_doxyfile()

### DIFF
--- a/xmake/plugins/doxygen/main.lua
+++ b/xmake/plugins/doxygen/main.lua
@@ -27,7 +27,7 @@ import("private.action.require.impl.packagenv")
 import("private.action.require.impl.install_packages")
 
 -- generate doxyfile
-function _generate_doxyfile()
+function _generate_doxyfile(doxygen)
 
     -- generate the default doxyfile
     local doxyfile = path.join(project.directory(), "doxyfile")
@@ -98,7 +98,7 @@ function main()
     -- get doxyfile first
     local doxyfile = "doxyfile"
     if not os.isfile(doxyfile) then
-        doxyfile = _generate_doxyfile()
+        doxyfile = _generate_doxyfile(doxygen)
     end
     assert(os.isfile(doxyfile), "%s not found!", doxyfile)
 


### PR DESCRIPTION
xmake doxygen can't exexcute properly
with output below:
```
xmake doxygen -vD
error: @programdir\core\main.lua:302: @programdir\plugins\doxygen\main.lua:34: attempt to index a nil value (global 'doxygen')
```
_generate_doxyfile function block use doxygen parameter which need to be passed outside

