### PR TITLE
Adding the latest versions of clang (16, 17, 18) to the toolchain list

### DIFF
--- a/xmake/toolchains/clang-16/xmake.lua
+++ b/xmake/toolchains/clang-16/xmake.lua
@@ -1,0 +1,3 @@
+includes(path.join(os.scriptdir(), "../clang/xmake.lua"))
+
+toolchain_clang("16")

--- a/xmake/toolchains/clang-17/xmake.lua
+++ b/xmake/toolchains/clang-17/xmake.lua
@@ -1,0 +1,3 @@
+includes(path.join(os.scriptdir(), "../clang/xmake.lua"))
+
+toolchain_clang("17")

--- a/xmake/toolchains/clang-18/xmake.lua
+++ b/xmake/toolchains/clang-18/xmake.lua
@@ -1,0 +1,3 @@
+includes(path.join(os.scriptdir(), "../clang/xmake.lua"))
+
+toolchain_clang("18")


### PR DESCRIPTION
This commit adds multiple versions of clang to the toolchain list.

- Version 16 was released already, and it has been deployed in multiple package managers.
- Version 17 is already in RC4 soon to be released.
- The clang git repository already makes a few commits for version 18. I'm currently compiling from the main branch and using this version.

