### PR TITLE
fix issue with existing working tmpdir

### DIFF
--- a/xmake/modules/private/xrepo/action/env.lua
+++ b/xmake/modules/private/xrepo/action/env.lua
@@ -105,6 +105,8 @@ function _enter_project()
         os.vrunv("xmake", {"create", "-P", "."})
     else
         os.cd(workdir)
+        os.rm("*")
+        os.vrunv("xmake", {"create", "-P", "."})
     end
     project.chdir(workdir)
 end


### PR DESCRIPTION
如果在激活虚拟环境时，xrepo/working 这个文件夹已经存在并且为空，则报错找不到xmake.lua。这里检测到有文件夹时应该将其清空，然后重新创建项目。