### PR TITLE
vsproject generation: handle filegroups merging

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -589,8 +589,24 @@ function make(outputdir, vsinfo)
                 table.sort(_target.headerfiles)
 
                 -- save file groups
-                _target.filegroups = target:get("filegroups")
-                _target.filegroups_extraconf = target:extraconf("filegroups")
+                _target.filegroups = table.unique(table.join(_target.filegroups or {}, target:get("filegroups")))
+                
+                for filegroup, groupconf in pairs(target:extraconf("filegroups")) do
+                    _target.filegroups_extraconf = _target.filegroups_extraconf or {}
+                    local mergedconf = _target.filegroups_extraconf[filegroup]
+                    if not mergedconf then
+                        mergedconf = {}
+                        _target.filegroups_extraconf[filegroup] = mergedconf
+                    end
+
+                    if groupconf.rootdir then
+                        mergedconf.rootdir = table.unique(table.join(mergedconf.rootdir or {}, table.wrap(groupconf.rootdir)))
+                    end
+                    if groupconf.files then
+                        mergedconf.files = table.unique(table.join(mergedconf.files or {}, table.wrap(groupconf.files)))
+                    end
+                    mergedconf.plain = groupconf.plain or mergedconf.plain
+                end
 
                 -- make target headers
                 _make_targetheaders(mode, arch, target, mode_idx == #vsinfo.modes and arch_idx == 2)

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj_filters.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj_filters.lua
@@ -103,6 +103,10 @@ function _make_filter(filepath, target, vcxprojdir)
                         break
                     end
                 end
+                -- stop once a rootdir matches
+                if filter then
+                    break
+                end
             end
         end
     end

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj_filters.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj_filters.lua
@@ -100,14 +100,15 @@ function _make_filter(filepath, target, vcxprojdir)
                         if filter and filter == '.' then
                             filter = nil
                         end
-                        break
+                        goto found_filter
                     end
                 end
                 -- stop once a rootdir matches
                 if filter then
-                    break
+                    goto found_filter
                 end
             end
+            ::found_filter::
         end
     end
     if not filter and not is_plain then

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj_filters.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj_filters.lua
@@ -76,30 +76,32 @@ function _make_filter(filepath, target, vcxprojdir)
             local extraconf = filegroups_extraconf[filegroup] or {}
             local rootdir = extraconf.rootdir
             assert(rootdir, "please set root directory, e.g. add_filegroups(%s, {rootdir = 'xxx'})", filegroup)
-            if not path.is_absolute(rootdir) then
-                rootdir = path.absolute(rootdir, scriptdir)
-            end
-            local fileitem = path.relative(filepath, rootdir)
-            local files = extraconf.files or "**"
-            local mode = extraconf.mode
-            for _, filepattern in ipairs(files) do
-                filepattern = path.pattern(path.absolute(path.join(rootdir, filepattern)))
-                if filepath:match(filepattern) then
-                    if mode == "plain" then
-                        filter = path.normalize(filegroup)
-                        is_plain = true
-                    else
-                        -- file tree mode (default)
-                        if filegroup ~= "" then
-                            filter = path.normalize(path.join(filegroup, path.directory(fileitem)))
+            for _, rootdir in ipairs(table.wrap(rootdir)) do
+                if not path.is_absolute(rootdir) then
+                    rootdir = path.absolute(rootdir, scriptdir)
+                end
+                local fileitem = path.relative(filepath, rootdir)
+                local files = extraconf.files or "**"
+                local mode = extraconf.mode
+                for _, filepattern in ipairs(files) do
+                    filepattern = path.pattern(path.absolute(path.join(rootdir, filepattern)))
+                    if filepath:match(filepattern) then
+                        if mode == "plain" then
+                            filter = path.normalize(filegroup)
+                            is_plain = true
                         else
-                            filter = path.normalize(path.directory(fileitem))
+                            -- file tree mode (default)
+                            if filegroup ~= "" then
+                                filter = path.normalize(path.join(filegroup, path.directory(fileitem)))
+                            else
+                                filter = path.normalize(path.directory(fileitem))
+                            end
                         end
+                        if filter and filter == '.' then
+                            filter = nil
+                        end
+                        break
                     end
-                    if filter and filter == '.' then
-                        filter = nil
-                    end
-                    break
                 end
             end
         end

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -352,6 +352,10 @@ function _make_filter(filepath, target, vcxprojdir)
                         break
                     end
                 end
+                -- stop once a rootdir matches
+                if filter then
+                    break
+                end
             end
         end
     end

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -349,14 +349,15 @@ function _make_filter(filepath, target, vcxprojdir)
                         if filter and filter == '.' then
                             filter = nil
                         end
-                        break
+                        goto found_filter
                     end
                 end
                 -- stop once a rootdir matches
                 if filter then
-                    break
+                    goto found_filter
                 end
             end
+            ::found_filter::
         end
     end
     if not filter and not is_plain then


### PR DESCRIPTION
I noticed an issue when generating a vs project using filegroups that were not the same across modes.

For example:
```lua
rule("natvis")
    on_config(function (target)
        for name, pkg in pairs(target:pkgs()) do
            local includedir = path.join(pkg:installdir(), "include")
            local natvis = os.files(path.join(includedir, "**.natvis"))
            if #natvis > 0 then
                local groups = table.wrap(target:get("filegroups"))
                if not table.find(groups, name) then
                    target:add("headerfiles", natvis, { install = false })
                    target:add("filegroups", name, { rootdir = includedir })
                end
            end
        end
    end)

add_rules("mode.debug", "mode.release", "natvis")

set_runtimes(is_mode("debug") and "MDd" or "MD")

add_requires("joltphysics")

target("example")
    add_files("src/*.cpp")
    add_packages("joltphysics")
```

this works fine, but will add different filegroups in debug and in release mode (because of different vs_runtime), with the current code one filegroup will override the other and it will generate an absolute path filter chain.

this fixes it by merging filegroups confs or a target across modes.