### PR TITLE
add swig java support

### DIFF
--- a/xmake/rules/swig/xmake.lua
+++ b/xmake/rules/swig/xmake.lua
@@ -46,7 +46,7 @@ rule("swig.base")
                     target:set("extension", ".pyd")
                 end
             end
-        elseif moduletype == "lua" then
+        elseif moduletype == "lua" or moduletype == "java" then
             target:set("prefixname", "")
             if not target:is_plat("windows") then
                 target:set("extension", ".so")
@@ -68,6 +68,8 @@ rule("swig.base")
                         scriptfile = scriptfile .. ".py"
                     elseif moduletype == "lua" then
                         scriptfile = scriptfile .. ".lua"
+                    elseif moduletype == "java" then
+                        scriptfile = scriptfile .. ".java"
                     end
                     table.insert(scriptfiles, scriptfile)
                     if scriptdir then


### PR DESCRIPTION
为swig添加java支持；

用法示例：

```lua
    add_rules("swig.cpp", {moduletype="java"})
    add_files("example.i", {swigflags={
        '-package',
        'com.compilelife.example',
        '-outdir',
        'android-project/src/main/java/com/compilelife/example/'
        }
    })
```

缺点：
1. 在scriptfiles中增加了不存在的scriptfile
2. 需要上层自己指定包名和拷贝路径