### PR TITLE
fix apt alias on specified dependency versions

### DIFF
--- a/xmake/modules/package/manager/apt/find_package.lua
+++ b/xmake/modules/package/manager/apt/find_package.lua
@@ -98,7 +98,7 @@ function _find_package(dpkg, name, opt)
             for _, line in ipairs(statusinfo:split("\n", {plain = true})) do
                 -- parse depends, e.g. Depends: libboost1.74-dev
                 if line:startswith("Depends:") then
-                    local depends = line:sub(9):split("%s+")
+                    local depends = line:sub(9):gsub("%(.-%)", ""):split("%s+")
                     if #depends == 1 then
                         return _find_package(dpkg, depends[1], opt)
                     end

--- a/xmake/modules/package/manager/apt/find_package.lua
+++ b/xmake/modules/package/manager/apt/find_package.lua
@@ -96,7 +96,7 @@ function _find_package(dpkg, name, opt)
         local statusinfo = try {function () return os.iorunv(dpkg.program, {"--status", name}) end}
         if statusinfo then
             for _, line in ipairs(statusinfo:split("\n", {plain = true})) do
-                -- parse depends, e.g. Depends: libboost1.74-dev
+                -- parse depends, e.g. Depends: libboost1.74-dev, libomp-14-dev (>= 14~)
                 if line:startswith("Depends:") then
                     local depends = line:sub(9):gsub("%(.-%)", ""):split("%s+")
                     if #depends == 1 then


### PR DESCRIPTION
apt 测试package alias的时候有时候输出会包括版本信息：
```
$ dpkg --status libomp-dev
Package: libomp-dev
Status: install ok installed
Priority: optional
Section: libdevel
Installed-Size: 16
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Architecture: amd64
Multi-Arch: same
Source: llvm-defaults (0.55~exp2)
Version: 1:14.0-55~exp2
Depends: libomp-14-dev (>= 14~)
Description: LLVM OpenMP runtime - dev package
 The runtime is the part of the OpenMP implementation that your code is
 linked against, and that manages the multiple threads in an OpenMP program
 while it is executing.
 This is a dependency package providing the default LLVM OpenMP dev
 package.
Original-Maintainer: LLVM Packaging Team <pkg-llvm-team@lists.alioth.debian.org>
```
版本信息在括号中，因此要正确检测alias需要去掉括号。