### PR TITLE
[add] make visual studio project support wasm intellisense

### DIFF
--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -110,10 +110,27 @@ function _make_targetinfo(mode, arch, target)
     ,   sdkver = config.get("vs_sdkver")
     }
 
+    --replace plat wasm and arch wasm32 to windows and x64
+    if "wasm" == targetinfo.plat then
+        config.set("plat", "windows", {force = true})
+        targetinfo.plat = config.get("plat")
+        print("replacing for wasm plat: %s", targetinfo.plat)
+        
+    end
+
+    if "wasm32" == targetinfo.arch then
+        config.set("arch", "x86",{force = true})
+        targetinfo.arch = config.get("arch")
+        targetinfo.vsarch = "Win32"
+        print("replacing for wasm32 arch: %s", targetinfo.arch)
+        
+    end
+
     -- write only if not default
     -- use target:get("xxx") rather than target:xxx()
 
     -- save target kind
+
     targetinfo.kind          = target:kind()
 
     -- is default?
@@ -285,6 +302,13 @@ function _make_vsinfo_archs()
     if not vsinfo_archs or #vsinfo_archs == 0 then
         vsinfo_archs = { config.arch() }
     end
+
+    for k, v in pairs(vsinfo_archs) do
+        if "wasm32" == v then
+            vsinfo_archs[k] = "x86"
+        end
+    end
+
     return vsinfo_archs
 end
 

--- a/xmake/plugins/project/vsxmake/vsproj/Xmake.props
+++ b/xmake/plugins/project/vsxmake/vsproj/Xmake.props
@@ -59,6 +59,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
+    <PlatformToolset Condition="'$([System.IO.Path]::GetExtension($(XmakeFilename)))' == '.html'">ClangCL</PlatformToolset>
   </PropertyGroup>
 
   <PropertyGroup Label="AdditionalProps">


### PR DESCRIPTION
Add wasm intellisense support to visual studio project,this feature only support "vsmake" plugin.
It "cheat" visual studio because visual studio does not support wasm platform.Replace the platform "wasm" to  "windows" and arch name "wasm32" to "x86".Finally， add "ClangCL" PlatformToolSet. Since we use vsmake,the operations have no risk,and the intellisense works well.
THIS PATCH LOOKS UGLY,PLEASE REVIEW IT AND GIVE ME SOME SUGGESTIONS TO IMPROVE IT!

