### PR TITLE
Update msbuild.lua

### DIFF
--- a/xmake/modules/package/tools/msbuild.lua
+++ b/xmake/modules/package/tools/msbuild.lua
@@ -22,13 +22,13 @@
 import("core.base.option")
 import("core.tool.toolchain")
 import("lib.detect.find_tool")
+import("private.utils.upgrade_vsproj")
 
 -- get the number of parallel jobs
 function _get_parallel_njobs(opt)
     return opt.jobs or option.get("jobs") or tostring(os.default_njob())
 end
 
--- tra
 -- get msvc
 function _get_msvc(package)
     local msvc = toolchain.load("msvc", {plat = package:plat(), arch = package:arch()})
@@ -74,8 +74,6 @@ end
 
 -- build package
 function build(package, configs, opt)
-
-    -- init options
     opt = opt or {}
 
     -- pass configurations
@@ -88,6 +86,14 @@ function build(package, configs, opt)
             else
                 table.insert(argv, name .. "=" .. value)
             end
+        end
+    end
+
+    -- upgrade vs solution file?
+    -- @see https://github.com/xmake-io/xmake/issues/3871
+    if opt.upgrade then
+        for _, value in pairs(opt.upgrade) do
+            upgrade_vsproj.upgrade(value, table.join(opt, {msvc = _get_msvc(package)}))
         end
     end
 


### PR DESCRIPTION
这样用起来比较灵活，已经可以跑通了
```
    on_install("windows", function (package)
        local configs = {"wolfssl64.sln"}
        local debug_str = package:debug() and "Debug" or "Release"
        local plat_str = package:is_arch("x64") and "x64" or "Win32"

        table.insert(configs, "/p:Configuration=" .. debug_str)
        table.insert(configs, "/p:Platform=" .. plat_str)
        table.insert(configs, "-t:wolfssl")
        import("package.tools.msbuild").build(package, configs, {upgrade={"wolfssl64.sln", "wolfssl.vcxproj"}})
        os.cp("wolfssl", package:installdir("include"))
        os.cp(path.join(debug_str, plat_str, "*"), package:installdir("lib"))
    end)
```