### PR TITLE
fix and improve mingw package toolchain

### DIFF
--- a/xmake/toolchains/mingw/check.lua
+++ b/xmake/toolchains/mingw/check.lua
@@ -24,29 +24,24 @@ import("detect.sdks.find_mingw")
 
 -- check the mingw toolchain
 function main(toolchain)
-    local mingw = find_mingw(toolchain:config("mingw") or config.get("mingw"), {verbose = true, bindir = toolchain:bindir(), cross = toolchain:cross()})
-    if not mingw then
-        for _, package in ipairs(toolchain:packages()) do
-            local installdir = package:installdir()
-            if installdir and os.isdir(installdir) then
-                mingw = find_mingw(installdir, {verbose = true, cross = toolchain:cross()})
-                if mingw then
-                    break
-                end
+    local mingw
+    for _, package in ipairs(toolchain:packages()) do
+        local installdir = package:installdir()
+        if installdir and os.isdir(installdir) then
+            mingw = find_mingw(installdir, {verbose = true, cross = toolchain:cross()})
+            if mingw then
+                break
             end
         end
+    end
+    if not mingw then
+        mingw = find_mingw(toolchain:config("mingw") or config.get("mingw"), {verbose = true, bindir = toolchain:bindir(), cross = toolchain:cross()})
     end
     if mingw then
         toolchain:config_set("mingw", mingw.sdkdir)
         toolchain:config_set("cross", mingw.cross)
         toolchain:config_set("bindir", mingw.bindir)
         toolchain:configs_save()
-    else
-        -- failed
-        cprint("${bright color.error}please run:")
-        cprint("    - xmake config --mingw=xxx")
-        cprint("or  - xmake global --mingw=xxx")
-        raise()
+        return true
     end
-    return true
 end


### PR DESCRIPTION
```lua
add_requires("mingw-w64", {system = false})
add_requires("libogg")
target("test")
    add_files("src/*.cpp")
    add_packages("libogg")
    set_toolchains("mingw@mingw-w64")
```

```console
D:\projects\personal\testw>xmake -vD
checking for mingw directory ... no
checkinfo: cannot runv(unzip.exe -v), No such file or directory
checking for unzip ... no
checking for 7z ... D:\projects\personal\xmake\scripts\..\xmake\winenv\bin\7z
checking for git ... ok
checkinfo: cannot runv(gzip.exe --version), No such file or directory
checking for gzip ... no
git rev-parse HEAD
checking for mingw-w64 ... no
checking for cmake ... no
checking for cl.exe ... C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.37.32705\bin\HostX64\x64\cl.exe
checking for Microsoft Visual Studio (x64) version ... 2022
checking for cmake ... no
checking for cmake ... no
finding libogg from xmake ..
checking for xmake::libogg ... no
finding libogg from vcpkg ..
finding libogg from conan ..
checking for libogg ... no
note: install or modify (m) these packages (pass -y to skip confirm)?
in xmake-repo:
  -> mingw-w64 8.1.0
  -> libogg v1.3.4 [toolchains:"mingw@mingw-w64"]
please input: y (y/n/m)

checking for ping ... ok
pinging the host(sourceforge.net) ... 32 ms
pinging the host(gitlab.xiph.org) ... 282 ms
D:\projects\personal\xmake\scripts\..\xmake\winenv\bin\7z x -y x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z -osource.tmp

7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21

Scanning the drive for archives:
1 file, 49370037 bytes (48 MiB)

Extracting archive: x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z
--
Path = x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z
Type = 7z
Physical Size = 49370037
Headers Size = 105634
Method = LZMA2:26 LZMA:20 BCJ2
Solid = +
Blocks = 2

Everything is Ok

Folders: 333
Files: 13203
Size:       457580460
Compressed: 49370037
checking for mingw-w64 ... no
{
  description = "The mingw-w64 project is a complete runtime environment for gcc to support binaries native to Windows 64-bit and 32-bit operating systems.",
  kind = "toolchain",
  name = "mingw-w64",
  repo = {
    branch = "master",
    url = "https://gitee.com/tboox/xmake-repo.git",
    name = "xmake-repo",
    commit = "041f792caf007871839f882f5b4993e6681fe4f1"
  },
  arch = "x64",
  envs = {
    PATH = {
      "bin"
    }
  },
  artifacts = {
    installdir = "C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92"
  },
  version = "8.1.0",
  plat = "windows",
  configs = {
    debug = false,
    shared = false,
    python2 = false
  },
  mode = "release"
}

gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/../libexec/gcc/x86_64-w64-mingw32/8.1.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../../../src/gcc-8.1.0/configure --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --prefix=/mingw64 --with-sysroot=/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64 --enable-shared --enable-static --disable-multilib --enable-languages=c,c++,fortran,lto --enable-libstdcxx-time=yes --enable-threads=posix --enable-libgomp --enable-libatomic --enable-lto --enable-graphite --enable-checking=release --enable-fully-dynamic-string --enable-version-specific-runtime-libs --disable-libstdcxx-pch --disable-libstdcxx-debug --enable-bootstrap --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-gnu-as --with-gnu-ld --with-arch=nocona --with-tune=core2 --with-libiconv --with-system-zlib --with-gmp=/c/mingw810/prerequisites/x86_64-w64-mingw32-static --with-mpfr=/c/mingw810/prerequisites/x86_64-w64-mingw32-static --with-mpc=/c/mingw810/prerequisites/x86_64-w64-mingw32-static --with-isl=/c/mingw810/prerequisites/x86_64-w64-mingw32-static --with-pkgversion='x86_64-posix-seh-rev0, Built by MinGW-W64 project' --with-bugurl=https://sourceforge.net/projects/mingw-w64 CFLAGS='-O2 -pipe -fno-ident -I/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64/opt/include -I/c/mingw810/prerequisites/x86_64-zlib-static/include -I/c/mingw810/prerequisites/x86_64-w64-mingw32-static/include' CXXFLAGS='-O2 -pipe -fno-ident -I/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64/opt/include -I/c/mingw810/prerequisites/x86_64-zlib-static/include -I/c/mingw810/prerequisites/x86_64-w64-mingw32-static/include' CPPFLAGS=' -I/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64/opt/include -I/c/mingw810/prerequisites/x86_64-zlib-static/include -I/c/mingw810/prerequisites/x86_64-w64-mingw32-static/include' LDFLAGS='-pipe -fno-ident -L/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64/opt/lib -L/c/mingw810/prerequisites/x86_64-zlib-static/lib -L/c/mingw810/prerequisites/x86_64-w64-mingw32-static/lib '
Thread model: posix
gcc version 8.1.0 (x86_64-posix-seh-rev0, Built by MinGW-W64 project)
gfortran -v
Using built-in specs.
COLLECT_GCC=gfortran
COLLECT_LTO_WRAPPER=C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/../libexec/gcc/x86_64-w64-mingw32/8.1.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../../../src/gcc-8.1.0/configure --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --prefix=/mingw64 --with-sysroot=/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64 --enable-shared --enable-static --disable-multilib --enable-languages=c,c++,fortran,lto --enable-libstdcxx-time=yes --enable-threads=posix --enable-libgomp --enable-libatomic --enable-lto --enable-graphite --enable-checking=release --enable-fully-dynamic-string --enable-version-specific-runtime-libs --disable-libstdcxx-pch --disable-libstdcxx-debug --enable-bootstrap --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-gnu-as --with-gnu-ld --with-arch=nocona --with-tune=core2 --with-libiconv --with-system-zlib --with-gmp=/c/mingw810/prerequisites/x86_64-w64-mingw32-static --with-mpfr=/c/mingw810/prerequisites/x86_64-w64-mingw32-static --with-mpc=/c/mingw810/prerequisites/x86_64-w64-mingw32-static --with-isl=/c/mingw810/prerequisites/x86_64-w64-mingw32-static --with-pkgversion='x86_64-posix-seh-rev0, Built by MinGW-W64 project' --with-bugurl=https://sourceforge.net/projects/mingw-w64 CFLAGS='-O2 -pipe -fno-ident -I/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64/opt/include -I/c/mingw810/prerequisites/x86_64-zlib-static/include -I/c/mingw810/prerequisites/x86_64-w64-mingw32-static/include' CXXFLAGS='-O2 -pipe -fno-ident -I/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64/opt/include -I/c/mingw810/prerequisites/x86_64-zlib-static/include -I/c/mingw810/prerequisites/x86_64-w64-mingw32-static/include' CPPFLAGS=' -I/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64/opt/include -I/c/mingw810/prerequisites/x86_64-zlib-static/include -I/c/mingw810/prerequisites/x86_64-w64-mingw32-static/include' LDFLAGS='-pipe -fno-ident -L/c/mingw810/x86_64-810-posix-seh-rt_v6-rev0/mingw64/opt/lib -L/c/mingw810/prerequisites/x86_64-zlib-static/lib -L/c/mingw810/prerequisites/x86_64-w64-mingw32-static/lib '
Thread model: posix
gcc version 8.1.0 (x86_64-posix-seh-rev0, Built by MinGW-W64 project)
  => install mingw-w64 8.1.0 .. ok
D:\projects\personal\xmake\scripts\..\xmake\winenv\bin\7z x -y ogg-v1.3.4.tar.gz -oC:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_5EF65DFA3D91450083F6E48F8DEFEA50.tar

7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21

Scanning the drive for archives:
1 file, 255911 bytes (250 KiB)

Extracting archive: ogg-v1.3.4.tar.gz
--
Path = ogg-v1.3.4.tar.gz
Type = gzip
Headers Size = 10

Everything is Ok

Size:       860160
Compressed: 255911
D:\projects\personal\xmake\scripts\..\xmake\winenv\bin\7z x -y C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_5EF65DFA3D91450083F6E48F8DEFEA50.tar\ogg-v1.3.4.tar -osource.tmp

7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21

Scanning the drive for archives:
1 file, 860160 bytes (840 KiB)

Extracting archive: C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_5EF65DFA3D91450083F6E48F8DEFEA50.tar\ogg-v1.3.4.tar
--
Path = C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_5EF65DFA3D91450083F6E48F8DEFEA50.tar\ogg-v1.3.4.tar
Type = tar
Physical Size = 860160
Headers Size = 81920
Code Page = UTF-8

Everything is Ok

Folders: 13
Files: 129
Size:       745194
Compressed: 860160
patching C:\Users\wangrunqing\AppData\Local\.xmake\repositories\xmake-repo\packages\l\libogg\patches\1.3.4\macos_fix.patch to libogg-v1.3.4 ..
git apply --reject --ignore-whitespace C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\patches\libogg\v1.3.4\macos_fix.patch
Checking patch include/ogg/os_types.h...
Applied patch include/ogg/os_types.h cleanly.
checking for mingw directory ... C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92
checking for x86_64-w64-mingw32-gcc ... C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-gcc
checking for the c compiler (cc) ... x86_64-w64-mingw32-gcc
checking for x86_64-w64-mingw32-g++ ... C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-g++
checking for the c++ compiler (cxx) ... x86_64-w64-mingw32-g++
checking for x86_64-w64-mingw32-gcc ... C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-gcc
checking for the assember (as) ... x86_64-w64-mingw32-gcc
checking for C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\ar ... ok
checking for the static library archiver (ar) ... ar
checking for C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\ranlib ... ok
checking for unknown toolkind ranlib (ranlib) ... ranlib
checkinfo: @programdir\core\sandbox\modules\os.lua:273: cannot runv(x86_64-w64-mingw32-windres.exe -i C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_2B150B7AFC5E43008CE6FEEDB3707670.rc -o C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_FA33C4F1B92847108B121958D2CFAC70.o), No such file or directory
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:921]:
    [@programdir\core\sandbox\modules\os.lua:273]: in function 'runv'
    [@programdir\modules\detect\tools\find_windres.lua:48]: in function '_check'
    [@programdir\modules\detect\tools\find_windres.lua:69]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:280]:
    [...\core\sandbox\modules\import\lib\detect\find_program.lua:68]: in function '_do_check'
    [...\core\sandbox\modules\import\lib\detect\find_program.lua:91]: in function '_check'
    [...\core\sandbox\modules\import\lib\detect\find_program.lua:245]: in function '_find'
    [...\core\sandbox\modules\import\lib\detect\find_program.lua:314]:
    [@programdir\modules\lib\detect\find_tool.lua:31]: in function '_find_from_modules'
    [@programdir\modules\lib\detect\find_tool.lua:42]: in function '_find_tool'
    [@programdir\modules\lib\detect\find_tool.lua:88]:
    [@programdir\core\tool\toolchain.lua:470]: in function '_checktool'
    [@programdir\core\tool\toolchain.lua:210]: in function 'tool'
    [@programdir\core\tool\toolchain.lua:740]:
    [@programdir\core\package\package.lua:1049]: in function 'index'
    [@programdir\core\package\package.lua:1027]: in function 'build_getenv'
    [@programdir\modules\package\tools\cmake.lua:437]: in function '_get_configs_for_mingw'
    [@programdir\modules\package\tools\cmake.lua:700]: in function '_get_configs'
    [@programdir\modules\package\tools\cmake.lua:983]: in function 'install'
    [...make\repositories\xmake-repo\packages\l\libogg\xmake.lua:29]: in function 'script'
    [...dir\modules\private\action\require\impl\utils\filter.lua:125]: in function 'call'
    [...\modules\private\action\require\impl\actions\install.lua:364]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:280]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [...\modules\private\action\require\impl\actions\install.lua:328]:
    [...modules\private\action\require\impl\install_packages.lua:479]: in function 'jobfunc'
    [@programdir\modules\private\async\runjobs.lua:232]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:280]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [@programdir\modules\private\async\runjobs.lua:218]: in function 'cotask'
    [@programdir\core\base\scheduler.lua:404]:

checking for x86_64-w64-mingw32-windres ... no
checking for the windows resource compiler (mrc: x86_64-w64-mingw32-windres) ... no
checking for C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\windres ... ok
checking for the windows resource compiler (mrc) ... windres
checking for x86_64-w64-mingw32-g++ ... C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-g++
checking for the linker (ld) ... x86_64-w64-mingw32-g++
checking for x86_64-w64-mingw32-g++ ... C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-g++
checking for the shared library linker (sh) ... x86_64-w64-mingw32-g++
checking for cmake ... ok
checkinfo: cannot runv(pkgconf.exe --version), No such file or directory
checking for pkgconf ... no
cmake -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=C:\Users\wangrunqing\AppData\Local\.xmake\packages\l\libogg\v1.3.4\9a5df378fe804aac801f02202e7cd72e -DCMAKE_INSTALL_LIBDIR:PATH=lib -G "MinGW Makefiles" -DCMAKE_RANLIB=C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/ranlib.exe -DCMAKE_ASM_FLAGS=-m64 -DCMAKE_C_FLAGS=-m64 -DCMAKE_ASM_COMPILER=C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/x86_64-w64-mingw32-gcc.exe -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_EXE_LINKER_FLAGS=-m64 -DCMAKE_AR=C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/ar.exe -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH -DCMAKE_MAKE_PROGRAM=C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\mingw32-make.exe -DCMAKE_FIND_ROOT_PATH=C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92 -DHAVE_FLAG_SEARCH_PATHS_FIRST=0 -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER -DCMAKE_C_COMPILER=C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/x86_64-w64-mingw32-gcc.exe -DCMAKE_CXX_FLAGS=-m64 -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH -DCMAKE_CXX_COMPILER=C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/x86_64-w64-mingw32-g++.exe -DCMAKE_RC_COMPILER=C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/windres.exe -DCMAKE_STATIC_LINKER_FLAGS= -DCMAKE_SHARED_LINKER_FLAGS=-m64 C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source
-- The C compiler identification is GNU 8.1.0
-- The CXX compiler identification is GNU 8.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/x86_64-w64-mingw32-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/x86_64-w64-mingw32-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring libogg 1.3.4
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Looking for include file stdint.h
-- Looking for include file stdint.h - found
-- Looking for include file sys/types.h
-- Looking for include file sys/types.h - found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of int16_t
-- Check size of int16_t - done
-- Check size of uint16_t
-- Check size of uint16_t - done
-- Check size of u_int16_t
-- Check size of u_int16_t - failed
-- Check size of int32_t
-- Check size of int32_t - done
-- Check size of uint32_t
-- Check size of uint32_t - done
-- Check size of u_int32_t
-- Check size of u_int32_t - failed
-- Check size of int64_t
-- Check size of int64_t - done
-- Check size of short
-- Check size of short - done
-- Check size of int
-- Check size of int - done
-- Check size of long
-- Check size of long - done
-- Check size of long long
-- Check size of long long - done
-- Configuring done (15.6s)
-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_ASM_COMPILER
    CMAKE_ASM_FLAGS
    CMAKE_FIND_ROOT_PATH
    CMAKE_FIND_ROOT_PATH_MODE_LIBRARY
    HAVE_FLAG_SEARCH_PATHS_FIRST


-- Build files have been written to: C:/Users/wangrunqing/AppData/Local/.xmake/cache/packages/2307/l/libogg/v1.3.4/source/build_9a5df378
C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\mingw32-make.exe -j6 VERBOSE=1
C:\Users\wangrunqing\AppData\Local\.xmake\packages\c\cmake\3.26.4\4d23fc87455a4a1c819e093bd8456f0f\bin\cmake.exe -SC:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source -BC:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\build_9a5df378 --check-build-system CMakeFiles\Makefile.cmake 0
C:\Users\wangrunqing\AppData\Local\.xmake\packages\c\cmake\3.26.4\4d23fc87455a4a1c819e093bd8456f0f\bin\cmake.exe -E cmake_progress_start C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\build_9a5df378\CMakeFiles C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\build_9a5df378\\CMakeFiles\progress.marks
C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/mingw32-make  -f CMakeFiles\Makefile2 all
mingw32-make[1]: Entering directory 'C:/Users/wangrunqing/AppData/Local/.xmake/cache/packages/2307/l/libogg/v1.3.4/source/build_9a5df378'
C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/mingw32-make  -f CMakeFiles\ogg.dir\build.make CMakeFiles/ogg.dir/depend
mingw32-make[2]: Entering directory 'C:/Users/wangrunqing/AppData/Local/.xmake/cache/packages/2307/l/libogg/v1.3.4/source/build_9a5df378'
C:\Users\wangrunqing\AppData\Local\.xmake\packages\c\cmake\3.26.4\4d23fc87455a4a1c819e093bd8456f0f\bin\cmake.exe -E cmake_depends "MinGW Makefiles" C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\build_9a5df378 C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\build_9a5df378 C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\build_9a5df378\CMakeFiles\ogg.dir\DependInfo.cmake --color=
mingw32-make[2]: Leaving directory 'C:/Users/wangrunqing/AppData/Local/.xmake/cache/packages/2307/l/libogg/v1.3.4/source/build_9a5df378'
C:/Users/wangrunqing/AppData/Local/.xmake/packages/m/mingw-w64/8.1.0/56aa6e64d5e4436e887c6df8f2e26e92/bin/mingw32-make  -f CMakeFiles\ogg.dir\build.make CMakeFiles/ogg.dir/build
mingw32-make[2]: Entering directory 'C:/Users/wangrunqing/AppData/Local/.xmake/cache/packages/2307/l/libogg/v1.3.4/source/build_9a5df378'
[ 33%] Building C object CMakeFiles/ogg.dir/src/bitwise.c.obj
C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-gcc.exe  @CMakeFiles/ogg.dir/includes_C.rsp -m64 -O3 -DNDEBUG -MD -MT CMakeFiles/ogg.dir/src/bitwise.c.obj -MF CMakeFiles\ogg.dir\src\bitwise.c.obj.d -o CMakeFiles\ogg.dir\src\bitwise.c.obj -c C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\src\bitwise.c
[ 66%] Building C object CMakeFiles/ogg.dir/src/framing.c.obj
C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-gcc.exe  @CMakeFiles/ogg.dir/includes_C.rsp -m64 -O3 -DNDEBUG -MD -MT CMakeFiles/ogg.dir/src/framing.c.obj -MF CMakeFiles\ogg.dir\src\framing.c.obj.d -o CMakeFiles\ogg.dir\src\framing.c.obj -c C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\src\framing.c
[100%] Linking C static library libogg.a
C:\Users\wangrunqing\AppData\Local\.xmake\packages\c\cmake\3.26.4\4d23fc87455a4a1c819e093bd8456f0f\bin\cmake.exe -P CMakeFiles\ogg.dir\cmake_clean_target.cmake
C:\Users\wangrunqing\AppData\Local\.xmake\packages\c\cmake\3.26.4\4d23fc87455a4a1c819e093bd8456f0f\bin\cmake.exe -E cmake_link_script CMakeFiles\ogg.dir\link.txt --verbose=1
C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\ar.exe qc libogg.a CMakeFiles/ogg.dir/src/bitwise.c.obj CMakeFiles/ogg.dir/src/framing.c.obj
C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\ranlib.exe libogg.a
mingw32-make[2]: Leaving directory 'C:/Users/wangrunqing/AppData/Local/.xmake/cache/packages/2307/l/libogg/v1.3.4/source/build_9a5df378'
[100%] Built target ogg
mingw32-make[1]: Leaving directory 'C:/Users/wangrunqing/AppData/Local/.xmake/cache/packages/2307/l/libogg/v1.3.4/source/build_9a5df378'
C:\Users\wangrunqing\AppData\Local\.xmake\packages\c\cmake\3.26.4\4d23fc87455a4a1c819e093bd8456f0f\bin\cmake.exe -E cmake_progress_start C:\Users\wangrunqing\AppData\Local\.xmake\cache\packages\2307\l\libogg\v1.3.4\source\build_9a5df378\CMakeFiles 0
C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\mingw32-make.exe install
[100%] Built target ogg
Install the project...
-- Install configuration: "Release"
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/lib/libogg.a
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/include/ogg/config_types.h
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/include/ogg/ogg.h
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/include/ogg/os_types.h
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/lib/cmake/Ogg/OggTargets.cmake
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/lib/cmake/Ogg/OggTargets-release.cmake
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/lib/cmake/Ogg/OggConfig.cmake
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/lib/cmake/Ogg/OggConfigVersion.cmake
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/lib/pkgconfig/ogg.pc
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/framing.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/index.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/oggstream.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/ogg-multiplex.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/fish_xiph_org.png
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/multiplex1.png
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/packets.png
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/pages.png
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/stream.png
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/vorbisword2.png
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/white-ogg.png
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/white-xifish.png
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/rfc3533.txt
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/rfc5334.txt
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/skeleton.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/bitpacking.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/datastructures.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/decoding.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/encoding.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/general.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/index.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/Makefile.am
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_adv.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_adv1.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_bits.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_buffer.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_bytes.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_get_buffer.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_look.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_look1.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_read.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_read1.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_readinit.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_reset.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_write.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_writealign.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_writecheck.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_writeclear.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_writecopy.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_writeinit.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/oggpack_writetrunc.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_iovec_t.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_packet.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_packet_clear.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_bos.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_checksum_set.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_continued.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_eos.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_granulepos.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_packets.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_pageno.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_serialno.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_page_version.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_check.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_clear.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_destroy.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_eos.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_flush.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_flush_fill.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_init.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_iovecin.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_packetin.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_packetout.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_packetpeek.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_pagein.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_pageout.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_pageout_fill.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_reset.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_reset_serialno.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_stream_state.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_buffer.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_check.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_clear.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_destroy.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_init.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_pageout.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_pageseek.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_reset.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_state.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/ogg_sync_wrote.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/overview.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/reference.html
-- Installing: C:/Users/wangrunqing/AppData/Local/.xmake/packages/l/libogg/v1.3.4/9a5df378fe804aac801f02202e7cd72e/share/doc/libogg/html/libogg/style.css
finding libogg from xmake ..
checking for xmake::libogg ... libogg v1.3.4
{
  links = {
    "ogg"
  },
  version = "v1.3.4",
  static = true,
  libfiles = {
    "C:\Users\wangrunqing\AppData\Local\.xmake\packages\l\libogg\v1.3.4\9a5df378fe804aac801f02202e7cd72e\lib\libogg.a"
  },
  sysincludedirs = {
    "C:\Users\wangrunqing\AppData\Local\.xmake\packages\l\libogg\v1.3.4\9a5df378fe804aac801f02202e7cd72e\include"
  },
  linkdirs = {
    "C:\Users\wangrunqing\AppData\Local\.xmake\packages\l\libogg\v1.3.4\9a5df378fe804aac801f02202e7cd72e\lib"
  }
}

> C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-gcc -c -m64 -isystem C:\Users\wangrunqing\AppData\Local\.xmake\packages\l\libogg\v1.3.4\9a5df378fe804aac801f02202e7cd72e\include -o C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_4A71AA6E3C46417085FEE58141FFF8E0.o C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_40608C4E43524700B5C9FE259316A532.c
checking for C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-gcc ... ok
checking for flags (-fdiagnostics-color=always) ... ok
> x86_64-w64-mingw32-gcc "-fdiagnostics-color=always" "-m64"
> C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-g++ -o C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_4A71AA6E3C46417085FEE58141FFF8E0.b C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_4A71AA6E3C46417085FEE58141FFF8E0.o -m64 -LC:\Users\wangrunqing\AppData\Local\.xmake\packages\l\libogg\v1.3.4\9a5df378fe804aac801f02202e7cd72e\lib -logg
> checking for c includes(stdint.h, ogg/ogg.h)
> checking for c funcs(ogg_sync_init)
> checking for c links(ogg)
> checking for c snippet(has_cfuncs)
  => install libogg v1.3.4 .. ok
checking for C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-g++ ... ok
checking for flags (-fvisibility-inlines-hidden) ... ok
> x86_64-w64-mingw32-g++ "-fvisibility-inlines-hidden" "-m64"
checking for flags (-O3) ... ok
> x86_64-w64-mingw32-g++ "-O3" "-m64"
checking for flags (-DNDEBUG) ... ok
> x86_64-w64-mingw32-g++ "-DNDEBUG" "-m64"
[ 25%]: cache compiling.release src\main.cpp
C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-g++ -c -m64 -fvisibility=hidden -fvisibility-inlines-hidden -O3 -isystem C:\Users\wangrunqing\AppData\Local\.xmake\packages\l\libogg\v1.3.4\9a5df378fe804aac801f02202e7cd72e\include -DNDEBUG -o build\.objs\testw\mingw\x86_64\release\src\main.cpp.obj src\main.cpp
checking for flags (-MMD -MF) ... ok
> x86_64-w64-mingw32-g++ "-MMD" "-MF" "C:\Users\WANGRU~1\AppData\Local\Temp\.xmake\230727\_25FAA87AB7AE45408AB4AB78DFA1F880" "-m64"
checking for flags (-fdiagnostics-color=always) ... ok
> x86_64-w64-mingw32-g++ "-fdiagnostics-color=always" "-m64"
[ 50%]: linking.release testw.exe
C:\Users\wangrunqing\AppData\Local\.xmake\packages\m\mingw-w64\8.1.0\56aa6e64d5e4436e887c6df8f2e26e92\bin\x86_64-w64-mingw32-g++ -o build\mingw\x86_64\release\testw.exe build\.objs\testw\mingw\x86_64\release\src\main.cpp.obj -m64 -LC:\Users\wangrunqing\AppData\Local\.xmake\packages\l\libogg\v1.3.4\9a5df378fe804aac801f02202e7cd72e\lib -s -logg

build cache stats:
cache directory: build\.build_cache
cache hit rate: 50%
cache hit: 1
cache miss: 1
new cached files: 1
remote cache hit: 0
remote new cached files: 0
preprocess failed: 0
compile fallback count: 0

[100%]: build ok, spent 2.047s
```