### PR TITLE
add deepin for linuxos

### DIFF
--- a/xmake/core/base/linuxos.lua
+++ b/xmake/core/base/linuxos.lua
@@ -93,6 +93,8 @@ function linuxos.name()
                     name = "fedora"
                 elseif os_release:find("uos", 1, true) then
                     name = "uos"
+                elseif os_release:find("deepin", 1, true) then
+                    name = "deepin"
                 elseif os_release:find("linux mint", 1, true) or os_release:find("linuxmint", 1, true) then
                     name = "linuxmint"
                 elseif os_release:find("ubuntu", 1, true) then


### PR DESCRIPTION
It will read `/etc/os-release` and use string find to test if it contains the string `deepin`.
```
$ cat /etc/os-release 
PRETTY_NAME="Deepin 15"
NAME="Deepin"
VERSION_ID="15.11"
VERSION="15.11"
ID=deepin
HOME_URL="https://www.deepin.org/"
BUG_REPORT_URL="http://feedback.deepin.org/feedback/"
```

After the pull request:
```
$ xmake l linuxos.name
"deepin"
```