### PR TITLE
🐞 fix(xmake/modules/net/fasturl.lua): fix _parse_host when it has a port

### DIFF
--- a/xmake/modules/net/fasturl.lua
+++ b/xmake/modules/net/fasturl.lua
@@ -21,10 +21,10 @@
 -- imports
 import("ping")
 
--- http[s]://xxx.com/.. or git@git.xxx.com:xxx/xxx.git
+-- http[s]://xxx.com[:1234]/.. or git@git.xxx.com:xxx/xxx.git
 function _parse_host(url)
     _g._URLHOSTS = _g._URLHOSTS or {}
-    local host = _g._URLHOSTS[url] or url:match("://(.-)/") or url:match("@(.-):")
+    local host = _g._URLHOSTS[url] or url:match("://([^/:]+)") or url:match("@(.-):")
     _g._URLHOSTS[url] = host
     return host
 end


### PR DESCRIPTION
在`add_urls`等接口添加多个`url`，但当`url`中存在端口号时，由于 `_parse_host` 的错误匹配，会将端口号一同匹配进去，最后导致`ping`失败

示例：`http://127.0.0.1:1234/hello`


