### PR TITLE
Refactor runenvs so renderdoc can store envs

### DIFF
--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -27,7 +27,7 @@ import("core.project.project")
 import("core.platform.platform")
 import("devel.debugger")
 import("private.async.runjobs")
-import("private.action.run.make_runenvs")
+import("private.action.run.runenvs")
 import("private.service.remote_build.action", {alias = "remote_build_action"})
 
 -- run target
@@ -44,23 +44,18 @@ function _do_run_target(target)
     -- get the absolute target file path
     local targetfile = path.absolute(target:targetfile())
 
-    -- add run environments
-    local addrunenvs, setrunenvs = make_runenvs(target)
-    for name, values in pairs(addrunenvs) do
-        os.addenv(name, table.unpack(table.wrap(values)))
-    end
-    for name, value in pairs(setrunenvs) do
-        os.setenv(name, table.unpack(table.wrap(value)))
-    end
+    -- build run environments
+    local addrunenvs, setrunenvs = runenvs.make(target)
 
     -- get run arguments
     local args = table.wrap(option.get("arguments") or target:get("runargs"))
 
     -- debugging?
     if option.get("debug") then
-        debugger.run(targetfile, args, {curdir = rundir})
+        debugger.run(targetfile, args, {curdir = rundir, addrunenvs = addrunenvs, setrunenvs = setrunenvs})
     else
-        os.execv(targetfile, args, {curdir = rundir, detach = option.get("detach")})
+        local envs = runenvs.join(addrunenvs, setrunenvs)
+        os.execv(targetfile, args, {curdir = rundir, detach = option.get("detach"), envs = envs})
     end
 end
 

--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -45,16 +45,16 @@ function _do_run_target(target)
     local targetfile = path.absolute(target:targetfile())
 
     -- build run environments
-    local addrunenvs, setrunenvs = runenvs.make(target)
+    local addenvs, setenvs = runenvs.make(target)
 
     -- get run arguments
     local args = table.wrap(option.get("arguments") or target:get("runargs"))
 
     -- debugging?
     if option.get("debug") then
-        debugger.run(targetfile, args, {curdir = rundir, addrunenvs = addrunenvs, setrunenvs = setrunenvs})
+        debugger.run(targetfile, args, {curdir = rundir, addenvs = addenvs, setenvs = setenvs})
     else
-        local envs = runenvs.join(addrunenvs, setrunenvs)
+        local envs = runenvs.join(addenvs, setenvs)
         os.execv(targetfile, args, {curdir = rundir, detach = option.get("detach"), envs = envs})
     end
 end

--- a/xmake/modules/devel/debugger/run.lua
+++ b/xmake/modules/devel/debugger/run.lua
@@ -259,7 +259,7 @@ function _run_renderdoc(program, argv, opt)
             table.insert(environment, {
                 separator = "Platform style",
                 type = "Append",
-                value = table.concat(values, path.envsep()),
+                value = path.joinenv(values),
                 variable = name
             })
         end
@@ -270,7 +270,7 @@ function _run_renderdoc(program, argv, opt)
             table.insert(environment, {
                 separator = "Platform style",
                 type = "Set",
-                value = table.concat(values, path.envsep()),
+                value = path.joinenv(values),
                 variable = name
             })
         end

--- a/xmake/modules/devel/debugger/run.lua
+++ b/xmake/modules/devel/debugger/run.lua
@@ -51,7 +51,7 @@ function _run_gdb(program, argv, opt)
     table.insert(argv, 1, "--args")
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     os.execv(gdb, argv, table.join(opt, {exclusive = true}))
@@ -74,7 +74,7 @@ function _run_cudagdb(program, argv, opt)
     table.insert(argv, 1, "--args")
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     os.execv(gdb, argv, table.join(opt, {exclusive = true}))
@@ -104,7 +104,7 @@ function _run_lldb(program, argv, opt)
     end
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     os.execv(names[1], argv, table.join(opt, {exclusive = true}))
@@ -125,7 +125,7 @@ function _run_windbg(program, argv, opt)
     table.insert(argv, 1, program)
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     opt.detach = true
@@ -147,7 +147,7 @@ function _run_cudamemcheck(program, argv, opt)
     table.insert(argv, 1, program)
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     os.execv(cudamemcheck, argv, opt)
@@ -168,7 +168,7 @@ function _run_x64dbg(program, argv, opt)
     table.insert(argv, 1, program)
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     opt.detach = true
@@ -190,7 +190,7 @@ function _run_ollydbg(program, argv, opt)
     table.insert(argv, 1, program)
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     opt.detach = true
@@ -212,7 +212,7 @@ function _run_vsjitdebugger(program, argv, opt)
     table.insert(argv, 1, program)
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     opt.detach = true
@@ -235,7 +235,7 @@ function _run_devenv(program, argv, opt)
     table.insert(argv, 2, program)
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     opt.detach = true
@@ -254,8 +254,8 @@ function _run_renderdoc(program, argv, opt)
 
     -- build capture settings
     local environment = {}
-    if opt.addrunenvs then
-        for name, values in pairs(opt.addrunenvs) do
+    if opt.addenvs then
+        for name, values in pairs(opt.addenvs) do
             table.insert(environment, {
                 separator = "Platform style",
                 type = "Append",
@@ -265,8 +265,8 @@ function _run_renderdoc(program, argv, opt)
         end
     end
 
-    if opt.setrunenvs then
-        for name, values in pairs(opt.setrunenvs) do
+    if opt.setenvs then
+        for name, values in pairs(opt.setenvs) do
             table.insert(environment, {
                 separator = "Platform style",
                 type = "Set",
@@ -309,8 +309,8 @@ function _run_renderdoc(program, argv, opt)
 
     -- run renderdoc
     opt.detach = true
-    opt.addrunenvs = nil
-    opt.setrunenvs = nil
+    opt.addenvs = nil
+    opt.setenvs = nil
     os.execv(renderdoc, { capturefile }, opt)
     return true
 end
@@ -333,7 +333,7 @@ function _run_gede(program, argv, opt)
     table.insert(argv, 1, "--no-show-config")
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     os.execv(gede.program, argv, table.join(opt, {exclusive = true}))
@@ -356,7 +356,7 @@ function _run_seergdb(program, argv, opt)
     table.insert(argv, 1, "--start")
 
     -- handle envs
-    opt.envs = runenvs.join(opt.addrunenvs, opt.setrunenvs)
+    opt.envs = runenvs.join(opt.addenvs, opt.setenvs)
 
     -- run it
     os.execv(seergdb.program, argv, table.join(opt, {exclusive = true}))

--- a/xmake/modules/private/action/run/runenvs.lua
+++ b/xmake/modules/private/action/run/runenvs.lua
@@ -75,8 +75,9 @@ function _flatten_envs(envs)
     return flatten_envs
 end
 
+-- join addenvs and setenvs in a common envs table
 function join(addenvs, setenvs)
-    local envs = addenvs and _flatten_envs(addenvs) or {}
+    local envs = os.joinenvs(addenvs and _flatten_envs(addenvs) or {})
     if setenvs then
         table.join2(envs, _flatten_envs(setenvs))
     end

--- a/xmake/modules/private/action/run/runenvs.lua
+++ b/xmake/modules/private/action/run/runenvs.lua
@@ -72,7 +72,6 @@ function _flatten_envs(envs)
     for name, values in pairs(envs) do
         flatten_envs[name] = table.concat(values, path.envsep())
     end
-
     return flatten_envs
 end
 
@@ -81,7 +80,6 @@ function join(addrunenvs, setrunenvs)
     if setrunenvs then
         table.join2(envs, _flatten_envs(setrunenvs))
     end
-
     return envs
 end
 

--- a/xmake/modules/private/action/run/runenvs.lua
+++ b/xmake/modules/private/action/run/runenvs.lua
@@ -70,7 +70,7 @@ end
 function _flatten_envs(envs)
     local flatten_envs = {}
     for name, values in pairs(envs) do
-        flatten_envs[name] = table.concat(values, path.envsep())
+        flatten_envs[name] = path.joinenv(values)
     end
     return flatten_envs
 end

--- a/xmake/modules/private/action/run/runenvs.lua
+++ b/xmake/modules/private/action/run/runenvs.lua
@@ -79,7 +79,7 @@ end
 function join(addenvs, setenvs)
     local envs = os.joinenvs(addenvs and _flatten_envs(addenvs) or {})
     if setenvs then
-        table.join2(envs, _flatten_envs(setenvs))
+        envs = os.joinenvs(envs, _flatten_envs(setenvs))
     end
     return envs
 end

--- a/xmake/modules/private/action/run/runenvs.lua
+++ b/xmake/modules/private/action/run/runenvs.lua
@@ -75,10 +75,10 @@ function _flatten_envs(envs)
     return flatten_envs
 end
 
-function join(addrunenvs, setrunenvs)
-    local envs = addrunenvs and _flatten_envs(addrunenvs) or {}
-    if setrunenvs then
-        table.join2(envs, _flatten_envs(setrunenvs))
+function join(addenvs, setenvs)
+    local envs = addenvs and _flatten_envs(addenvs) or {}
+    if setenvs then
+        table.join2(envs, _flatten_envs(setenvs))
     end
     return envs
 end

--- a/xmake/modules/private/action/run/runenvs.lua
+++ b/xmake/modules/private/action/run/runenvs.lua
@@ -14,8 +14,8 @@
 --
 -- Copyright (C) 2015-present, TBOOX Open Source Group.
 --
--- @author      ruki, OpportunityLiu
--- @file        make_runenvs.lua
+-- @author      ruki, OpportunityLiu, SirLynix
+-- @file        runenvs.lua
 --
 
 -- imports
@@ -66,7 +66,26 @@ function _make_runpath_on_windows(target)
     return pathenv
 end
 
-function main(target)
+-- flatten envs ({PATH = {"A", "B"}} => {PATH = "A;B"})
+function _flatten_envs(envs)
+    local flatten_envs = {}
+    for name, values in pairs(envs) do
+        flatten_envs[name] = table.concat(values, path.envsep())
+    end
+
+    return flatten_envs
+end
+
+function join(addrunenvs, setrunenvs)
+    local envs = addrunenvs and _flatten_envs(addrunenvs) or {}
+    if setrunenvs then
+        table.join2(envs, _flatten_envs(setrunenvs))
+    end
+
+    return envs
+end
+
+function make(target)
 
     -- check
     assert(target)

--- a/xmake/modules/private/xrepo/action/env.lua
+++ b/xmake/modules/private/xrepo/action/env.lua
@@ -27,7 +27,7 @@ import("core.project.config")
 import("core.project.project")
 import("core.tool.toolchain")
 import("lib.detect.find_tool")
-import("private.action.run.make_runenvs")
+import("private.action.run.runenvs")
 import("private.action.require.impl.package")
 import("private.action.require.impl.utils.get_requires")
 
@@ -234,7 +234,7 @@ function _target_addenvs(envs)
             end
         end
         -- add run environments
-        local addrunenvs = make_runenvs(target)
+        local addrunenvs = runenvs.make(target)
         for name, values in pairs(addrunenvs) do
             _addenvs(envs, name, table.unpack(table.wrap(values)))
         end

--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -36,7 +36,7 @@ import("vsutils")
 import("core.cache.memcache")
 import("core.cache.localcache")
 import("private.action.require.install", {alias = "install_requires"})
-import("private.action.run.make_runenvs")
+import("private.action.run.runenvs")
 import("actions.config.configfiles", {alias = "generate_configfiles", rootdir = os.programdir()})
 import("actions.config.configheader", {alias = "generate_configheader", rootdir = os.programdir()})
 import("private.utils.batchcmds")
@@ -324,7 +324,7 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
 
     -- save runenvs
     local runenvs = {}
-    local addrunenvs, setrunenvs = make_runenvs(target)
+    local addrunenvs, setrunenvs = runenvs.make(target)
     for k, v in table.orderpairs(target:pkgenvs()) do
         addrunenvs = addrunenvs or {}
         addrunenvs[k] = table.join(table.wrap(addrunenvs[k]), path.splitenv(v))

--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -323,7 +323,7 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
     targetinfo.rundir = target:rundir()
 
     -- save runenvs
-    local runenvs = {}
+    local targetrunenvs = {}
     local addrunenvs, setrunenvs = runenvs.make(target)
     for k, v in table.orderpairs(target:pkgenvs()) do
         addrunenvs = addrunenvs or {}
@@ -337,25 +337,25 @@ function _make_targetinfo(mode, arch, target, vcxprojdir)
     end
     for k, v in table.orderpairs(addrunenvs) do
         if k:upper() == "PATH" then
-            runenvs[k] = _translate_path(v, vcxprojdir) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
+            targetrunenvs[k] = _translate_path(v, vcxprojdir) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
         else
-            runenvs[k] = path.joinenv(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
+            targetrunenvs[k] = path.joinenv(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
         end
     end
     for k, v in table.orderpairs(setrunenvs) do
         if #v == 1 then
             v = v[1]
             if path.is_absolute(v) and v:startswith(project.directory()) then
-                runenvs[k] = _translate_path(v, vcxprojdir)
+                targetrunenvs[k] = _translate_path(v, vcxprojdir)
             else
-                runenvs[k] = v[1]
+                targetrunenvs[k] = v[1]
             end
         else
-            runenvs[k] = path.joinenv(v)
+            targetrunenvs[k] = path.joinenv(v)
         end
     end
     local runenvstr = {}
-    for k, v in table.orderpairs(runenvs) do
+    for k, v in table.orderpairs(targetrunenvs) do
         table.insert(runenvstr, k .. "=" .. v)
     end
     targetinfo.runenvs = table.concat(runenvstr, "\n")

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -541,7 +541,7 @@ function main(outputdir, vsinfo)
         end
     end
 
-    -- we need set startup project for default or binary target
+    -- we need to set startup project for default or binary target
     -- @see https://github.com/xmake-io/xmake/issues/1249
     local targetnames = {}
     for targetname, target in table.orderpairs(project.targets()) do

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -31,7 +31,7 @@ import("core.tool.toolchain")
 import("core.cache.memcache")
 import("core.cache.localcache")
 import("lib.detect.find_tool")
-import("private.action.run.make_runenvs")
+import("private.action.run.runenvs")
 import("private.action.require.install", {alias = "install_requires"})
 import("actions.config.configheader", {alias = "generate_configheader", rootdir = os.programdir()})
 import("actions.config.configfiles", {alias = "generate_configfiles", rootdir = os.programdir()})
@@ -165,7 +165,7 @@ function _make_targetinfo(mode, arch, target)
 
     -- save runenvs
     local runenvs = {}
-    local addrunenvs, setrunenvs = make_runenvs(target)
+    local addrunenvs, setrunenvs = runenvs.make(target)
     for k, v in table.orderpairs(target:pkgenvs()) do
         addrunenvs = addrunenvs or {}
         addrunenvs[k] = table.join(table.wrap(addrunenvs[k]), path.splitenv(v))
@@ -541,7 +541,7 @@ function main(outputdir, vsinfo)
         end
     end
 
-    -- we need to set startup project for default or binary target
+    -- we need set startup project for default or binary target
     -- @see https://github.com/xmake-io/xmake/issues/1249
     local targetnames = {}
     for targetname, target in table.orderpairs(project.targets()) do

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -164,7 +164,7 @@ function _make_targetinfo(mode, arch, target)
     end
 
     -- save runenvs
-    local runenvs = {}
+    local targetrunenvs = {}
     local addrunenvs, setrunenvs = runenvs.make(target)
     for k, v in table.orderpairs(target:pkgenvs()) do
         addrunenvs = addrunenvs or {}
@@ -180,25 +180,25 @@ function _make_targetinfo(mode, arch, target)
         -- https://github.com/xmake-io/xmake/issues/3391
         v = table.unique(v)
         if k:upper() == "PATH" then
-            runenvs[k] = _make_dirs(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
+            targetrunenvs[k] = _make_dirs(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .. "'))"
         else
-            runenvs[k] = path.joinenv(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
+            targetrunenvs[k] = path.joinenv(v) .. ";$([System.Environment]::GetEnvironmentVariable('" .. k .."'))"
         end
     end
     for k, v in table.orderpairs(setrunenvs) do
         if #v == 1 then
             v = v[1]
             if path.is_absolute(v) and v:startswith(project.directory()) then
-                runenvs[k] = _make_dirs(v)
+                targetrunenvs[k] = _make_dirs(v)
             else
-                runenvs[k] = v[1]
+                targetrunenvs[k] = v[1]
             end
         else
-            runenvs[k] = path.joinenv(v)
+            targetrunenvs[k] = path.joinenv(v)
         end
     end
     local runenvstr = {}
-    for k, v in table.orderpairs(runenvs) do
+    for k, v in table.orderpairs(targetrunenvs) do
         table.insert(runenvstr, k .. "=" .. v)
     end
     targetinfo.runenvs = table.concat(runenvstr, "\n")

--- a/xmake/rules/xcode/application/run.lua
+++ b/xmake/rules/xcode/application/run.lua
@@ -21,7 +21,7 @@
 -- imports
 import("core.base.option")
 import("devel.debugger")
-import("private.action.run.make_runenvs")
+import("private.action.run.runenvs")
 
 -- run on macosx
 function _run_on_macosx(target, opt)
@@ -38,19 +38,13 @@ function _run_on_macosx(target, opt)
     local oldir = os.cd(rundir)
 
     -- add run environments
-    local addrunenvs, setrunenvs = make_runenvs(target)
-    for name, values in pairs(addrunenvs) do
-        os.addenv(name, table.unpack(table.wrap(values)))
-    end
-    for name, value in pairs(setrunenvs) do
-        os.setenv(name, table.unpack(table.wrap(value)))
-    end
+    local addrunenvs, setrunenvs = runenvs.make(target)
 
     -- debugging?
     if option.get("debug") then
-        debugger.run(targetfile, option.get("arguments"))
+        debugger.run(targetfile, option.get("arguments"), {addrunenvs = addrunenvs, setrunenvs = setrunenvs})
     else
-        os.execv(targetfile, option.get("arguments"))
+        os.execv(targetfile, option.get("arguments"), {envs = runenvs.join()})
     end
 
     -- restore the previous directory

--- a/xmake/rules/xcode/application/run.lua
+++ b/xmake/rules/xcode/application/run.lua
@@ -44,7 +44,7 @@ function _run_on_macosx(target, opt)
     if option.get("debug") then
         debugger.run(targetfile, option.get("arguments"), {addrunenvs = addrunenvs, setrunenvs = setrunenvs})
     else
-        os.execv(targetfile, option.get("arguments"), {envs = runenvs.join()})
+        os.execv(targetfile, option.get("arguments"), {envs = runenvs.join(addrunenvs, setrunenvs)})
     end
 
     -- restore the previous directory


### PR DESCRIPTION
Something a bit annoying when using renderdoc as a debugger is that you can't save the environment variables in renderdoc captures files, as renderdoc is not aware of that.

I had to refactor a bit of xmake runenvs handling for that but I think it's for the best