### PR TITLE
Add win_flex and win_bison binary support.

### DIFF
--- a/xmake/modules/detect/tools/find_bison.lua
+++ b/xmake/modules/detect/tools/find_bison.lua
@@ -38,13 +38,9 @@ import("lib.detect.find_programver")
 function main(opt)
     opt = opt or {}
     local program = find_program(opt.program or "bison", opt)
-
-    -- try win_bison if bison is not found on windows
-    if not program and is_host("windows") then
+    if not program and not opt.program and is_host("windows") then
         program = find_program("win_bison", opt)
     end
-
-    -- find program version
     local version = nil
     if program and opt and opt.version then
         version = find_programver(program, opt)

--- a/xmake/modules/detect/tools/find_bison.lua
+++ b/xmake/modules/detect/tools/find_bison.lua
@@ -43,6 +43,11 @@ function main(opt)
     -- find program
     local program = find_program(opt.program or "bison", opt)
 
+    -- try win_bison if bison is not found on windows
+    if not program and not opt.program and os.host() == "windows" then
+        program = find_program("win_bison", opt)
+    end
+
     -- find program version
     local version = nil
     if program and opt and opt.version then

--- a/xmake/modules/detect/tools/find_bison.lua
+++ b/xmake/modules/detect/tools/find_bison.lua
@@ -44,8 +44,8 @@ function main(opt)
     local program = find_program(opt.program or "bison", opt)
 
     -- try win_bison if bison is not found on windows
-    if not program and not opt.program and os.host() == "windows" then
-        program = find_program("win_bison", opt)
+    if not program and is_host("windows") then
+        program = find_program("win_bison.exe", opt)
     end
 
     -- find program version

--- a/xmake/modules/detect/tools/find_bison.lua
+++ b/xmake/modules/detect/tools/find_bison.lua
@@ -36,16 +36,12 @@ import("lib.detect.find_programver")
 -- @endcode
 --
 function main(opt)
-
-    -- init options
     opt = opt or {}
-
-    -- find program
     local program = find_program(opt.program or "bison", opt)
 
     -- try win_bison if bison is not found on windows
     if not program and is_host("windows") then
-        program = find_program("win_bison.exe", opt)
+        program = find_program("win_bison", opt)
     end
 
     -- find program version
@@ -53,7 +49,5 @@ function main(opt)
     if program and opt and opt.version then
         version = find_programver(program, opt)
     end
-
-    -- ok?
     return program, version
 end

--- a/xmake/modules/detect/tools/find_flex.lua
+++ b/xmake/modules/detect/tools/find_flex.lua
@@ -36,11 +36,7 @@ import("lib.detect.find_programver")
 -- @endcode
 --
 function main(opt)
-
-    -- init options
     opt = opt or {}
-
-    -- find program
     local program = find_program(opt.program or "flex", opt)
 
     -- try win_flex if flex is not found on windows
@@ -53,7 +49,5 @@ function main(opt)
     if program and opt and opt.version then
         version = find_programver(program, opt)
     end
-
-    -- ok?
     return program, version
 end

--- a/xmake/modules/detect/tools/find_flex.lua
+++ b/xmake/modules/detect/tools/find_flex.lua
@@ -38,13 +38,9 @@ import("lib.detect.find_programver")
 function main(opt)
     opt = opt or {}
     local program = find_program(opt.program or "flex", opt)
-
-    -- try win_flex if flex is not found on windows
-    if not program and is_host("windows") then
+    if not program and not opt.program and is_host("windows") then
         program = find_program("win_flex", opt)
     end
-
-    -- find program version
     local version = nil
     if program and opt and opt.version then
         version = find_programver(program, opt)

--- a/xmake/modules/detect/tools/find_flex.lua
+++ b/xmake/modules/detect/tools/find_flex.lua
@@ -43,6 +43,11 @@ function main(opt)
     -- find program
     local program = find_program(opt.program or "flex", opt)
 
+    -- try win_flex if flex is not found on windows
+    if not program and not opt.program and os.host() == "windows" then
+        program = find_program("win_flex", opt)
+    end
+
     -- find program version
     local version = nil
     if program and opt and opt.version then

--- a/xmake/modules/detect/tools/find_flex.lua
+++ b/xmake/modules/detect/tools/find_flex.lua
@@ -44,7 +44,7 @@ function main(opt)
     local program = find_program(opt.program or "flex", opt)
 
     -- try win_flex if flex is not found on windows
-    if not program and not opt.program and os.host() == "windows" then
+    if not program and is_host("windows") then
         program = find_program("win_flex", opt)
     end
 


### PR DESCRIPTION
This PR solves flex/bison not found issue when you installed win_flex_bison package, which will use the binary name win_flex, win_bison instead of original flex/bison names. 