### PR TITLE
Fix capnproto by adding c++ extension

### DIFF
--- a/xmake/languages/c++/xmake.lua
+++ b/xmake/languages/c++/xmake.lua
@@ -20,7 +20,7 @@
 
 language("c++")
     add_rules("c++")
-    set_sourcekinds {cc = ".c", cxx = {".cpp", ".cc", ".cxx", ".mpp", ".mxx", ".cppm", ".ixx"}}
+    set_sourcekinds {cc = ".c", cxx = {".cpp", ".cc", ".cxx", ".mpp", ".mxx", ".cppm", ".ixx", ".c++"}}
     set_sourceflags {cc = {"cflags", "cxflags"}, cxx = {"cxxflags", "cxflags"}}
     set_targetkinds {binary = "ld", static = "ar", shared = "sh"}
     set_targetflags {binary = "ldflags", static = "arflags", shared = "shflags"}


### PR DESCRIPTION
The capnproto test project was failing with the  `error: .c++ is unknown extension`
