### PR TITLE
fix modpost parameter of linux driver rule

### DIFF
--- a/xmake/rules/platform/linux/driver/driver_modules.lua
+++ b/xmake/rules/platform/linux/driver/driver_modules.lua
@@ -283,9 +283,9 @@ function link(target, opt)
         -- generate target.mod.c
         local orderfile = path.join(path.directory(targetfile_o), "modules.order")
         local symversfile = path.join(path.directory(targetfile_o), "Module.symvers")
-        argv = {"-m", "-a", "-o", symversfile, "-e", "-N", "-w", "-T", "-"}
+        argv = {"-m", "-a", "-o", symversfile, "-e", "-N", "-w", "-T", orderfile}
         io.writefile(orderfile, targetfile_o .. "\n")
-        os.vrunv(modpost, argv, {stdin = orderfile})
+        os.vrunv(modpost, argv)
 
         -- compile target.mod.c
         local targetfile_mod_c = targetfile_o:gsub("%.o$", ".mod.c")


### PR DESCRIPTION
The modpost of 6.2.0-36-generic do not read order file from stdin when using `-T -`. So that it replace the parameter with `-T orderfile`