### PR TITLE
update shebang and usage

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # xmake getter
-# usage: bash <(curl -s <my location>) [branch|__local__|__run__] [commit/__install_only__]
+# usage: curl -s <my location> | sh -- [branch|__local__|__run__] [commit/__install_only__]
 
 set -o pipefail
 


### PR DESCRIPTION
Hello,

I was tinkering around with the install script `get.sh` and realized it was fully compatible with `sh` (it doesn't require any feature of `bash`).

To make the install process fully compatible with `sh` (while still maintaining `bash` compatibility) it's only needed to change the shebang and
```diff
- bash <(remote_get_content https://fastly.jsdelivr.net/gh/xmake-io/xmake@dev/scripts/get.sh) $@
+ remote_get_content https://fastly.jsdelivr.net/gh/xmake-io/xmake@dev/scripts/get.sh | sh -- $@
```
from [this script](https://xmake.io/shget.text).
Change proposed [here](https://github.com/xmake-io/xmake-docs/pull/129)

I think it would be nice to have since you're also working on a full `sh` compatible version of `xmake`.

In this PR I only updated the shebang of `get.sh` and its usage to be compatible with `sh` since `<()` syntaxe is [not defined](https://www.shellcheck.net/wiki/SC3001).