### PR TITLE
以debug模式编译windows驱动时，vs会加DBG宏

### DIFF
--- a/xmake/rules/wdk/xmake.lua
+++ b/xmake/rules/wdk/xmake.lua
@@ -21,6 +21,10 @@
 -- define rule: driver
 rule("wdk.driver")
 
+    if is_mode("debug") then
+        add_defines("DBG")
+    end
+
     -- add rules
     add_deps("wdk.inf", "wdk.man", "wdk.mc", "wdk.mof", "wdk.tracewpp", "wdk.sign", "wdk.package.cab")
 


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/3568
之前提了一个issue，xmake最好也保持一样的行为