### PR TITLE
Fixed libcmt warning

### DIFF
--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -179,8 +179,8 @@ function nf_runtime(self, vs_runtime)
             }
         elseif kind == "ld" or kind == "sh" then
             maps = {
-                MD  = "-nostdlib -lmsvcrt",
-                MDd = "-nostdlib -lmsvcrtd"
+                MD  = {"-nostdlib", "-lmsvcrt"},
+                MDd = {"-nostdlib", "-lmsvcrtd"}
             }
         end
         return maps and maps[vs_runtime]

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -179,8 +179,8 @@ function nf_runtime(self, vs_runtime)
             }
         elseif kind == "ld" or kind == "sh" then
             maps = {
-                MD  = "-lmsvcrt",
-                MDd = "-lmsvcrtd"
+                MD  = "-nostdlib -lmsvcrt",
+                MDd = "-nostdlib -lmsvcrtd"
             }
         end
         return maps and maps[vs_runtime]


### PR DESCRIPTION
Windows default stdlib has conflict warning with msvcrt on windows.