### PR TITLE
[INSTALL SCRIPT]: `grep` "unrecognized option: P" on `alpine`

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -104,7 +104,7 @@ get_host_speed() {
     if [ `uname` == "Darwin" ]; then
         ping -c 1 -t 1 $1 2>/dev/null | egrep -o 'time=\d+' | egrep -o "\d+" || echo "65535"
     else
-        ping -c 1 -W 1 $1 2>/dev/null | grep -P -o 'time=\d+' | grep -P -o "\d+" || echo "65535"
+        ping -c 1 -W 1 $1 2>/dev/null | grep -E -o 'time=[0-9]+' | grep -E -o "[0-9]+" || echo "65535"
     fi
 }
 


### PR DESCRIPTION
I found out while installing `xmake` on an `Alpine` system that `grep -P` wasn't an available option.
This changes `-P` by `-E` with a small edit to the regex.
As you can see the result now works on both `Alpine`, `Ubuntu`, and even MacOs
If you want me to try other systems just tell me 😉.


---
## Alpine
```
43d33c5a8009:/# neofetch
       .hddddddddddddddddddddddh.          root@43d33c5a8009 
      :dddddddddddddddddddddddddd:         ----------------- 
     /dddddddddddddddddddddddddddd/        OS: Alpine Linux v3.18 aarch64 
    +dddddddddddddddddddddddddddddd+       Host: QEMU Virtual Machine virt-8.1 
  `sdddddddddddddddddddddddddddddddds`     Kernel: 6.4.15-200.fc38.aarch64 
 `ydddddddddddd++hdddddddddddddddddddy`    Uptime: 1 hour, 13 mins 
.hddddddddddd+`  `+ddddh:-sdddddddddddh.   Packages: 20 (apk) 
hdddddddddd+`      `+y:    .sddddddddddh   Shell: ash 
ddddddddh+`   `//`   `.`     -sddddddddd   CPU: (1) 
ddddddh+`   `/hddh/`   `:s-    -sddddddd   Memory: 203MiB / 1953MiB 
ddddh+`   `/+/dddddh/`   `+s-    -sddddd
ddd+`   `/o` :dddddddh/`   `oy-    .yddd                           
hdddyo+ohddyosdddddddddho+oydddy++ohdddh                           
.hddddddddddddddddddddddddddddddddddddh.
 `yddddddddddddddddddddddddddddddddddy`
  `sdddddddddddddddddddddddddddddddds`
    +dddddddddddddddddddddddddddddd+
     /dddddddddddddddddddddddddddd/
      :dddddddddddddddddddddddddd:
       .hddddddddddddddddddddddh.

43d33c5a8009:/# RES=$(ping -c 1 -W 1 gitee.com 2>/dev/null)
43d33c5a8009:/# echo $RES
PING gitee.com (182.255.33.134): 56 data bytes 64 bytes from 182.255.33.134: seq=0 ttl=42 time=1.677 ms --- gitee.com ping statistics --- 1 packets transmitted, 1 packets received, 0% packet loss round-trip min/avg/max = 1.677/1.677/1.677 ms
43d33c5a8009:/# echo $RES | grep -E -o 'time=[0-9]+' | grep -E -o "[0-9]+"
1
43d33c5a8009:/# echo $RES | grep -P -o 'time=\d+' | grep -P -o "\d+"
grepgrep: unrecognized option: P
: unrecognized option: P
BusyBox v1.36.1 (2023-07-27 17:12:24 UTC)BusyBox v1.36.1 (2023-07-27 17:12:24 UTC) multi-call binary.

Usage: grep [-HhnlLoqvsrRiwFE] [-m N] [-A|B|C N] { PATTERN | -e PATTERN... | -f FILE... } [FILE]...

Search for PATTERN in FILEs (or stdin)

        -H      Add 'filename:' prefix
        -h      Do not add 'filename:' prefix
        -n      Add 'line_no:' prefix
        -l      Show only names of files that match
        -L      Show only names of files that don't match
        -c      Show only count of matching lines
        -o      Show only the matching part of line
        -q      Quiet. Return 0 if PATTERN is found, 1 otherwise
        -v      Select non-matching lines
        -s      Suppress open and read errors
        -r      Recurse
        -R      Recurse and dereference symlinks
        -i      Ignore case
        -w      Match whole words only
        -x      Match whole lines only
        -F      PATTERN is a literal (not regexp)
        -E      PATTERN is an extended regexp
        -m N    Match up to N times per file
        -A N    Print N lines of trailing context
        -B N    Print N lines of leading context
        -C N    Same as '-A N -B N'
        -e PTRN Pattern to match
        -f FILE Read pattern from file multi-call binary.

Usage: grep [-HhnlLoqvsrRiwFE] [-m N] [-A|B|C N] { PATTERN | -e PATTERN... | -f FILE... } [FILE]...

Search for PATTERN in FILEs (or stdin)

        -H      Add 'filename:' prefix
        -h      Do not add 'filename:' prefix
        -n      Add 'line_no:' prefix
        -l      Show only names of files that match
        -L      Show only names of files that don't match
        -c      Show only count of matching lines
        -o      Show only the matching part of line
        -q      Quiet. Return 0 if PATTERN is found, 1 otherwise
        -v      Select non-matching lines
        -s      Suppress open and read errors
        -r      Recurse
        -R      Recurse and dereference symlinks
        -i      Ignore case
        -w      Match whole words only
        -x      Match whole lines only
        -F      PATTERN is a literal (not regexp)
        -E      PATTERN is an extended regexp
        -m N    Match up to N times per file
        -A N    Print N lines of trailing context
        -B N    Print N lines of leading context
        -C N    Same as '-A N -B N'
        -e PTRN Pattern to match
        -f FILE Read pattern from file
```

--- 

## Ubuntu
```
root@ab123fc246d6:/# neofetch
            .-/+oossssoo+/-.               root@ab123fc246d6 
        `:+ssssssssssssssssss+:`           ----------------- 
      -+ssssssssssssssssssyyssss+-         OS: Ubuntu 22.04.3 LTS aarch64 
    .ossssssssssssssssssdMMMNysssso.       Host: QEMU Virtual Machine virt-8.1 
   /ssssssssssshdmmNNmmyNMMMMhssssss/      Kernel: 6.4.15-200.fc38.aarch64 
  +ssssssssshmydMMMMMMMNddddyssssssss+     Uptime: 1 hour, 15 mins 
 /sssssssshNMMMyhhyyyyhmNMMMNhssssssss/    Packages: 234 (dpkg) 
.ssssssssdMMMNhsssssssssshNMMMdssssssss.   Shell: bash 5.1.16 
+sssshhhyNMMNyssssssssssssyNMMMysssssss+   CPU: (1) 
ossyNMMMNyMMhsssssssssssssshmmmhssssssso   Memory: 221MiB / 1953MiB 
ossyNMMMNyMMhsssssssssssssshmmmhssssssso
+sssshhhyNMMNyssssssssssssyNMMMysssssss+                           
.ssssssssdMMMNhsssssssssshNMMMdssssssss.                           
 /sssssssshNMMMyhhyyyyhdNMMMNhssssssss/
  +sssssssssdmydMMMMMMMMddddyssssssss+
   /ssssssssssshdmNNNNmyNMMMMhssssss/
    .ossssssssssssssssssdMMMNysssso.
      -+sssssssssssssssssyyyssss+-
        `:+ssssssssssssssssss+:`
            .-/+oossssoo+/-.

root@ab123fc246d6:/# RES=$(ping -c 1 -W 1 gitee.com 2>/dev/null)
root@ab123fc246d6:/# echo $RES
PING gitee.com (182.255.33.134) 56(84) bytes of data. 64 bytes from 182.255.33.134 (182.255.33.134): icmp_seq=1 ttl=254 time=0.451 ms --- gitee.com ping statistics --- 1 packets transmitted, 1 received, 0% packet loss, time 0ms rtt min/avg/max/mdev = 0.451/0.451/0.451/0.000 ms
root@ab123fc246d6:/# echo $RES | grep -E -o 'time=[0-9]+' | grep -E -o "[0-9]+"
0
root@ab123fc246d6:/# echo $RES | grep -P -o 'time=\d+' | grep -P -o "\d+"
0
```

---
Bonus:
Also works on MacOS, so it might be possible to simplify even more.
I can look into it if you want.
```
  zsh ❯ neofetch
                    'c.          vic1707@Victors-MacBook-Pro.local 
                 ,xNMM.          --------------------------------- 
               .OMMMMo           OS: macOS 13.5.1 22G90 arm64 
               OMMM0,            Host: Mac14,10 
     .;loddo:' loolloddol;.      Kernel: 22.6.0 
   cKMMMMMMMMMMNWMMMMMMMMMM0:    Uptime: 9 days, 16 hours, 29 mins 
 .KMMMMMMMMMMMMMMMMMMMMMMMWd.    Packages: 140 (brew) 
 XMMMMMMMMMMMMMMMMMMMMMMMX.      Shell: zsh 5.9 
;MMMMMMMMMMMMMMMMMMMMMMMM:       Resolution: 1728x1117 
:MMMMMMMMMMMMMMMMMMMMMMMM:       DE: Aqua 
.MMMMMMMMMMMMMMMMMMMMMMMMX.      WM: Quartz Compositor 
 kMMMMMMMMMMMMMMMMMMMMMMMMWd.    WM Theme: Blue (Dark) 
 .XMMMMMMMMMMMMMMMMMMMMMMMMMMk   Terminal: vscode 
  .XMMMMMMMMMMMMMMMMMMMMMMMMK.   CPU: Apple M2 Pro 
    kMMMMMMMMMMMMMMMMMMMMMMd     GPU: Apple M2 Pro 
     ;KMMMMMMMWXXWMMMMMMMk.      Memory: 3024MiB / 16384MiB 
       .cooc,.    .,coo:.
                                                         
                                                         
 zsh ❯ RES=$(ping -c 1 -t 1 gitee.com 2>/dev/null)
 
 zsh ❯ echo $RES                                                 
PING gitee.com (182.255.33.134): 56 data bytes
64 bytes from 182.255.33.134: icmp_seq=0 ttl=52 time=592.023 ms

--- gitee.com ping statistics ---
1 packets transmitted, 1 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 592.023/592.023/592.023/0.000 ms

  zsh ❯ echo $RES | grep -E -o 'time=[0-9]+' | grep -E -o "[0-9]+"
592

  zsh ❯ echo $RES | grep -P -o 'time=\d+' | grep -P -o "\d+"
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]
```