### PR TITLE
Use pattern paramter

### DIFF
--- a/xmake/core/sandbox/modules/import/core/base/semver.lua
+++ b/xmake/core/sandbox/modules/import/core/base/semver.lua
@@ -46,7 +46,7 @@ end
 -- semver.match('a.b.c') => nil
 --
 function sandbox_core_base_semver.match(str, pos, pattern)
-    return semver.match(str, pos)
+    return semver.match(str, pos, pattern)
 end
 
 -- is valid version?


### PR DESCRIPTION
I was documenting the semver module when I noticed that the pattern parameter is not passed to the underlying function.