### PR TITLE
use pushd and popd to tackle venv

### DIFF
--- a/scripts/xrepo.bat
+++ b/scripts/xrepo.bat
@@ -1,4 +1,5 @@
-@set "XMAKE_EXE=xmake"
+@set "XMAKE_ROOTDIR=%~dp0"
+@set "XMAKE_EXE=%XMAKE_ROOTDIR%xmake.exe"
 
 @if [%1]==[env] (
     if [%2]==[quit] (
@@ -88,21 +89,16 @@
             echo Please rerun `xrepo env %2 %3 shell` to enter the environment.
             exit /B 1
         ) else (
+            pushd %XMAKE_ROOTDIR%
             setlocal EnableDelayedExpansion
-            @%XMAKE_EXE% lua --quiet private.xrepo.action.env | findstr . && (
-                echo error: corrupt xmake.lua detected in the current directory^^!
-                exit /B 1
-            )
-            @%XMAKE_EXE% lua --quiet private.xrepo.action.env
-            if !errorlevel! neq 0 (
-                exit /B !errorlevel!
-            )
             %XMAKE_EXE% lua private.xrepo.action.env.info config %3
             if !errorlevel! neq 0 (
+                popd
                 exit /B !errorlevel!
             )
             @%XMAKE_EXE% lua --quiet private.xrepo.action.env.info prompt %3 1>nul
             if !errorlevel! neq 0 (
+                popd
                 echo error: environment not found^^!
                 exit /B !errorlevel!
             )
@@ -120,6 +116,7 @@
             @"%XMAKE_EXE%" lua --quiet private.xrepo.action.env.info script.cmd %3 1>"%%i.bat"
             call "%%i.bat"
         )
+        popd
         goto :ENDXREPO
     )
 )

--- a/xmake/scripts/virtualenvs/register-virtualenvs.sh
+++ b/xmake/scripts/virtualenvs/register-virtualenvs.sh
@@ -21,6 +21,7 @@
 if test "${XMAKE_ROOTDIR}"; then
     export XMAKE_EXE=${XMAKE_ROOTDIR}/xmake
 else
+    local -i XMAKE_ROOTDIR=~/.local/bin
     export XMAKE_EXE=xmake
 fi
 
@@ -69,22 +70,20 @@ function xrepo {
                         unset XMAKE_PROMPT_BACKUP
                         unset XMAKE_ENV_BACKUP
                     fi
-                    local currentTest="$("$XMAKE_EXE" lua --quiet private.xrepo.action.env)" || return 1
-                    if [ ! -z "$currentTest" ]; then
-                        echo "error: corrupt xmake.lua detected in the current directory!"
-                        return 1
-                    fi
-                    "$XMAKE_EXE" lua private.xrepo.action.env.info config $bnd || return 1
-                    local prompt="$("$XMAKE_EXE" lua --quiet private.xrepo.action.env.info prompt $bnd)" || return 1
+                    pushd ${XMAKE_ROOTDIR} 1>/dev/null
+                    "$XMAKE_EXE" lua private.xrepo.action.env.info config $bnd || (popd 1>/dev/null && return 1)
+                    local prompt="$("$XMAKE_EXE" lua --quiet private.xrepo.action.env.info prompt $bnd)" || (popd 1>/dev/null && return 1)
                     if [ -z "${prompt+x}" ]; then
+                        popd 1>/dev/null
                         echo "error: invalid environment!"
                         return 1
                     fi
-                    local activateCommand="$("$XMAKE_EXE" lua --quiet private.xrepo.action.env.info script.bash $bnd)" || return 1
+                    local activateCommand="$("$XMAKE_EXE" lua --quiet private.xrepo.action.env.info script.bash $bnd)" || (popd 1>/dev/null && return 1)
                     export XMAKE_ENV_BACKUP="$("$XMAKE_EXE" lua private.xrepo.action.env.info envfile $bnd)"
                     export XMAKE_PROMPT_BACKUP="${PS1}"
                     "$XMAKE_EXE" lua --quiet private.xrepo.action.env.info backup.bash $bnd 1>"$XMAKE_ENV_BACKUP"
                     eval "$activateCommand"
+                    popd 1>/dev/null
                     PS1="${prompt} $PS1"
                 else
                     "$XMAKE_EXE" lua private.xrepo "$@"


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/3544
https://github.com/xmake-io/xmake/pull/3556

现在的解决方案还是有问题，如果当前目录没有下载一些包，那探测的时候就会卡死。这里用了另一种方法，临时在script里面切换到xmake executable目录，这样彻底解决xrepo env -b xxx shell依赖当前目录的问题。