### PR TITLE
Improve d projects

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Installation
         run: |
           brew install dmd
+          brew install dub
 
       - name: Tests
         run: |

--- a/tests/projects/dlang/dub_package/src/main.d
+++ b/tests/projects/dlang/dub_package/src/main.d
@@ -1,0 +1,7 @@
+import util.log;
+
+void main()
+{
+    log = Log(stderrLogger, stdoutLogger(LogLevel.info), fileLogger("log"));
+    log.warn("test");
+}

--- a/tests/projects/dlang/dub_package/test.lua
+++ b/tests/projects/dlang/dub_package/test.lua
@@ -1,0 +1,6 @@
+-- main entry
+function main(t)
+
+    -- build project
+    t:build()
+end

--- a/tests/projects/dlang/dub_package/test.lua
+++ b/tests/projects/dlang/dub_package/test.lua
@@ -2,5 +2,9 @@
 function main(t)
 
     -- build project
-    t:build()
+    if is_host("macosx") and os.arch() ~= "arm64" then
+        t:build()
+    else
+        return t:skip("wrong host platform")
+    end
 end

--- a/tests/projects/dlang/dub_package/xmake.lua
+++ b/tests/projects/dlang/dub_package/xmake.lua
@@ -1,0 +1,8 @@
+add_rules("mode.debug", "mode.release")
+
+add_requires("dub::log 0.4.3")
+
+target("test")
+    set_kind("binary")
+    add_files("src/main.d")
+    add_packages("dub::log")

--- a/xmake/modules/core/tools/dmd.lua
+++ b/xmake/modules/core/tools/dmd.lua
@@ -83,6 +83,8 @@ function nf_symbol(self, level)
             _g.symbol_maps = maps
         end
         return maps[level .. '_' .. kind] or maps[level]
+    elseif kind == "dcld" then
+        return "-g"
     end
 end
 

--- a/xmake/modules/core/tools/dmd.lua
+++ b/xmake/modules/core/tools/dmd.lua
@@ -72,7 +72,7 @@ function nf_strip(self, level)
 end
 
 -- make the symbol flag
-function nf_symbol(self, level)
+function nf_symbol(self, level, target)
     local kind = self:kind()
     if language.sourcekinds()[kind] then
         local maps = _g.symbol_maps
@@ -83,7 +83,7 @@ function nf_symbol(self, level)
             _g.symbol_maps = maps
         end
         return maps[level .. '_' .. kind] or maps[level]
-    elseif kind == "dcld" then
+    elseif (kind == "dcld" or kind == "dcsh") and target:is_plat("windows") and level == "debug" then
         return "-g"
     end
 end

--- a/xmake/modules/core/tools/ldc2.lua
+++ b/xmake/modules/core/tools/ldc2.lua
@@ -49,7 +49,7 @@ function nf_optimize(self, level)
 end
 
 -- make the symbol flag
-function nf_symbol(self, level)
+function nf_symbol(self, level, target)
     local kind = self:kind()
     if language.sourcekinds()[kind] then
         local maps = _g.symbol_maps
@@ -61,7 +61,7 @@ function nf_symbol(self, level)
             _g.symbol_maps = maps
         end
         return maps[level .. '_' .. kind] or maps[level]
-    elseif kind == "dcld" then
+    elseif (kind == "dcld" or kind == "dcsh") and target:is_plat("windows") and level == "debug" then
         return "-g"
     end
 end

--- a/xmake/modules/core/tools/ldc2.lua
+++ b/xmake/modules/core/tools/ldc2.lua
@@ -61,5 +61,7 @@ function nf_symbol(self, level)
             _g.symbol_maps = maps
         end
         return maps[level .. '_' .. kind] or maps[level]
+    elseif kind == "dcld" then
+        return "-g"
     end
 end

--- a/xmake/modules/package/manager/dub/find_package.lua
+++ b/xmake/modules/package/manager/dub/find_package.lua
@@ -49,7 +49,7 @@ function main(name, opt)
     if pkglist then
         local pkgdir
         for _, line in ipairs(pkglist:split('\n', {plain = true})) do
-            local pkginfo = line:split(':', {plain = true})
+            local pkginfo = line:split(': ', {plain = true})
             if #pkginfo == 2 then
                 local pkgkey  = pkginfo[1]:trim():split(' ', {plain = true})
                 local pkgpath = pkginfo[2]:trim()


### PR DESCRIPTION
This PR fixes two bugs in D projects, dub packages are not working on windows and pdb are not generated in debug builds. I have also added a test for dub packages.

I have a few questions : 
- The original D tests (eg dlang/console) are skipped on many platforms, any idea why?
- Maybe it'd be worth adding a test for checking pdb generation? I can add that if you think it's worth it, but I'd need a bit of direction on how to a achieve that. 
- I haven't fix pdb with gdc. I suppose the fix is the same as with ldc, but since I can't test it (gdc won't work on windows) I didn't include it. Should I?
- I noticed that in release the boundscheck:off flag is enabled. This flag trades correctness against performances. I consider this flag just lik fastmath, something that should be enabled explicitly, rathan than by default.. Especially since it's not the case with dub. What is the rational behind that?

Thanks.