### PR TITLE
Fix pacman package lookup on msys Windows

### DIFF
--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -119,7 +119,7 @@ function main(name, opt)
         local prefix = "mingw-w64-"
         local arch = (opt.arch == "x86_64" and "x86_64-" or "i686-")
         local msystem = os.getenv("MSYSTEM")
-        if msystem and msystem ~= "MINGW32" and msystem ~= "MINGW64" then
+        if msystem and not msystem:startswith("MINGW") then
             local i, j = msystem:find("%D+")
             name_alt = prefix .. msystem:sub(i, j):lower() .. "-" .. arch .. name
         end

--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -118,9 +118,8 @@ function main(name, opt)
         -- https://www.msys2.org/docs/package-naming/
         local prefix = "mingw-w64-"
         local arch = (opt.arch == "x86_64" and "x86_64-" or "i686-")
-
         local msystem = os.getenv("MSYSTEM")
-        if msystem and msystem ~= "MINGW32" then
+        if msystem and msystem ~= "MINGW32" and msystem ~= "MINGW64" then
             local i, j = msystem:find("%D+")
             name_alt = prefix .. msystem:sub(i, j):lower() .. "-" .. arch .. name
         end

--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -112,14 +112,29 @@ function main(name, opt)
     end
 
     -- for msys2/mingw? mingw-w64-[i686|x86_64]-xxx
+    local name_alt
     if is_subhost("msys") and opt.plat == "mingw" then
         -- try to get the package prefix from the environment first
         -- https://www.msys2.org/docs/package-naming/
-        name = (os.getenv("MINGW_PACKAGE_PREFIX") or (opt.arch == "x86_64" and "mingw-w64-x86_64" or "mingw-w64-i686")) .. "-" .. name
+        local prefix = "mingw-w64-"
+        local arch = (opt.arch == "x86_64" and "x86_64-" or "i686-")
+
+        local msystem = os.getenv("MSYSTEM")
+        if msystem and msystem ~= "MINGW32" then
+            local i, j = msystem:find("%D+")
+            name_alt = prefix .. msystem:sub(i, j):lower() .. "-" .. arch .. name
+        end
+        name = prefix .. arch .. name
     end
 
     -- get package files list
-    local list = try { function() return os.iorunv(pacman.program, {"-Q", "-l", name}) end }
+    local list
+    for _, n in ipairs({name, name_alt}) do
+        list = n and try { function() return os.iorunv(pacman.program, {"-Q", "-l", n}) end }
+        if list then
+            break
+        end
+    end
     if not list then
         return
     end

--- a/xmake/modules/package/manager/pacman/find_package.lua
+++ b/xmake/modules/package/manager/pacman/find_package.lua
@@ -113,7 +113,9 @@ function main(name, opt)
 
     -- for msys2/mingw? mingw-w64-[i686|x86_64]-xxx
     if is_subhost("msys") and opt.plat == "mingw" then
-        name = (opt.arch == "x86_64" and "mingw-w64-x86_64-" or "mingw-w64-i686-") .. name
+        -- try to get the package prefix from the environment first
+        -- https://www.msys2.org/docs/package-naming/
+        name = (os.getenv("MINGW_PACKAGE_PREFIX") or (opt.arch == "x86_64" and "mingw-w64-x86_64" or "mingw-w64-i686")) .. "-" .. name
     end
 
     -- get package files list


### PR DESCRIPTION
On MSYS2 windows, packages have an extra section in the prefix for the environment (mingw32/64, clang32/64, ucrt64). There's an environment variable that's used to check what environment the current user is running in.

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

