### PR TITLE
update info.lua

### DIFF
--- a/xmake/modules/private/action/require/info.lua
+++ b/xmake/modules/private/action/require/info.lua
@@ -258,9 +258,9 @@ function main(requires_raw)
                         printf(configs_extra.description)
                     end
                     if configs_extra.default ~= nil then
-                        printf(" (default: %s", configs_extra.default)
+                        printf(" (default: %s)", configs_extra.default)
                     elseif configs_extra.type ~= nil and configs_extra.type ~= "string" then
-                        printf(" (type: %s", configs_extra.type)
+                        printf(" (type: %s)", configs_extra.type)
                     end
                     print("")
                     if configs_extra.values then


### PR DESCRIPTION
第一个pr改错的地方复原
config built in 少了右括号
![image](https://github.com/xmake-io/xmake/assets/97490782/917b088d-479b-4930-bbed-a315a510fc23)
