### PR TITLE
Add native file meson

### DIFF
--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -84,12 +84,116 @@ function _translate_flags(package, flags)
     return flags
 end
 
+function _insert_cross_configs(package, file, opt)
+    -- host machine
+    file:print("[host_machine]")
+    if opt.host_machine then
+        file:print("%s", opt.host_machine)
+    elseif package:is_plat("iphoneos", "macosx") then
+        local cpu
+        local cpu_family
+        if package:is_arch("arm64") then
+            cpu = "aarch64"
+            cpu_family = "aarch64"
+        elseif package:is_arch("armv7") then
+            cpu = "arm"
+            cpu_family = "arm"
+        elseif package:is_arch("x64", "x86_64") then
+            cpu = "x86_64"
+            cpu_family = "x86_64"
+        elseif package:is_arch("x86", "i386") then
+            cpu = "i686"
+            cpu_family = "x86"
+        else
+            raise("unsupported arch(%s)", package:arch())
+        end
+        file:print("system = 'darwin'")
+        file:print("cpu_family = '%s'", cpu_family)
+        file:print("cpu = '%s'", cpu)
+        file:print("endian = 'little'")
+    elseif package:is_plat("android") then
+        local cpu
+        local cpu_family
+        if package:is_arch("arm64-v8a") then
+            cpu = "aarch64"
+            cpu_family = "aarch64"
+        elseif package:is_arch("armeabi-v7a") then
+            cpu = "arm"
+            cpu_family = "arm"
+        elseif package:is_arch("x64", "x86_64") then
+            cpu = "x86_64"
+            cpu_family = "x86_64"
+        elseif package:is_arch("x86", "i386") then
+            cpu = "i686"
+            cpu_family = "x86"
+        else
+            raise("unsupported arch(%s)", package:arch())
+        end
+        file:print("system = 'android'")
+        file:print("cpu_family = '%s'", cpu_family)
+        file:print("cpu = '%s'", cpu)
+        file:print("endian = 'little'")
+    elseif package:is_plat("mingw") then
+        local cpu
+        local cpu_family
+        if package:is_arch("x64", "x86_64") then
+            cpu = "x86_64"
+            cpu_family = "x86_64"
+        elseif package:is_arch("x86", "i386") then
+            cpu = "i686"
+            cpu_family = "x86"
+        else
+            raise("unsupported arch(%s)", package:arch())
+        end
+        file:print("system = 'windows'")
+        file:print("cpu_family = '%s'", cpu_family)
+        file:print("cpu = '%s'", cpu)
+        file:print("endian = 'little'")
+    elseif package:is_plat("windows") then
+        local cpu
+        local cpu_family
+        if package:is_arch("arm64") then
+            cpu = "aarch64"
+            cpu_family = "aarch64"
+        elseif package:is_arch("x86") then
+            cpu = "x86"
+            cpu_family = "x86"
+        elseif package:is_arch("x64") then
+            cpu = "x86_64"
+            cpu_family = "x86_64"
+        else
+            raise("unsupported arch(%s)", package:arch())
+        end
+        file:print("system = 'windows'")
+        file:print("cpu_family = '%s'", cpu_family)
+        file:print("cpu = '%s'", cpu)
+        file:print("endian = 'little'")
+    elseif package:is_plat("wasm") then
+        file:print("system = 'emscripten'")
+        file:print("cpu_family = 'wasm32'")
+        file:print("cpu = 'wasm32'")
+        file:print("endian = 'little'")
+    else
+        local cpu = package:arch()
+        if package:is_arch("arm64") or package:is_arch("aarch64") then
+            cpu = "aarch64"
+        elseif package:is_arch("arm.*") then
+            cpu = "arm"
+        end
+        local cpu_family = cpu
+        file:print("system = '%s'", package:targetos() or "linux")
+        file:print("cpu_family = '%s'", cpu_family)
+        file:print("cpu = '%s'", cpu)
+        file:print("endian = 'little'")
+    end
+end
+
 -- get cross file
-function _get_cross_file(package, opt)
+function _get_configs_file(package, opt)
     opt = opt or {}
-    local crossfile = path.join(_get_buildir(package, opt), "cross_file.txt")
-    if not os.isfile(crossfile) then
-        local file = io.open(crossfile, "w")
+    local configsfile = path.join(_get_buildir(package, opt), "configs_file.txt")
+    if not os.isfile(configsfile) then
+        local file = io.open(configsfile, "w")
         -- binaries
         file:print("[binaries]")
         local cc = package:build_getenv("cc")
@@ -165,113 +269,15 @@ function _get_cross_file(package, opt)
             file:print("c_link_args=['%s']", table.concat(linkflags, "', '"))
             file:print("cpp_link_args=['%s']", table.concat(linkflags, "', '"))
         end
-        file:print("")
-
-        -- host machine
-        file:print("[host_machine]")
-        if opt.host_machine then
-            file:print("%s", opt.host_machine)
-        elseif package:is_plat("iphoneos", "macosx") then
-            local cpu
-            local cpu_family
-            if package:is_arch("arm64") then
-                cpu = "aarch64"
-                cpu_family = "aarch64"
-            elseif package:is_arch("armv7") then
-                cpu = "arm"
-                cpu_family = "arm"
-            elseif package:is_arch("x64", "x86_64") then
-                cpu = "x86_64"
-                cpu_family = "x86_64"
-            elseif package:is_arch("x86", "i386") then
-                cpu = "i686"
-                cpu_family = "x86"
-            else
-                raise("unsupported arch(%s)", package:arch())
-            end
-            file:print("system = 'darwin'")
-            file:print("cpu_family = '%s'", cpu_family)
-            file:print("cpu = '%s'", cpu)
-            file:print("endian = 'little'")
-        elseif package:is_plat("android") then
-            local cpu
-            local cpu_family
-            if package:is_arch("arm64-v8a") then
-                cpu = "aarch64"
-                cpu_family = "aarch64"
-            elseif package:is_arch("armeabi-v7a") then
-                cpu = "arm"
-                cpu_family = "arm"
-            elseif package:is_arch("x64", "x86_64") then
-                cpu = "x86_64"
-                cpu_family = "x86_64"
-            elseif package:is_arch("x86", "i386") then
-                cpu = "i686"
-                cpu_family = "x86"
-            else
-                raise("unsupported arch(%s)", package:arch())
-            end
-            file:print("system = 'android'")
-            file:print("cpu_family = '%s'", cpu_family)
-            file:print("cpu = '%s'", cpu)
-            file:print("endian = 'little'")
-        elseif package:is_plat("mingw") then
-            local cpu
-            local cpu_family
-            if package:is_arch("x64", "x86_64") then
-                cpu = "x86_64"
-                cpu_family = "x86_64"
-            elseif package:is_arch("x86", "i386") then
-                cpu = "i686"
-                cpu_family = "x86"
-            else
-                raise("unsupported arch(%s)", package:arch())
-            end
-            file:print("system = 'windows'")
-            file:print("cpu_family = '%s'", cpu_family)
-            file:print("cpu = '%s'", cpu)
-            file:print("endian = 'little'")
-        elseif package:is_plat("windows") then
-            local cpu
-            local cpu_family
-            if package:is_arch("arm64") then
-                cpu = "aarch64"
-                cpu_family = "aarch64"
-            elseif package:is_arch("x86") then
-                cpu = "x86"
-                cpu_family = "x86"
-            elseif package:is_arch("x64") then
-                cpu = "x86_64"
-                cpu_family = "x86_64"
-            else
-                raise("unsupported arch(%s)", package:arch())
-            end
-            file:print("system = 'windows'")
-            file:print("cpu_family = '%s'", cpu_family)
-            file:print("cpu = '%s'", cpu)
-            file:print("endian = 'little'")
-        elseif package:is_plat("wasm") then
-            file:print("system = 'emscripten'")
-            file:print("cpu_family = 'wasm32'")
-            file:print("cpu = 'wasm32'")
-            file:print("endian = 'little'")
-        else
-            local cpu = package:arch()
-            if package:is_arch("arm64") or package:is_arch("aarch64") then
-                cpu = "aarch64"
-            elseif package:is_arch("arm.*") then
-                cpu = "arm"
-            end
-            local cpu_family = cpu
-            file:print("system = '%s'", package:targetos() or "linux")
-            file:print("cpu_family = '%s'", cpu_family)
-            file:print("cpu = '%s'", cpu)
-            file:print("endian = 'little'")
+        
+        if package:is_cross() then
+            file:print("")
+            _insert_cross_configs(package, file, opt)
+            file:print("")
         end
-        file:print("")
         file:close()
     end
-    return crossfile
+    return configsfile
 end
 
 -- get configs
@@ -307,8 +313,10 @@ function _get_configs(package, configs, opt)
     end
 
     -- add cross file
-    if package:is_cross() or package:is_plat("mingw") then
-        table.insert(configs, "--cross-file=" .. _get_cross_file(package, opt))
+    if package:is_cross() then
+        table.insert(configs, "--cross-file=" .. _get_configs_file(package, opt))
+    else 
+        table.insert(configs, "--native-file=" .. _get_configs_file(package, opt))
     end
 
     -- add build directory


### PR DESCRIPTION
Previously, meson didn't use the toolchain selected by the user with `--toolchain` or depending on the platform, like mingw.