### PR TITLE
Fix buildhash check with transient deps

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -899,10 +899,10 @@ function _instance:manifest_save()
     end
 
     -- save deps
-    if self:deps() then
+    if self:librarydeps() then
         manifest.deps = {}
-        for name, dep in pairs(self:deps()) do
-            manifest.deps[name] = {
+        for _, dep in ipairs(self:librarydeps()) do
+            manifest.deps[dep:name()] = {
                 version = dep:version_str(),
                 buildhash = dep:buildhash()
             }

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -1070,7 +1070,7 @@ function _compatible_with_previous_librarydeps(package, opt)
     if manifest and manifest.librarydeps then
         local deps = manifest.deps or {}
         for _, depname in ipairs(manifest.librarydeps) do
-            if strict_compatibility or (package:dep(depname) and package:dep(depname):policy("package.strict_compatibility")) then
+            if strict_compatibility or (package:dep(depname) and package:dep(depname):policy("package.strict_compatibility")) or depinfos_curr[depname] then
                 local depinfo = deps[depname]
                 if depinfo and depinfo.buildhash then
                     depinfos_prev[depname] = depinfo


### PR DESCRIPTION
I noticed a bug with package dephash check when trying to build https://github.com/SweetId/NazaraEditor

See the bug here:
```
please input: y (y/n/m)
lynix@SirLaptopVanLynix:/mnt/d/GitHub/NazaraEditor$ xmake.exe f --check
checking for Microsoft Visual Studio (x64) version ... 2022
note: install or modify (m) these packages (pass -y to skip confirm)?
in nazara-localization-repo:
  -> nazaralocalization 2023.10.21-2 [vs_runtime:"MDd", debug:y, deps:+nzsl,+nazarautils]
please input: y (y/n/m)
y
  => install nazaralocalization 2023.10.21-2 .. ok
lynix@SirLaptopVanLynix:/mnt/d/GitHub/NazaraEditor$ xmake.exe f --check
checking for Microsoft Visual Studio (x64) version ... 2022
note: install or modify (m) these packages (pass -y to skip confirm)?
in nazara-localization-repo:
  -> nazaralocalization 2023.10.21-2 [debug:y, vs_runtime:"MDd", deps:+nazarautils,+nzsl]
please input: y (y/n/m)
```

xmake tries to reinstall a package it just installed, this is because the manifest doesn't store all deps (librarydeps) but only direct deps. And when xmake checks the package hashes it compares librarydeps vs deps.

The packages are as is:
```
nazarautils (uses package.strict_compatibility)
nzsl (uses package.strict_compatibility, depends on nazarautils)
nazaraengine (does not use package.strict_compatibility, depends on nazarautils, nzsl)
nazaralocalization (does not use package.strict_compatibility, depends on nazaraengine)
```

The fix here is to store librarydeps hashes instead of just deps hashes.