### PR TITLE
Long Path checkbox

### DIFF
--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -285,6 +285,19 @@ Section "XMake (required)" InstallExeutable
 
 SectionEnd
 
+Section "Enable Long Path" LongPath
+  ; Get git path from the registry
+  ReadRegStr $R0 ${HKLM} "SOFTWARE\GitForWindows" "InstallPath"
+  ${If} $NOADMIN == "false"
+    ; In admin enable long path on both git system config and in registry
+    WriteRegDWORD ${HKLM} "SYSTEM\CurrentControlSet\Control\FileSystem" "LongPathsEnabled" 1
+    Exec '"$R0\cmd\git.exe" config --system core.longpaths true'
+  ${Else}
+    ; Enable only in git global config
+    Exec '"$R0\cmd\git.exe" config --global core.longpaths true'
+  ${EndIf}
+SectionEnd
+
 Section "Add to PATH" InstallPath
 
   ${If} $NOADMIN == "false"
@@ -314,11 +327,13 @@ SectionEnd
 ; Language strings
 LangString DESC_InstallExeutable ${LANG_ENGLISH} "A cross-platform build utility based on Lua"
 LangString DESC_InstallPath ${LANG_ENGLISH} "Add xmake to PATH"
+LangString DESC_LongPath ${LANG_ENGLISH} "Enable long path on both Windows and Git"
 
 ; Assign language strings to sections
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
 !insertmacro MUI_DESCRIPTION_TEXT ${InstallExeutable} $(DESC_InstallExeutable)
 !insertmacro MUI_DESCRIPTION_TEXT ${InstallPath} $(DESC_InstallPath)
+!insertmacro MUI_DESCRIPTION_TEXT ${LongPath} $(DESC_LongPath)
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
 ;--------------------------------

--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -321,7 +321,7 @@ SectionEnd
 ; Language strings
 LangString DESC_InstallExeutable ${LANG_ENGLISH} "A cross-platform build utility based on Lua"
 LangString DESC_InstallPath ${LANG_ENGLISH} "Add xmake to PATH"
-LangString DESC_LongPath ${LANG_ENGLISH} "Enable long path on both Windows and Git"
+LangString DESC_LongPath ${LANG_ENGLISH} "Increases the maximum path length limit, up to 32,767 characters (before 256). This can be useful if a project has many recursive subfolders to make sure that the project is compiled without errors. A reboot might be required because some processes may have started before the new value was set"
 
 ; Assign language strings to sections
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN

--- a/scripts/installer.nsi
+++ b/scripts/installer.nsi
@@ -286,15 +286,9 @@ Section "XMake (required)" InstallExeutable
 SectionEnd
 
 Section "Enable Long Path" LongPath
-  ; Get git path from the registry
-  ReadRegStr $R0 ${HKLM} "SOFTWARE\GitForWindows" "InstallPath"
   ${If} $NOADMIN == "false"
-    ; In admin enable long path on both git system config and in registry
+    ; Enable long path
     WriteRegDWORD ${HKLM} "SYSTEM\CurrentControlSet\Control\FileSystem" "LongPathsEnabled" 1
-    Exec '"$R0\cmd\git.exe" config --system core.longpaths true'
-  ${Else}
-    ; Enable only in git global config
-    Exec '"$R0\cmd\git.exe" config --global core.longpaths true'
   ${EndIf}
 SectionEnd
 


### PR DESCRIPTION
Sometimes when xmake is building a package on Windows, it fails because the path is too long to handle. This issue can also occur when installing a package from a repository with a lot of submodules. Therefore, this PR attempts to mitigate the problem by providing a setting in the NSIS installer.

The NSIS configuration file is modified to:

* Enable the Long Path option in the registry.
* Execute a git command to enable the long path option.

Unfortunately, the execution of git opens a terminal for a short time (~100ms). I did some research to remove this behavior, but it seems that the only way is to use nsExec plugin which is already present in the codebase but not enabled by default. Therefore, if you prefer to have a silent execution, you would have to compile the plugin first (That's why I have set this PR in draft mode).