### PR TITLE
fix linking issues for qt6

### DIFF
--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -368,6 +368,9 @@ function main(target, opt)
         _add_includedirs(target, path.join(qt.mkspecsdir, "wasm-emscripten"))
         target:add("rpathdirs", qt.libdir)
         target:add("linkdirs", qt.libdir)
+        for _, filepath in ipairs(os.files(path.join(qt.libdir, "objects-*","**.o"))) do
+            table.insert(target:objectfiles(), filepath)
+        end
         target:add("ldflags", "-s WASM=1", "-s FETCH=1", "-s FULL_ES2=1", "-s FULL_ES3=1", "-s USE_WEBGL2=1", "--bind")
         target:add("ldflags", "-s ERROR_ON_UNDEFINED_SYMBOLS=1", "-s EXTRA_EXPORTED_RUNTIME_METHODS=[\"UTF16ToString\",\"stringToUTF16\"]", "-s ALLOW_MEMORY_GROWTH=1")
         target:add("shflags", "-s WASM=1", "-s FETCH=1", "-s FULL_ES2=1", "-s FULL_ES3=1", "-s USE_WEBGL2=1", "--bind")

--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -368,7 +368,7 @@ function main(target, opt)
         _add_includedirs(target, path.join(qt.mkspecsdir, "wasm-emscripten"))
         target:add("rpathdirs", qt.libdir)
         target:add("linkdirs", qt.libdir)
-        for _, filepath in ipairs(os.files(path.join(qt.libdir, "objects-*","**.o"))) do
+        for _, filepath in ipairs(os.files(path.join(qt.libdir, "objects-*", "**.o"))) do
             table.insert(target:objectfiles(), filepath)
         end
         target:add("ldflags", "-s WASM=1", "-s FETCH=1", "-s FULL_ES2=1", "-s FULL_ES3=1", "-s USE_WEBGL2=1", "--bind")

--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -94,6 +94,8 @@ function _add_plugins(target, plugins)
         if plugin.linkdirs then
             target:values_add("qt.linkdirs", table.unpack(table.wrap(plugin.linkdirs)))
         end
+        -- TODO: add prebuilt object files in qt sdk.
+        -- these file is located at plugins/xxx/objects-Release/xxxPlugin_init/xxxPlugin_init.cpp.o
     end
 end
 
@@ -368,7 +370,9 @@ function main(target, opt)
         _add_includedirs(target, path.join(qt.mkspecsdir, "wasm-emscripten"))
         target:add("rpathdirs", qt.libdir)
         target:add("linkdirs", qt.libdir)
-        for _, filepath in ipairs(os.files(path.join(qt.libdir, "objects-*", "**.o"))) do
+        -- add prebuilt object files in qt sdk.
+        -- these file is located at lib/objects-Release/xxxmodule_resources_x/.rcc/xxxmodule.cpp.o
+        for _, filepath in ipairs(os.files(path.join(qt.libdir, "objects-*", "*_resources_*", ".rcc", "*.o"))) do
             table.insert(target:objectfiles(), filepath)
         end
         target:add("ldflags", "-s WASM=1", "-s FETCH=1", "-s FULL_ES2=1", "-s FULL_ES3=1", "-s USE_WEBGL2=1", "--bind")

--- a/xmake/rules/qt/xmake.lua
+++ b/xmake/rules/qt/xmake.lua
@@ -221,9 +221,11 @@ rule("qt.quickapp_static")
         -- https://github.com/xmake-io/xmake/issues/1047
         -- https://github.com/xmake-io/xmake/issues/2791
         local QtPlatformSupport
+        local OldQtWasm = true;
         if qt_sdkver then
             if qt_sdkver:ge("6.0") then
                 QtPlatformSupport = nil
+                OldQtWasm = false;
             elseif qt_sdkver:ge("5.9") then
                 QtPlatformSupport = "QtPlatformCompositorSupport"
             else
@@ -248,7 +250,9 @@ rule("qt.quickapp_static")
             end
         elseif target:is_plat("wasm") then
             plugins.QWasmIntegrationPlugin = {linkdirs = "plugins/platforms", links = {"qwasm"}}
-            table.join2(frameworks, "QtEventDispatcherSupport", "QtFontDatabaseSupport", "QtEglSupport")
+            if OldQtWasm then
+                table.join2(frameworks, "QtEventDispatcherSupport", "QtFontDatabaseSupport", "QtEglSupport")
+            end
         end
         import("load")(target, {gui = true, plugins = plugins, frameworks = frameworks})
     end)

--- a/xmake/rules/qt/xmake.lua
+++ b/xmake/rules/qt/xmake.lua
@@ -221,11 +221,9 @@ rule("qt.quickapp_static")
         -- https://github.com/xmake-io/xmake/issues/1047
         -- https://github.com/xmake-io/xmake/issues/2791
         local QtPlatformSupport
-        local OldQtWasm = true;
         if qt_sdkver then
             if qt_sdkver:ge("6.0") then
                 QtPlatformSupport = nil
-                OldQtWasm = false;
             elseif qt_sdkver:ge("5.9") then
                 QtPlatformSupport = "QtPlatformCompositorSupport"
             else
@@ -250,7 +248,7 @@ rule("qt.quickapp_static")
             end
         elseif target:is_plat("wasm") then
             plugins.QWasmIntegrationPlugin = {linkdirs = "plugins/platforms", links = {"qwasm"}}
-            if OldQtWasm then
+            if qt_sdkver and qt_sdkver:lt("6.0") then
                 table.join2(frameworks, "QtEventDispatcherSupport", "QtFontDatabaseSupport", "QtEglSupport")
             end
         end

--- a/xmake/rules/qt/xmake.lua
+++ b/xmake/rules/qt/xmake.lua
@@ -248,8 +248,12 @@ rule("qt.quickapp_static")
             end
         elseif target:is_plat("wasm") then
             plugins.QWasmIntegrationPlugin = {linkdirs = "plugins/platforms", links = {"qwasm"}}
-            if qt_sdkver and qt_sdkver:lt("6.0") then
-                table.join2(frameworks, "QtEventDispatcherSupport", "QtFontDatabaseSupport", "QtEglSupport")
+            if qt_sdkver then
+                if qt_sdkver:lt("6.0") then
+                    table.join2(frameworks, "QtEventDispatcherSupport", "QtFontDatabaseSupport", "QtEglSupport")
+                else
+                    table.join2(frameworks, "QtOpenGL")
+                end
             end
         end
         import("load")(target, {gui = true, plugins = plugins, frameworks = frameworks})


### PR DESCRIPTION
* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

# Summary

This pull request fixes linker errors which occurs on wasm compiling for qt.There is two aspects of this patch:
* Add missing object file in wasm.
 Similar error is reported in conan#5233 and similar solution is commited in conan#5234.
* Add correct qt modules references for wasm.
  Some qt modules is removed after qt6.
