### PR TITLE
fix nvcc error detection

### DIFF
--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -396,7 +396,7 @@ function compile(self, sourcefile, objectfile, dependinfo, flags)
                 local lines = errors:split("\n", {plain = true})
                 local start = 0
                 for index, line in ipairs(lines) do
-                    if line:find("error:", 1, true) or line:find("错误：", 1, true) or line:match("ptxas fatal%s*:") or line:match("error %a+[0-9]+%s*:") then
+                    if line:find("[eE]rror:", 1, true) or line:find("错误：", 1, true) or line:match("ptxas fatal%s*:") or line:match("error %a+[0-9]+%s*:") then
                         start = index
                         break
                     end

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -396,7 +396,7 @@ function compile(self, sourcefile, objectfile, dependinfo, flags)
                 local lines = errors:split("\n", {plain = true})
                 local start = 0
                 for index, line in ipairs(lines) do
-                    if line:find("[eE]rror:", 1, true) or line:find("错误：", 1, true) or line:match("ptxas fatal%s*:") or line:match("error %a+[0-9]+%s*:") then
+                    if line:match("[eE]rror:", 1, true) or line:find("错误：", 1, true) or line:match("ptxas fatal%s*:") or line:match("error %a+[0-9]+%s*:") then
                         start = index
                         break
                     end


### PR DESCRIPTION
nvcc在出现内部错误的时候报错是以Error开头的：`Error: Internal Compiler Error (codegen): "unexpected expression with aggregate type!"` 这里加入大写情况的探测。