### PR TITLE
Fix runjobs

### DIFF
--- a/xmake/modules/async/runjobs.lua
+++ b/xmake/modules/async/runjobs.lua
@@ -56,7 +56,7 @@ end
 function main(name, jobs, opt)
 
     -- init options
-    op = opt or {}
+    opt = opt or {}
     local total = opt.total or (type(jobs) == "table" and jobs:size()) or 1
     local comax = opt.comax or math.min(total, 4)
     local distcc = opt.distcc


### PR DESCRIPTION
'runjobs' would try to index a nil value if no options where given due to a typo in the initialization of 'opt'.