### PR TITLE
Fix cpp file recompilation when using modules

### DIFF
--- a/xmake/rules/c++/modules/modules_support/clang.lua
+++ b/xmake/rules/c++/modules/modules_support/clang.lua
@@ -947,6 +947,7 @@ function get_requiresflags(target, requires)
         ::continue::
     end
     if #flags > 0 then
+        table.sort(flags, function(left, right) return left < right end)
         return table.unique(flags)
     end
 end

--- a/xmake/rules/c++/modules/modules_support/msvc.lua
+++ b/xmake/rules/c++/modules/modules_support/msvc.lua
@@ -792,6 +792,11 @@ function get_requiresflags(target, requires, opt)
         end
     end
     if #requireflags > 0 then
+        if not opt.expand then
+            table.sort(requireflags, function(left, right)
+                return left[1] .. " " .. left[2] < right[1] .. " " .. right[2]
+            end)
+        end
         return requireflags
     end
 end


### PR DESCRIPTION
When using a complex module scenario, .cpp files are rebuilt every xmake call, this is due to the ordering of require_flags that may change between two xmake instance

i fixed it on clang and on msvc when using opt.expand, but i'm not comfortable enough with lua to fix it when opt.expand is not set so i may need a little help about that :D

as for GCC i'll check it later, GCC modules development is very slow, i'm waiting for improvements on their side before refine the GCC support in XMake