### PR TITLE
Add package.install_locally policy

### DIFF
--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -127,7 +127,7 @@ function policy.policies()
             ["diagnosis.check_build_deps"]        = {description = "Show diagnosis info for checking build dependencies", default = false, type = "boolean"},
             -- Set the network mode, e.g. public/private
             --   private: it will disable fetch remote package repositories
-            ["network.mode"]                      = {description = "Set the network mode", type = "string"}
+            ["network.mode"]                      = {description = "Set the network mode", type = "string"},
             -- Install packages in the project folder instead of XMAKE_PKG_INSTALLDIR
             ["package.install_locally"]           = {description = "Install packages in the project folder instead of XMAKE_PKG_INSTALLDIR", default = false, type = "boolean"},
         }
@@ -145,7 +145,7 @@ function policy.check(name, value)
         else
             local valtype = type(value)
             if valtype ~= defined_policy.type then
-                utils.warning("policy(%s): invalid value type(%s), it shound be '%s'!", name, valtype, defined_policy.type)
+                utils.warning("policy(%s): invalid value type(%s), it should be '%s'!", name, valtype, defined_policy.type)
             end
         end
         return value

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -128,6 +128,8 @@ function policy.policies()
             -- Set the network mode, e.g. public/private
             --   private: it will disable fetch remote package repositories
             ["network.mode"]                      = {description = "Set the network mode", type = "string"}
+            -- Install packages in the project folder instead of XMAKE_PKG_INSTALLDIR
+            ["package.install_locally"]           = {description = "Install packages in the project folder instead of XMAKE_PKG_INSTALLDIR", default = false, type = "boolean"},
         }
         policy._POLICIES = policies
     end


### PR DESCRIPTION
This adds a new policy allowing one to install new packages in the project folder instead of XMAKE_PKG_INSTALLDIR, but still try find packages in XMAKE_PKG_INSTALLDIR if they're not in the project folder.

This is useful in case where you want packages to be temporary installed, or installed with the project, to preserve disk space.

Note: this implementation works but can probably be improved a lot