### PR TITLE
LLVM toolchain is installed in a different path for ARM cpus

### DIFF
--- a/xmake/toolchains/llvm/check.lua
+++ b/xmake/toolchains/llvm/check.lua
@@ -61,9 +61,16 @@ function main(toolchain)
         if is_host("linux") and os.isfile("/usr/bin/llvm-ar") then
             sdkdir = "/usr"
         elseif is_host("macosx") then
-            local bindir = find_path("llvm-ar", "/usr/local/Cellar/llvm/*/bin")
-            if bindir then
-                sdkdir = path.directory(bindir)
+            if os.arch() == "arm64" then
+                local bindir = find_path("llvm-ar", "/opt/homebrew/opt/llvm/bin")
+                if bindir then
+                    sdkdir = path.directory(bindir)
+                end
+            else
+                local bindir = find_path("llvm-ar", "/usr/local/Cellar/llvm/*/bin")
+                if bindir then
+                    sdkdir = path.directory(bindir)
+                end
             end
         end
     end

--- a/xmake/toolchains/llvm/check.lua
+++ b/xmake/toolchains/llvm/check.lua
@@ -61,16 +61,14 @@ function main(toolchain)
         if is_host("linux") and os.isfile("/usr/bin/llvm-ar") then
             sdkdir = "/usr"
         elseif is_host("macosx") then
+            local bindir
             if os.arch() == "arm64" then
-                local bindir = find_path("llvm-ar", "/opt/homebrew/opt/llvm/bin")
-                if bindir then
-                    sdkdir = path.directory(bindir)
-                end
+                bindir = find_path("llvm-ar", "/opt/homebrew/opt/llvm/bin")
             else
-                local bindir = find_path("llvm-ar", "/usr/local/Cellar/llvm/*/bin")
-                if bindir then
-                    sdkdir = path.directory(bindir)
-                end
+                bindir = find_path("llvm-ar", "/usr/local/Cellar/llvm/*/bin")
+            end
+            if bindir then
+                sdkdir = path.directory(bindir)
             end
         end
     end


### PR DESCRIPTION
I'm getting an error when trying to use the LLVM package installed via homebrew on an M1 macOS, I assume it's the same situation for an M2.

```
llvm toolchain not found!
```

Looking into the codebase there is a check step on the llvm.lua toolchain that fails when searching for the packages on the system path. According to the official documentation:

> The script installs Homebrew to its default, supported, best prefix (/opt/homebrew for Apple Silicon, /usr/local for macOS Intel and /home/linuxbrew/.linuxbrew for Linux) so that [you don’t need sudo after Homebrew’s initial installation](https://docs.brew.sh/FAQ#why-does-homebrew-say-sudo-is-bad) when you brew install. 


For more information, please see https://docs.brew.sh/Installation

This change adds a check where depending on the architecture, it will check the previous path or the new one for M1.
