### PR TITLE
fix meson static library on windows

### DIFF
--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -331,7 +331,7 @@ end
 -- fix libname on windows
 function _fix_libname_on_windows(package)
     for _, lib in ipairs(os.files(path.join(package:installdir("lib"), "lib*.a"))) do
-        os.mv(lib, lib:gsub("(.+)lib(.-)%.a", "%1%2.lib"))
+        os.mv(lib, lib:gsub("(.+)\\lib(.-)%.a", "%1\\%2.lib"))
     end
 end
 


### PR DESCRIPTION
之前的模式匹配有问题，如果目标库本身就含有"lib"字符串那就会把名字改错，这里修复这个问题