### PR TITLE
extra include_directories and debug flags for cmake::find_package

### DIFF
--- a/xmake/modules/package/manager/cmake/configurations.lua
+++ b/xmake/modules/package/manager/cmake/configurations.lua
@@ -23,12 +23,12 @@ function main()
     return
     {
         link_libraries = {description = "Set the cmake package dependencies, e.g. {\"abc::lib1\", \"abc::lib2\"}"},
+        include_dirs   = {description = "Set the cmake package include directories, e.g. {\"${ZLIB_INCLUDE_DIRS}\"}"},
         search_mode    = {description = "Set the cmake package search mode, e.g. {\"config\", \"module\"}"},
         components     = {description = "Set the cmake package components, e.g. {\"regex\", \"system\"}"},
         moduledirs     = {description = "Set the cmake modules directories."},
         presets        = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
         envs           = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
-        find_name      = {description = "Set the name used for ${find_name}_LIBS/_INCLUDE_DIRS in cmake"},
         debug          = {description = "Set the CMAKE_BUILD_TYPE to Debug if set to true"},
     }
 end

--- a/xmake/modules/package/manager/cmake/configurations.lua
+++ b/xmake/modules/package/manager/cmake/configurations.lua
@@ -29,7 +29,6 @@ function main()
         moduledirs          = {description = "Set the cmake modules directories."},
         presets             = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
         envs                = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
-        debug               = {description = "Set the CMAKE_BUILD_TYPE=Debug if set to ture."}
     }
 end
 

--- a/xmake/modules/package/manager/cmake/configurations.lua
+++ b/xmake/modules/package/manager/cmake/configurations.lua
@@ -29,7 +29,6 @@ function main()
         moduledirs     = {description = "Set the cmake modules directories."},
         presets        = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
         envs           = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
-        debug          = {description = "Set the CMAKE_BUILD_TYPE to Debug if set to true"},
     }
 end
 

--- a/xmake/modules/package/manager/cmake/configurations.lua
+++ b/xmake/modules/package/manager/cmake/configurations.lua
@@ -29,6 +29,7 @@ function main()
         presets        = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
         envs           = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
         find_name      = {description = "Set the name used for ${find_name}_LIBS/_INCLUDE_DIRS in cmake"},
+        debug          = {description = "Set the CMAKE_BUILD_TYPE to Debug if set to true"},
     }
 end
 

--- a/xmake/modules/package/manager/cmake/configurations.lua
+++ b/xmake/modules/package/manager/cmake/configurations.lua
@@ -28,6 +28,7 @@ function main()
         moduledirs     = {description = "Set the cmake modules directories."},
         presets        = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
         envs           = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
+        find_name      = {description = "Set the name used for ${find_name}_LIBS/_INCLUDE_DIRS in cmake"},
     }
 end
 

--- a/xmake/modules/package/manager/cmake/configurations.lua
+++ b/xmake/modules/package/manager/cmake/configurations.lua
@@ -29,6 +29,7 @@ function main()
         moduledirs          = {description = "Set the cmake modules directories."},
         presets             = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
         envs                = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
+        debug               = {description = "Set the CMAKE_BUILD_TYPE=Debug if set to ture."}
     }
 end
 

--- a/xmake/modules/package/manager/cmake/configurations.lua
+++ b/xmake/modules/package/manager/cmake/configurations.lua
@@ -22,13 +22,13 @@
 function main()
     return
     {
-        link_libraries = {description = "Set the cmake package dependencies, e.g. {\"abc::lib1\", \"abc::lib2\"}"},
-        include_dirs   = {description = "Set the cmake package include directories, e.g. {\"${ZLIB_INCLUDE_DIRS}\"}"},
-        search_mode    = {description = "Set the cmake package search mode, e.g. {\"config\", \"module\"}"},
-        components     = {description = "Set the cmake package components, e.g. {\"regex\", \"system\"}"},
-        moduledirs     = {description = "Set the cmake modules directories."},
-        presets        = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
-        envs           = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
+        link_libraries      = {description = "Set the cmake package dependencies, e.g. {\"abc::lib1\", \"abc::lib2\"}"},
+        include_directories = {description = "Set the cmake package include directories, e.g. {\"${ZLIB_INCLUDE_DIRS}\"}"},
+        search_mode         = {description = "Set the cmake package search mode, e.g. {\"config\", \"module\"}"},
+        components          = {description = "Set the cmake package components, e.g. {\"regex\", \"system\"}"},
+        moduledirs          = {description = "Set the cmake modules directories."},
+        presets             = {description = "Set the preset values, e.g. {Boost_USE_STATIC_LIB = true}"},
+        envs                = {description = "Set the run environments of cmake, e.g. {CMAKE_PREFIX_PATH = \"xxx\"}"},
     }
 end
 

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -107,12 +107,9 @@ function _find_package(cmake, name, opt)
 
     -- run cmake
     local envs = configs.envs or opt.envs
-    if (configs.debug) then
-        if (not envs) then
-            envs = {CMAKE_BUILD_TYPE = "Debug"}
-        elseif (not envs.CMAKE_BUILD_TYPE) then
-            envs.CMAKE_BUILD_TYPE = "Debug"
-        end
+    if opt.mode == "debug" then
+        envs = envs or {}
+        envs.CMAKE_BUILD_TYPE = envs.CMAKE_BUILD_TYPE or "Debug"
     end
     try {function() return os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs}) end}
 

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -78,19 +78,20 @@ function _find_package(cmake, name, opt)
         end
     end
     local testname = "test_" .. name
+    local findname = configs.find_name or name
     cmakefile:print("find_package(%s REQUIRED %s)", requirestr, componentstr)
     cmakefile:print("if(%s_FOUND)", name)
     cmakefile:print("   add_executable(%s test.cpp)", testname)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        testname, name, name)
+        testname, findname, findname)
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        testname, name:upper(), name:upper())
+        testname, findname:upper(), findname:upper())
     cmakefile:print("   target_include_directories(%s PRIVATE ${%s_CXX_INCLUDE_DIRS})",
-        testname, name)
+        testname, findname)
     cmakefile:print("   target_link_libraries(%s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        testname, name, name, name)
+        testname, findname, findname, findname)
     cmakefile:print("   target_link_libraries(%s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        testname, name:upper(), name:upper(), name:upper())
+        testname, findname:upper(), findname:upper(), findname:upper())
     if configs.link_libraries then
         cmakefile:print("   target_link_libraries(%s %s)",
             testname, table.concat(table.wrap(configs.link_libraries), " "))

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -106,12 +106,12 @@ function _find_package(cmake, name, opt)
     cmakefile:close()
 
     -- run cmake
-    local envs = configs.envs or opt.envs or {}
+    local envs = configs.envs or opt.envs
     -- decide whether to enable debug build type
     if (not envs.CMAKE_BUILD_TYPE and opt.mode == "debug") then
         envs.CMAKE_BUILD_TYPE = "Debug"
     end
-    os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs})
+    try {function() return os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs}) end}
 
     -- pares defines and includedirs for macosx/linux
     local links

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -86,8 +86,8 @@ function _find_package(cmake, name, opt)
     if configs.include_dirs then
         includedirs = table.concat(table.wrap(configs.include_dirs), " ")
     else
-        includedirs = string.gsub("${X_INCLUDE_DIR} ${X_INCLUDE_DIRS}", "X", name)
-        includedirs = includedirs .. string.gsub(" ${X_INCLUDE_DIR} ${X_INCLUDE_DIRS}", "X", name:upper())
+        includedirs = ("${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS}"):format(name, name)
+        includedirs = includedirs .. (" ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS}"):format(name:upper(), name:upper())
     end
     cmakefile:print("   target_include_directories(%s PRIVATE %s)", testname, includedirs)
     -- reserved for backword compatibility
@@ -98,8 +98,8 @@ function _find_package(cmake, name, opt)
     if configs.link_libraries then
         linklibs = table.concat(table.wrap(configs.link_libraries), " ")
     else
-        linklibs = string.gsub("${X_LIBRARY} ${X_LIBRARIES} ${X_LIBS}", "X", name)
-        linklibs = linklibs .. string.gsub(" ${X_LIBRARY} ${X_LIBRARIES} ${X_LIBS}", "X", name:upper())
+        linklibs = ("${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS}"):format(name, name, name)
+        linklibs = linklibs .. (" ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS}"):format(name:upper(), name:upper(), name:upper())
     end
     cmakefile:print("   target_link_libraries(%s PRIVATE %s)", testname, linklibs)
     cmakefile:print("endif(%s_FOUND)", name)

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -107,10 +107,6 @@ function _find_package(cmake, name, opt)
 
     -- run cmake
     local envs = configs.envs or opt.envs
-    -- decide whether to enable debug build type
-    if (not envs.CMAKE_BUILD_TYPE and opt.mode == "debug") then
-        envs.CMAKE_BUILD_TYPE = "Debug"
-    end
     try {function() return os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs}) end}
 
     -- pares defines and includedirs for macosx/linux

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -78,24 +78,30 @@ function _find_package(cmake, name, opt)
         end
     end
     local testname = "test_" .. name
-    local findname = configs.find_name or name
     cmakefile:print("find_package(%s REQUIRED %s)", requirestr, componentstr)
     cmakefile:print("if(%s_FOUND)", name)
     cmakefile:print("   add_executable(%s test.cpp)", testname)
-    cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        testname, findname, findname)
-    cmakefile:print("   target_include_directories(%s PRIVATE ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS})",
-        testname, findname:upper(), findname:upper())
-    cmakefile:print("   target_include_directories(%s PRIVATE ${%s_CXX_INCLUDE_DIRS})",
-        testname, findname)
-    cmakefile:print("   target_link_libraries(%s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        testname, findname, findname, findname)
-    cmakefile:print("   target_link_libraries(%s ${%s_LIBRARY} ${%s_LIBRARIES} ${%s_LIBS})",
-        testname, findname:upper(), findname:upper(), findname:upper())
-    if configs.link_libraries then
-        cmakefile:print("   target_link_libraries(%s %s)",
-            testname, table.concat(table.wrap(configs.link_libraries), " "))
+    -- setup include directories
+    local includedirs = ""
+    if configs.include_dirs then
+        includedirs = table.concat(table.wrap(configs.include_dirs), " ")
+    else
+        includedirs = string.gsub("${X_INCLUDE_DIR} ${X_INCLUDE_DIRS}", "X", name)
+        includedirs = includedirs .. string.gsub(" ${X_INCLUDE_DIR} ${X_INCLUDE_DIRS}", "X", name:upper())
     end
+    cmakefile:print("   target_include_directories(%s PRIVATE %s)", testname, includedirs)
+    -- reserved for backword compatibility
+    cmakefile:print("   target_include_directories(%s PRIVATE ${%s_CXX_INCLUDE_DIRS})",
+        testname, name)
+    -- setup link library/target
+    local linklibs = ""
+    if configs.link_libraries then
+        linklibs = table.concat(table.wrap(configs.link_libraries), " ")
+    else
+        linklibs = string.gsub("${X_LIBRARY} ${X_LIBRARIES} ${X_LIBS}", "X", name)
+        linklibs = linklibs .. string.gsub(" ${X_LIBRARY} ${X_LIBRARIES} ${X_LIBS}", "X", name:upper())
+    end
+    cmakefile:print("   target_link_libraries(%s PRIVATE %s)", testname, linklibs)
     cmakefile:print("endif(%s_FOUND)", name)
     cmakefile:close()
 

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -108,7 +108,7 @@ function _find_package(cmake, name, opt)
     -- run cmake
     local envs = configs.envs or opt.envs or {}
     -- decide whether to enable debug build type
-    if (not envs.CMAKE_BUILD_TYPE and configs.debug) then
+    if (not envs.CMAKE_BUILD_TYPE and opt.mode == "debug") then
         envs.CMAKE_BUILD_TYPE = "Debug"
     end
     os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs})

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -101,6 +101,10 @@ function _find_package(cmake, name, opt)
 
     -- run cmake
     local envs = configs.envs or opt.envs
+    -- decide whether to enable debug build type
+    if (not envs.CMAKE_BUILD_TYPE and configs.debug) then
+        envs.CMAKE_BUILD_TYPE = "Debug"
+    end
     try {function() return os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs}) end}
 
     -- pares defines and includedirs for macosx/linux

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -83,8 +83,8 @@ function _find_package(cmake, name, opt)
     cmakefile:print("   add_executable(%s test.cpp)", testname)
     -- setup include directories
     local includedirs = ""
-    if configs.include_dirs then
-        includedirs = table.concat(table.wrap(configs.include_dirs), " ")
+    if configs.include_directories then
+        includedirs = table.concat(table.wrap(configs.include_directories), " ")
     else
         includedirs = ("${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS}"):format(name, name)
         includedirs = includedirs .. (" ${%s_INCLUDE_DIR} ${%s_INCLUDE_DIRS}"):format(name:upper(), name:upper())

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -106,12 +106,12 @@ function _find_package(cmake, name, opt)
     cmakefile:close()
 
     -- run cmake
-    local envs = configs.envs or opt.envs
+    local envs = configs.envs or opt.envs or {}
     -- decide whether to enable debug build type
     if (not envs.CMAKE_BUILD_TYPE and configs.debug) then
         envs.CMAKE_BUILD_TYPE = "Debug"
     end
-    try {function() return os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs}) end}
+    os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs})
 
     -- pares defines and includedirs for macosx/linux
     local links

--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -107,6 +107,13 @@ function _find_package(cmake, name, opt)
 
     -- run cmake
     local envs = configs.envs or opt.envs
+    if (configs.debug) then
+        if (not envs) then
+            envs = {CMAKE_BUILD_TYPE = "Debug"}
+        elseif (not envs.CMAKE_BUILD_TYPE) then
+            envs.CMAKE_BUILD_TYPE = "Debug"
+        end
+    end
     try {function() return os.vrunv(cmake.program, {workdir}, {curdir = workdir, envs = envs}) end}
 
     -- pares defines and includedirs for macosx/linux


### PR DESCRIPTION
Once merge, this PR should close #3492. 

# About `include_directories`
Since cmake has no convention on variables that saves the include directories and link libraries, some libraries have different variables rather than `XXX_INCLUDE_DIRS` or `XXX_LIBRARIES` defined within `XXXConfig.cmake`. To apply to this situation, use:

```lua
-- search for library deal.II defined with DEAL_II_INCLUDE_DIRS / DEAL_II_LIBRARIES
add_requires("cmake::deal.II", {system = true,
    configs = {include_directories = "${DEAL_II_INCLUDE_DIRS}",
               link_libraries = "${DEAL_II_LIBRARIES}"}})

-- targets are also supported
add_requires("cmake::deal.II", {system = true,
    configs = {include_directories = "${DEAL_II_INCLUDE_DIRS}",
               link_libraries = "deal_II"}})
```

About `debug`
Set to true if want to find package under `CMAKE_BUILD_TYPE=Debug`. Could use to spread the debug config automatically according to xmake mode, use like:

```lua
add_requires("cmake::ZLIB", {debug = is_mode("debug")})

-- add it into configs is also ok
add_requires("cmake::ZLIB", {configs = {debug = is_mode("debug")}})
```