### PR TITLE
Add systemverilog support,Fix verilator build error

### DIFF
--- a/xmake/rules/verilator/xmake.lua
+++ b/xmake/rules/verilator/xmake.lua
@@ -20,7 +20,7 @@
 
 -- @see https://github.com/xmake-io/xmake/issues/3257
 rule("verilator.binary")
-    set_extensions(".v")
+    set_extensions(".v", ".sv")
     on_load(function (target)
         target:set("kind", "binary")
     end)


### PR DESCRIPTION
1. Add extension .sv to enable systemverilog support
2. Remove unnecessary flags in test


------

我不知道为什么要在 `config` 函数中测试正确性的时候将 `verilator.flags` 读取进来，加入到那个很简单的 `main.v` 的编译参数中来，这样做的目的是什么？

进行内部测试的时候应该也不需要读取用户的参数，这就导致了很多问题，用户输入的参数会影响内部测试的结果。`verilator` 很多参数不能用，模块重命名等等。

关于原先 `--top` 参数不能用的问题（[Adding Support for Verilog and SystemVerilog · Issue #3257 · xmake-io/xmake · GitHub](https://github.com/xmake-io/xmake/issues/3257)），其实是参数解析的问题，我不知道为什么参数解析遇到空格就罢工了，是就这样子设计的吗？


经过修改后，我把一些工程改造为使用 `xmake` 编译运行，都没有问题，包括 `systemverilog` 工程。


# 文档应该说明的内容
> verilator 参数参考
> [verilator Arguments — Verilator 5.012 documentation](https://veripool.org/guide/latest/exe_verilator.html)


##  verilator 参数 --top 选项问题
`--top` **key** 和 **val** 需要分别添加，不能放在一个字符串里面，可能是 `xmake` 解析问题。
```lua
-- 正确用法
add_values("verilator.flags", "--top","test_top"）
-- 错误用法
add_values("verilator.flags", "--top test_top"）
```

如果使用 `"--top test_top"` 传递参数时，会直接传递为 `"--top test_top"`，由于多个双引号，导致参数解析错误

## verilator 参数 --prefix
这种 `--key val` 形式的参数，都需要将 `--key` 和 `val` 分别存放在两个字符串里。

`--prefix` 选项在 xmake 中已经被使用了，如果需要更改，可以改 `target`

```lua
-- 错误用法
target("Vtop")
    add_rules("verilator.binary")
    set_toolchains("@verilator")
    add_files("src/*.cpp")
    add_files("src/*.sv")
    add_values("verilator.flags", "--prefix","my_prefix")

-- 正确用法
target("my_prefix")
    add_rules("verilator.binary")
    set_toolchains("@verilator")
    add_files("src/*.cpp")
    add_files("src/*.sv")
```

## verilator 参数 --Mdir
`--Mdir` 已经被 `xmake` 内部使用，不能自定义，一个具体的编译命令如下（使用 `xmake -v` 得到 ）
```bash
verilator --cc --make cmake --prefix Vtop --Mdir build/.gens/Vtop/linux/x86_64/release/rules/verilator
```

## verilator 参数 --trace-fst 问题
`fst` 格式的波形文件比 `vcd` 格式的大小小的多，并且依赖于 `libz` ，如果启用，需要手动添加 `libz` 依赖。
```lua
-- 正确用法
add_values("verilator.flags", "--trace-fst"）
add_syslinks("z")
--错误用法
add_values("verilator.flags", "--trace-fst"）
```

 
## xmake 参数 add_includedirs()     add_defines() 问题


在 `xmake.lua` 中 `add_includedirs` 和 `add_defines` 都只作用于 `cpp` 文件，对于 `.v` `.sv` 文件是没有效果的。
如果要为 `rtl` 文件添加 `includedirs` 或者 `defines` 需要在 `add_values` 里面添加。具体方法如下：

**verilator 宏定义**
```shell
-D<var>=<value>
Defines the given preprocessor symbol. Similar to +define, but does not allow multiple definitions with a single option using plus signs. “+define” is relatively standard across Verilog tools, while “-D” is similar to gcc -D.

+define+<var>=<value>
+define+<var>=<value>[+<var2>=<value2>][...]
Defines the given preprocessor symbol, or multiple symbols if separated by plus signs. Similar to -D; +define is relatively standard across Verilog tools while -D is similar to gcc -D.
```

**verilator includedir**
```bash
-y <dir>
Add the directory to the list of directories that should be searched to find include files or libraries. The three flags -y, +incdir+<dir> and -I<dir> have a similar effect; +incdir+<dir> and -y are relatively standard across Verilog tools while -I<dir> is used by many C++ compilers.

Verilator defaults to the current directory “-y .” and any specified --Mdir, though these default paths are used after any user-specified directories. This allows ‘-y “$(pwd)”’ to be used if absolute filenames are desired for error messages instead of relative filenames.
```


```lua
-- 错误用法
add_includedirs("vsrc/include")
add_defines("VERILOG_DEFINE")
-- 正确方法 1
add_values("verilator.flags", "-DVERILOG_DEFINE"，"-y"，"vsrc/include"）
-- 正确方法 2
add_values("verilator.flags", "-DVERILOG_DEFINE"，"-Ivsrc/include"）
-- 正确用法 3
add_values("verilator.flags", "-DVERILOG_DEFINE"，"+incdir+vsrc/include"）
```






