### PR TITLE
Set cppstd for msvc in conan 2.0

### DIFF
--- a/xmake/modules/package/manager/conan/v2/install_package.lua
+++ b/xmake/modules/package/manager/conan/v2/install_package.lua
@@ -178,6 +178,7 @@ function _conan_generate_compiler_profile(profile, configs, opt)
         local vs = assert(config.get("vs"), "vs not found!")
         profile:print("compiler=msvc")
         profile:print("compiler.version=" .. assert(vsvers[vs], "unknown msvc version!"))
+        -- @see https://github.com/conan-io/conan/issues/12387
         if vs >= 2015 then
             profile:print("compiler.cppstd=14")
         end

--- a/xmake/modules/package/manager/conan/v2/install_package.lua
+++ b/xmake/modules/package/manager/conan/v2/install_package.lua
@@ -178,6 +178,9 @@ function _conan_generate_compiler_profile(profile, configs, opt)
         local vs = assert(config.get("vs"), "vs not found!")
         profile:print("compiler=msvc")
         profile:print("compiler.version=" .. assert(vsvers[vs], "unknown msvc version!"))
+        if vs >= 2015 then
+            profile:print("compiler.cppstd=14")
+        end
         local vs_runtime = configs.vs_runtime
         if vs_runtime then
             profile:print("compiler.runtime=" .. (vs_runtime:startswith("MD") and "dynamic" or "static"))


### PR DESCRIPTION
When using Conan 2.0 on Windows, it always try to build from source if `cppstd` is not specified. Adding `compiler.cppstd=14` will make Conan pull prebuilt binaries if it's available, see https://github.com/conan-io/conan/issues/12387.
