### PR TITLE
[Modules C++20] try to fix headerunits on msvc

### DIFF
--- a/xmake/rules/c++/modules/modules_support/msvc.lua
+++ b/xmake/rules/c++/modules/modules_support/msvc.lua
@@ -351,9 +351,8 @@ function generate_user_headerunits_for_batchjobs(target, batchjobs, headerunits,
                     "/Fo" .. objectfile
                 }
                 generate_headerunit_for_batchjob(target, headerunit.unique and path.filename(headerunit.name) or headerunit.name, flags, objectfile, index, total)
-
             end, {dependfile = target:dependfile(bmifile), files = {headerunit.path}})
-            _add_module_to_mapper(target, headerunitflag .. headerunit.type, headerunit.name, headerunit.type == ":quote" and headerunit.path or headerunit.name, objectfile,  bmifile)
+            _add_module_to_mapper(target, headerunitflag, headerunit.name, headerunit.path, objectfile,  bmifile)
         end, {rootjob = flushjob})
     end
 end
@@ -389,7 +388,7 @@ function generate_user_headerunits_for_batchcmds(target, batchcmds, headerunits,
         generate_headerunit_for_batchcmds(target, headerunit.unique and path.filename(headerunit.name) or headerunit.name, flags, objectfile, batchcmds, opt)
         batchcmds:add_depfiles(headerunit.path)
 
-        _add_module_to_mapper(target, headerunitflag .. headerunit.type, headerunit.name, headerunit.type == ":quote" and headerunit.path or headerunit.name, objectfile,  bmifile)
+        _add_module_to_mapper(target, headerunitflag, headerunit.name, headerunit.path, objectfile,  bmifile)
 
         depmtime = math.max(depmtime, os.mtime(bmifile))
     end

--- a/xmake/rules/c++/modules/modules_support/msvc.lua
+++ b/xmake/rules/c++/modules/modules_support/msvc.lua
@@ -350,7 +350,7 @@ function generate_user_headerunits_for_batchjobs(target, batchjobs, headerunits,
                     outputdir,
                     "/Fo" .. objectfile
                 }
-                generate_headerunit_for_batchjob(target, headerunit.unique and path.filename(headerunit.name) or headerunit.name, flags, objectfile, index, total)
+                generate_headerunit_for_batchjob(target, headerunit.name, flags, objectfile, index, total)
             end, {dependfile = target:dependfile(bmifile), files = {headerunit.path}})
             _add_module_to_mapper(target, headerunitflag, headerunit.name, headerunit.path, objectfile,  bmifile)
         end, {rootjob = flushjob})
@@ -385,7 +385,7 @@ function generate_user_headerunits_for_batchcmds(target, batchcmds, headerunits,
             outputdir,
             "/Fo" .. objectfile
         }
-        generate_headerunit_for_batchcmds(target, headerunit.unique and path.filename(headerunit.name) or headerunit.name, flags, objectfile, batchcmds, opt)
+        generate_headerunit_for_batchcmds(target, headerunit.name, flags, objectfile, batchcmds, opt)
         batchcmds:add_depfiles(headerunit.path)
 
         _add_module_to_mapper(target, headerunitflag, headerunit.name, headerunit.path, objectfile,  bmifile)


### PR DESCRIPTION
This fixes headerunits on VS 17.8 preview 1, and maybe VS 17.7

VS changed the way they handle headerunits

from MSVC STL server:

"there's your problem:
```
-headerUnit:quote C:\Dev\repos\header-unit-regression-VS17.8\src\header.hpp=build\.gens\user_headerunit\windows\x64\release\rules\modules\cache\be9473a8\header.hpp.ifc
```

The argument here points at the full header path, but it's written in source as #include "header.hpp".  In this release the compiler is more strict about the mapping between how it is written in source due to how easily we can optimize that path.  If you want a full path then you need to use /headerUnit without a : designating the type."