### PR TITLE
Use `cargo metadata` to fetch the name set of cargo libraries

### DIFF
--- a/tests/projects/rust/cargo_deps_cross_build/Cargo.toml
+++ b/tests/projects/rust/cargo_deps_cross_build/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 spin = "^0.9"
+
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+aarch64-cpu = "^9.3"

--- a/xmake/modules/package/manager/cargo/find_package.lua
+++ b/xmake/modules/package/manager/cargo/find_package.lua
@@ -87,7 +87,7 @@ end
 function _get_names_of_libraries(name, target, configs)
     local names = hashset.new()
     if configs.cargo_toml then
-        local cargo = assert(find_tool("cargo"), "cargo not found! Please ensure Rust has been installed")
+        local cargo = assert(find_tool("cargo"), "cargo not found!")
         local cargo_args = {"metadata", "--format-version", "1", "--manifest-path", configs.cargo_toml, "--color", "never"}
         if check_target(target, true) then
             table.insert(cargo_args, "--filter-platform")

--- a/xmake/modules/package/manager/cargo/find_package.lua
+++ b/xmake/modules/package/manager/cargo/find_package.lua
@@ -84,12 +84,13 @@ function _get_libname(name)
 end
 
 -- get the name set of libraries
-function _get_names_of_libraries(name, target, configs)
+function _get_names_of_libraries(name, opt)
+    local configs = opt.configs or {}
     local names = hashset.new()
     if configs.cargo_toml then
         local cargo = assert(find_tool("cargo"), "cargo not found!")
         local cargo_args = {"metadata", "--format-version", "1", "--manifest-path", configs.cargo_toml, "--color", "never"}
-        local target = check_target(target, true) and target or nil
+        local target = check_target(opt.arch, true) and opt.arch or nil
         if target then
             table.insert(cargo_args, "--filter-platform")
             table.insert(cargo_args, target)
@@ -143,7 +144,7 @@ function main(name, opt)
     local configs = opt.configs or {}
 
     -- get names of libraries
-    local names = _get_names_of_libraries(name, opt.arch, configs)
+    local names = _get_names_of_libraries(name, opt)
     assert(not names:empty())
 
     local frameworkdirs

--- a/xmake/modules/package/manager/cargo/find_package.lua
+++ b/xmake/modules/package/manager/cargo/find_package.lua
@@ -89,7 +89,8 @@ function _get_names_of_libraries(name, target, configs)
     if configs.cargo_toml then
         local cargo = assert(find_tool("cargo"), "cargo not found!")
         local cargo_args = {"metadata", "--format-version", "1", "--manifest-path", configs.cargo_toml, "--color", "never"}
-        if check_target(target, true) then
+        local target = check_target(target, true) and target or nil
+        if target then
             table.insert(cargo_args, "--filter-platform")
             table.insert(cargo_args, target)
         end

--- a/xmake/modules/package/manager/cargo/install_package.lua
+++ b/xmake/modules/package/manager/cargo/install_package.lua
@@ -22,6 +22,7 @@
 import("core.base.option")
 import("core.project.config")
 import("lib.detect.find_tool")
+import("private.tools.rust.check_target")
 
 -- install package
 --
@@ -55,11 +56,7 @@ function main(name, opt)
     -- get target
     -- e.g. x86_64-pc-windows-msvc, aarch64-unknown-none
     -- @see https://github.com/xmake-io/xmake/issues/4049
-    local target
-    local arch = opt.arch
-    if arch and #arch:split("%-") > 1 then
-        target = arch
-    end
+    local target = check_target(opt.arch, true) and opt.arch or nil
 
     -- generate Cargo.toml
     local sourcedir = path.join(opt.cachedir, "source")

--- a/xmake/modules/private/tools/rust/check_target.lua
+++ b/xmake/modules/private/tools/rust/check_target.lua
@@ -51,6 +51,8 @@ function main(arch, precise)
     local archs = arch:split("%-")
     if #archs >= 2 then
         result = true
+    else
+        utils.warning("The arch \"%s\" is NOT a valid target triple, will be IGNORED and may cause compilation errors. please check it again", arch)
     end
 
     -- 2: check by rustc

--- a/xmake/modules/private/tools/rust/check_target.lua
+++ b/xmake/modules/private/tools/rust/check_target.lua
@@ -52,7 +52,7 @@ function main(arch, precise)
     if #archs >= 2 then
         result = true
     else
-        utils.warning("The arch \"%s\" is NOT a valid target triple, will be IGNORED and may cause compilation errors. please check it again", arch)
+        utils.warning("the arch \"%s\" is NOT a valid target triple, will be IGNORED and may cause compilation errors, please check it again", arch)
     end
 
     -- 2: check by rustc
@@ -69,7 +69,7 @@ function main(arch, precise)
             end
         end
         if not result then
-            utils.warning("The arch \"%s\" is NOT supported by rustc, will be IGNORED and may cause compilation errors. please check it again", arch)
+            utils.warning("the arch \"%s\" is NOT supported by rustc, will be IGNORED and may cause compilation errors, please check it again", arch)
         end
     end
 

--- a/xmake/modules/private/tools/rust/check_target.lua
+++ b/xmake/modules/private/tools/rust/check_target.lua
@@ -40,7 +40,6 @@ end
 --
 -- @return          true if arch != nil and the target is supported by rustc, otherwise false
 function main(arch, precise)
-    print("arch: " .. arch)
 
     if not arch then
         return false
@@ -52,7 +51,7 @@ function main(arch, precise)
     if #archs >= 2 then
         result = true
     else
-        utils.warning("the arch \"%s\" is NOT a valid target triple, will be IGNORED and may cause compilation errors, please check it again", arch)
+        wprint("the arch \"%s\" is NOT a valid target triple, will be IGNORED and may cause compilation errors, please check it again", arch)
     end
 
     -- 2: check by rustc
@@ -69,7 +68,7 @@ function main(arch, precise)
             end
         end
         if not result then
-            utils.warning("the arch \"%s\" is NOT supported by rustc, will be IGNORED and may cause compilation errors, please check it again", arch)
+            wprint("the arch \"%s\" is NOT supported by rustc, will be IGNORED and may cause compilation errors, please check it again", arch)
         end
     end
 

--- a/xmake/modules/private/tools/rust/check_target.lua
+++ b/xmake/modules/private/tools/rust/check_target.lua
@@ -1,0 +1,75 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      w568w
+-- @file        check_target.lua
+--
+
+-- imports
+import("lib.detect.find_tool")
+
+-- get rustc supported targets
+--
+-- @return          the supported target list. If rustc not found, return nil
+function _get_rustc_supported_target()
+    local rustc = find_tool("rustc")
+    if not rustc then
+        return nil
+    end
+    local output = os.iorunv(rustc.program, {"--print", "target-list"})
+    return output:split('\n')
+end
+
+-- check whether the target is supported by rustc
+--
+-- @param arch      the target name, e.g. x86_64-unknown-linux-gnu
+-- @param precise   whether to check the target precisely (i.e. check by rustc), otherwise only by syntax
+--
+-- @return          true if arch != nil and the target is supported by rustc, otherwise false
+function main(arch, precise)
+    print("arch: " .. arch)
+
+    if not arch then
+        return false
+    end
+
+    -- 1: check by syntax
+    local result = false
+    local archs = arch:split("%-")
+    if #archs >= 2 then
+        result = true
+    end
+
+    -- 2: check by rustc
+    if not precise then
+        return result
+    end
+    result = false
+    local rustc_supported_target = _get_rustc_supported_target()
+    if rustc_supported_target then
+        for _, v in ipairs(rustc_supported_target) do
+            if v == arch then
+                result = true
+                break
+            end
+        end
+        if not result then
+            utils.warning("The arch \"%s\" is NOT supported by rustc, will be IGNORED and may cause compilation errors. please check it again", arch)
+        end
+    end
+
+    return result
+end


### PR DESCRIPTION
Related to #4049.

This is an attempt to obtain the metadata of a given package using [`cargo metadata`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html). This standard way of parsing `Cargo.toml` gives much more precise information about the dependencies than regex matching on strings, thus resolving correctly in some complex cases.

It has been confirmed to work on the example [w568w/xmake#rust/cargo_deps_cross_build](https://github.com/w568w/xmake/tree/0b82a790bad9538e09102afc31fc29c1e9bac826/tests/projects/rust/cargo_deps_cross_build). The configuration items newly added (i.e. `features`, `default_features` and `opt.arch`) have also been taken into account.

However, the case of a `Cargo.toml` containing multiple packages is not considered. Currently, in this case, only the dependencies of the first package are resolved.

---

To make the terminology more accurate, a few terms are clarified here:

- A `Cargo.toml` represents up to one workspace.
- A workspace consists of one or more packages.
- A package consists of up to one binary crate and zero or more library crates.
- A crate is a single compilation unit.