### PR TITLE
Fix librarydeps.compatible_checked

### DIFF
--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -995,7 +995,7 @@ function _compatible_with_previous_librarydeps(package, opt)
     -- has been checked?
     local compatible_checked = package:data("librarydeps.compatible_checked")
     if compatible_checked then
-        return
+        return true
     end
 
     -- check strict compatibility for librarydeps?


### PR DESCRIPTION
When setting package:data_set("librarydeps.compatible_checked", true), `_compatible_with_previous_librarydeps` returns nil instead of true
