### PR TITLE
fix xcode.frameword can't build macos static-framework

### DIFF
--- a/xmake/rules/xcode/framework/xmake.lua
+++ b/xmake/rules/xcode/framework/xmake.lua
@@ -105,12 +105,14 @@ rule("xcode.framework")
             end
             os.vcp(target:targetfile(), contentsdir)
 
-            -- change rpath
-            -- @see https://github.com/xmake-io/xmake/issues/2679#issuecomment-1221839215
-            local filename = path.filename(target:targetfile())
-            local targetfile = path.join(contentsdir, filename)
-            local rpath = path.relative(contentsdir, path.directory(bundledir))
-            os.vrunv("install_name_tool", {"-id", path.join("@rpath", rpath, filename), targetfile})
+            if target:is_shared() then
+                -- change rpath
+                -- @see https://github.com/xmake-io/xmake/issues/2679#issuecomment-1221839215
+                local filename = path.filename(target:targetfile())
+                local targetfile = path.join(contentsdir, filename)
+                local rpath = path.relative(contentsdir, path.directory(bundledir))
+                os.vrunv("install_name_tool", {"-id", path.join("@rpath", rpath, filename), targetfile})
+            end
 
             -- move header files
             os.tryrm(headersdir)


### PR DESCRIPTION
编译macos静态库并使用规则add_rules("xcode.framework")时，编译时会收到如下报错：
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: input file: build/macosx/arm64/release/XXXXX.framework/Versions/A/XXXXX is not a Mach-O file
原因是“xcode.framework”这个规则会调用install_name_tool命令进行change rpath，但静态库不需要rpath，所以在设置rpath时判断当前target是否为动态库