### PR TITLE
fix the uac setting of embed manifest

### DIFF
--- a/xmake/rules/platform/windows/manifest/xmake.lua
+++ b/xmake/rules/platform/windows/manifest/xmake.lua
@@ -37,6 +37,7 @@ rule("platform.windows.manifest")
                 end
             end
             if manifest then
+                target:add("ldflags", "/MANIFESTUAC:NO", {force = true})
                 target:add("ldflags", "/manifest:embed", {force = true})
             end
         end


### PR DESCRIPTION
当清单里修改了uac设置并且与链接器的默认uac设置不同时，会冲突 所以这里要关掉