### PR TITLE
fix xmake check for configfiles

### DIFF
--- a/xmake/modules/private/check/checkers/api/target/configfiles.lua
+++ b/xmake/modules/private/check/checkers/api/target/configfiles.lua
@@ -24,6 +24,7 @@ import(".api_checker")
 function main(opt)
     opt = opt or {}
     api_checker.check_targets("configfiles", table.join(opt, {check = function(target, value)
+        value = value:gsub("[()]", "")
         local configfiles = os.files(value)
         if not configfiles or #configfiles == 0 then
             return false, string.format("configfiles '%s' not found", value)


### PR DESCRIPTION
https://xmake.io/#/manual/project_target?id=targetadd_configfiles 这里add_configfiles也是可以保持目录结构的，所以应该和add_headerfiles一样处理