### PR TITLE
Adjusted swig’s java library naming for various platforms. Supported mingw.

### DIFF
--- a/xmake/rules/swig/xmake.lua
+++ b/xmake/rules/swig/xmake.lua
@@ -42,18 +42,24 @@ rule("swig.base")
                     end
                 end
             else
-                if target:is_plat("windows") then
+                if target:is_plat("windows", "mingw") then
                     target:set("extension", ".pyd")
                 end
             end
         elseif moduletype == "lua" then
             target:set("prefixname", "")
-            if not target:is_plat("windows") then
+            if not target:is_plat("windows", "mingw")  then
                 target:set("extension", ".so")
             end
         elseif moduletype == "java" then
-            target:set("prefixname", "lib")
-            if not target:is_plat("windows") then
+            if target:is_plat("windows", "mingw") then
+                target:set("prefixname", "")
+                target:set("extension", ".dll")
+            elseif target:is_plat("macosx") then
+                target:set("prefixname", "lib")
+                target:set("extension", ".dylib")
+            elseif target:is_plat("linux") then
+                target:set("prefixname", "lib")
                 target:set("extension", ".so")
             end
         else


### PR DESCRIPTION


Windows
[jdk8/jdk8/jdk: 687fd7c7986d src/windows/javavm/export/jvm\_md.h](https://hg.openjdk.org/jdk8/jdk8/jdk/file/687fd7c7986d/src/windows/javavm/export/jvm_md.h)

```C++
#define JNI_LIB_PREFIX ""
#define JNI_LIB_SUFFIX ".dll"
```


Macosx
[jdk8/jdk8/jdk: 687fd7c7986d src/macosx/javavm/export/jvm\_md.h](https://hg.openjdk.org/jdk8/jdk8/jdk/file/687fd7c7986d/src/macosx/javavm/export/jvm_md.h)

```C++
#define JNI_LIB_PREFIX "lib"
#define JNI_LIB_SUFFIX ".dylib"
```


