### PR TITLE
change `$SHELL` with `$<SHELL>_VERSION`

### DIFF
--- a/xmake/scripts/profile-unix.sh
+++ b/xmake/scripts/profile-unix.sh
@@ -19,9 +19,9 @@
 #
 
 # register completions
-if   [[ "$SHELL" = */zsh ]]; then
+if   [[ -n "$ZSH_VERSION" ]]; then
   . "$XMAKE_PROGRAM_DIR/scripts/completions/register-completions.zsh"
-elif [[ "$SHELL" = */bash ]]; then
+elif [[ -n "$BASH_VERSION" ]]; then
   . "$XMAKE_PROGRAM_DIR/scripts/completions/register-completions.bash"
 fi
 


### PR DESCRIPTION
fixes #3915, now completions are loaded based on current shell not default one.
(tested on macos and linux via a docker container)