### PR TITLE
support different qt versions by --qmake config

### DIFF
--- a/xmake/modules/detect/sdks/find_qt.lua
+++ b/xmake/modules/detect/sdks/find_qt.lua
@@ -177,6 +177,10 @@ function _find_qt(sdkdir, sdkver)
         return
     end
 
+    return _find_qt_by_qmake(qmake)
+end
+
+function _find_qt_by_qmake(qmake)
     -- get qt environments
     local qtenvs = _get_qtenvs(qmake)
     if not qtenvs then
@@ -241,7 +245,12 @@ function main(sdkdir, opt)
     end
 
     -- find qt
-    local qt = _find_qt(sdkdir or config.get("qt") or global.get("qt") or config.get("sdk"), opt.version or config.get("qt_sdkver"))
+    local qt
+    if config.get("qmake") then
+        qt = _find_qt_by_qmake(config.get("qmake"))
+    else
+        qt = _find_qt(sdkdir or config.get("qt") or global.get("qt") or config.get("sdk"), opt.version or config.get("qt_sdkver"))
+    end
     if qt then
 
         -- save to config

--- a/xmake/platforms/bsd/xmake.lua
+++ b/xmake/platforms/bsd/xmake.lua
@@ -51,6 +51,7 @@ platform("bsd")
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
+                ,   {nil, "qmake",          "kv", "auto",       "The Qt QMake Tool"                 }
                 }
 
             ,   global =

--- a/xmake/platforms/haiku/xmake.lua
+++ b/xmake/platforms/haiku/xmake.lua
@@ -48,6 +48,7 @@ platform("haiku")
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
+                ,   {nil, "qmake",          "kv", "auto",       "The Qt QMake Tool"                 }
                 }
 
             ,   global =

--- a/xmake/platforms/linux/xmake.lua
+++ b/xmake/platforms/linux/xmake.lua
@@ -51,6 +51,7 @@ platform("linux")
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
+                ,   {nil, "qmake",          "kv", "auto",       "The Qt QMake Tool"                 }
                 ,   {category = "Vcpkg Configuration"                                               }
                 ,   {nil, "vcpkg",          "kv", "auto",       "The Vcpkg Directory"               }
                 }

--- a/xmake/platforms/macosx/xmake.lua
+++ b/xmake/platforms/macosx/xmake.lua
@@ -58,6 +58,7 @@ platform("macosx")
                 ,   {category = "Qt SDK Configuration"                                                       }
                 ,   {nil, "qt",                      "kv", "auto",       "The Qt SDK Directory"              }
                 ,   {nil, "qt_sdkver",               "kv", "auto",       "The Qt SDK Version"                }
+                ,   {nil, "qmake",          "kv", "auto",       "The Qt QMake Tool"                 }
                 ,   {category = "Vcpkg Configuration"                                                        }
                 ,   {nil, "vcpkg",                   "kv", "auto",       "The Vcpkg Directory"               }
                 }

--- a/xmake/platforms/windows/xmake.lua
+++ b/xmake/platforms/windows/xmake.lua
@@ -58,6 +58,7 @@ platform("windows")
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",         "kv", "auto", "The Qt SDK Directory"                        }
                 ,   {nil, "qt_sdkver",  "kv", "auto", "The Qt SDK Version"                          }
+                ,   {nil, "qmake",      "kv", "auto", "The Qt QMake Tool"                           }
                 ,   {category = "WDK Configuration"                                                 }
                 ,   {nil, "wdk",        "kv", "auto", "The WDK Directory"                           }
                 ,   {nil, "wdk_sdkver", "kv", "auto", "The WDK Version"                             }


### PR DESCRIPTION
add `--qmake` config option to specifiy Qt SDK, in case you have multiple version installed in system like ArchLinux

for example:
```sh 
# this will find the default version(qt5)
xmake f --qmake=/usr/bin/qmake  
```

or 
```sh
# this will find qt version 6
xmake f --qmake=/usr/bin/qmake6
```