### PR TITLE
Fix the behaviour caused by system package being disabled during cross-compilation

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1756,9 +1756,6 @@ function _instance:fetch(opt)
         -- we need ignore `{system = true/false}` argument if be 3rd package
         -- @see https://github.com/xmake-io/xmake/issues/726
         system = nil
-    elseif self:is_cross() then
-        -- we need to disable system package for cross-compilation
-        system = false
     end
 
     -- use sysincludedirs/-isystem instead of -I?
@@ -1782,8 +1779,8 @@ function _instance:fetch(opt)
             end
         end
 
-        -- fetch it from the system directories
-        if not fetchinfo and system ~= false then
+        -- fetch it from the system directories (disabled for cross-compilation)
+        if not fetchinfo and system ~= false and not self:is_cross() then
             fetchinfo = self:_fetch_tool({system = true, require_version = require_ver, force = opt.force})
             if fetchinfo then
                 is_system = true
@@ -1799,8 +1796,8 @@ function _instance:fetch(opt)
             end
         end
 
-        -- fetch it from the system and external package sources
-        if not fetchinfo and system ~= false then
+        -- fetch it from the system and external package sources (disabled for cross-compilation)
+        if not fetchinfo and system ~= false and not self:is_cross() then
             fetchinfo = self:_fetch_library({system = true, require_version = require_ver, external = external, force = opt.force})
             if fetchinfo then
                 is_system = true

--- a/xmake/modules/private/action/require/impl/install_packages.lua
+++ b/xmake/modules/private/action/require/impl/install_packages.lua
@@ -733,7 +733,11 @@ function main(requires, opt)
 
     -- exists not found packages?
     if #packages_not_found > 0 then
-        cprint("${bright color.warning}note: ${clear}the following packages were not found on your system, try again after installing them:")
+        if packages_not_found[1]:is_cross() then
+            cprint("${bright color.warning}note: ${clear}system package is not supported for cross-compilation currently, the following system packages cannot be found:")
+        else
+            cprint("${bright color.warning}note: ${clear}the following packages were not found on your system, try again after installing them:")
+        end
         for _, instance in ipairs(packages_not_found) do
             print("  -> %s %s", instance:displayname(), instance:version_str() or "")
         end


### PR DESCRIPTION
The `system` option is set to `false` during cross-compilation, causing xrepo packages to pass the `system` detection.