### PR TITLE
Fix sed on forward slashes

### DIFF
--- a/configure
+++ b/configure
@@ -3727,7 +3727,7 @@ _replace_configvar_define() {
 _replace_configvar_value() {
     local name="${1}"
     local value="${2}"
-    _ret="s/\${${name}}/${value}/g"
+    _ret="s@\${${name}}@${value}@g"
 }
 
 # generate configfile for the given target


### PR DESCRIPTION
Locally for Debian packaging, xmake fails to configure properly. Some paths are passed to sed, which causes sed to not execute as intended. The changes prepared are the same as a patch in Debian's salsa to change the symbol delimiter that sed is using from '/' to '@'.
