### PR TITLE
Fix visual studio startup project #4458

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x_solution.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_solution.lua
@@ -43,7 +43,7 @@ function _make_projects(slnfile, vsinfo)
             table.insert(targets, 1, target)
         elseif target:is_binary() then
             local first_target = targets[1]
-            if not first_target or not first_target:is_default() then
+            if not first_target or first_target:get("default") ~= true then
                 table.insert(targets, 1, target)
             else
                 table.insert(targets, target)

--- a/xmake/plugins/project/vstudio/impl/vs201x_solution.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_solution.lua
@@ -43,7 +43,7 @@ function _make_projects(slnfile, vsinfo)
             table.insert(targets, 1, target)
         elseif target:is_binary() then
             local first_target = targets[1]
-            if not first_target or first_target:is_default() then
+            if not first_target or not first_target:is_default() then
                 table.insert(targets, 1, target)
             else
                 table.insert(targets, target)

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -580,7 +580,7 @@ function main(outputdir, vsinfo)
             table.insert(targetnames, 1, targetname)
         elseif target:is_binary() then
             local first_target = targetnames[1] and project.target(targetnames[1])
-            if not first_target or not first_target:is_default() then
+            if not first_target or first_target:get("default") ~= true then
                 table.insert(targetnames, 1, targetname)
             else
                 table.insert(targetnames, targetname)

--- a/xmake/plugins/project/vsxmake/getinfo.lua
+++ b/xmake/plugins/project/vsxmake/getinfo.lua
@@ -580,7 +580,7 @@ function main(outputdir, vsinfo)
             table.insert(targetnames, 1, targetname)
         elseif target:is_binary() then
             local first_target = targetnames[1] and project.target(targetnames[1])
-            if not first_target or first_target:is_default() then
+            if not first_target or not first_target:is_default() then
                 table.insert(targetnames, 1, targetname)
             else
                 table.insert(targetnames, targetname)


### PR DESCRIPTION
Non default binary targets would always be inserted at position one, even if the traget before was set to default.
Fixes #4458
