### PR TITLE
Fix #3680: While building xmake: PROCESSOR_ARCHITECTURE_ARM64 not def…

### DIFF
--- a/core/src/xmake/engine.c
+++ b/core/src/xmake/engine.c
@@ -935,9 +935,11 @@ static tb_void_t xm_engine_init_arch(xm_engine_t* engine)
     case PROCESSOR_ARCHITECTURE_AMD64:
         sysarch = "x64";
         break;
+#if defined(PROCESSOR_ARCHITECTURE_ARM64)
     case PROCESSOR_ARCHITECTURE_ARM64:
         sysarch = "arm64";
         break;
+#endif
     case PROCESSOR_ARCHITECTURE_ARM:
         sysarch = "arm";
         break;


### PR DESCRIPTION
…ined.

Using Microsoft Visual Studio 14.0, I got this error when trying to build xmake from source:

```
src\xmake\engine.c(938): error C2065: 'PROCESSOR_ARCHITECTURE_ARM64': undeclared identifier
```

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

