### PR TITLE
Fix typos in manpages

### DIFF
--- a/scripts/man/xmake.1
+++ b/scripts/man/xmake.1
@@ -124,7 +124,7 @@ Print lots of verbose information for users.
 
 .TP
 .B \-\-root
-Allow to run xmake as root.
+Allow one to run xmake as root.
 
 .TP
 .B \-D, \-\-diagnosis
@@ -151,7 +151,7 @@ file.
 Change to the given project directory.
 Search priority:
   1. The Given Command Argument
-  2. The Envirnoment Variable: \fBXMAKE_PROJECT_DIR\fR
+  2. The Environment Variable: \fBXMAKE_PROJECT_DIR\fR
   3. The Current Directory
 
 

--- a/scripts/man/xrepo.1
+++ b/scripts/man/xrepo.1
@@ -90,7 +90,7 @@ Input yes by default if need user confirm.
 
 .TP
 .B \-\-root
-Allow to run xrepo as root.
+Allow one to run xrepo as root.
 
 .TP
 .B \-v, \-\-verbose


### PR DESCRIPTION
There are some minor typos in manpages that Debian's lintian caught. The changes prepared are the same as a patch in Debian's salsa.

