### PR TITLE
Fix asan and lto config handling

### DIFF
--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -655,8 +655,9 @@ function _inherit_parent_configs(requireinfo, package, parentinfo)
             if requireinfo_configs.pic == nil then
                 requireinfo_configs.pic = parentinfo_configs.pic
             end
-            if not requireinfo_configs.pic then
-                requireinfo_configs.pic = nil
+            -- remove pic entry if pic is true (to prevent cache mismatch), as it the default behavior
+            if requireinfo_configs.pic == true then
+                requireinfo_configs.pic = nil -- pic is enabled by default
             end
         end
         if parentinfo.plat then

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -502,8 +502,17 @@ function _init_requireinfo(requireinfo, package, opt)
         if project.policy("package.inherit_external_configs") then
             requireinfo.configs.vs_runtime = requireinfo.configs.vs_runtime or get_config("vs_runtime")
         end
-        requireinfo.configs.lto = requireinfo.configs.lto or project.policy("build.optimization.lto")
-        requireinfo.configs.asan = requireinfo.configs.asan or project.policy("build.sanitizer.address")
+        local function initconfig(key, default)
+            if requireinfo.configs[key] == nil then
+                requireinfo.configs[key] = default
+            end
+            -- set false key as nil so hashes match
+            if not requireinfo.configs[key] then
+                requireinfo.configs[key] = nil
+            end
+        end
+        initconfig("asan", project.policy("build.sanitizer.address"))
+        initconfig("lto", project.policy("build.optimization.lto"))
     end
     -- but we will ignore some configs for buildhash in the headeronly and host/binary package
     -- @note on_test still need these configs, @see https://github.com/xmake-io/xmake/issues/4124

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -655,6 +655,9 @@ function _inherit_parent_configs(requireinfo, package, parentinfo)
             if requireinfo_configs.pic == nil then
                 requireinfo_configs.pic = parentinfo_configs.pic
             end
+            if not requireinfo_configs.pic then
+                requireinfo_configs.pic = nil
+            end
         end
         if parentinfo.plat then
             requireinfo.plat = parentinfo.plat

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -665,7 +665,13 @@ function _inherit_parent_configs(requireinfo, package, parentinfo)
         requireinfo_configs.toolchains = requireinfo_configs.toolchains or parentinfo_configs.toolchains
         requireinfo_configs.vs_runtime = requireinfo_configs.vs_runtime or parentinfo_configs.vs_runtime
         requireinfo_configs.lto = requireinfo_configs.lto or parentinfo_configs.lto
+        if not requireinfo_configs.lto then
+            requireinfo_configs.lto = nil
+        end
         requireinfo_configs.asan = requireinfo_configs.asan or parentinfo_configs.asan
+        if not requireinfo_configs.asan then
+            requireinfo_configs.asan = nil
+        end
         requireinfo.configs = requireinfo_configs
     end
 end


### PR DESCRIPTION
This fixes two things:

1) when `project.policy("build.sanitizer.address")` is true, there is no way to disable asan on a package, `add_requires("xx", { configs { asan = false } })` won't work because of the `or` (it should check for nil)

https://github.com/xmake-io/xmake/blob/3d9cf6af8a3fae36dbb5e8fe055a54000ddcadfb/xmake/modules/private/action/require/impl/package.lua#L506

2) When asan is set to false, it won't match installed packages with asan key set to nil even though they are identical. So when asan/lto key is set to false, it will remove the asan/lto key from config
