### PR TITLE
Include directories for header-only libraries in CMake only support INTERFACE access types

### DIFF
--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -467,7 +467,8 @@ end
 function _add_target_include_directories(cmakelists, target, outputdir)
     local includedirs = _get_configs_from_target(target, "includedirs")
     if #includedirs > 0 then
-        cmakelists:print("target_include_directories(%s PRIVATE", target:name())
+        local access_type = target:kind() == "headeronly" and "INTERFACE" or "PRIVATE"
+        cmakelists:print("target_include_directories(%s %s", target:name(), access_type)
         for _, includedir in ipairs(includedirs) do
             cmakelists:print("    " .. _get_relative_unix_path(includedir, outputdir))
         end


### PR DESCRIPTION
CMake only allows the use of the INTERFACE access type to include directories in header-only libraries.

However, Xmake generates a faulty CMakeLists.txt file when a header-only library has dependencies. This results in the following error message: "target_include_directories may only set INTERFACE properties on INTERFACE targets".

The root cause of this issue is that the include directory function is using a PRIVATE access type instead of INTERFACE. To address this problem, the proposed change checks whether the target is a header-only library and adjusts the access type accordingly.
