### PR TITLE
add --cxxstl= flag to configure clang/llvm c++ stl library

### DIFF
--- a/tests/projects/c++/libc++/src/main.cpp
+++ b/tests/projects/c++/libc++/src/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+using namespace std;
+
+int main(int argc, char** argv)
+{
+    cout << "hello world!" << endl; 
+    return 0;
+}

--- a/tests/projects/c++/libc++/test.lua
+++ b/tests/projects/c++/libc++/test.lua
@@ -1,0 +1,45 @@
+import("lib.detect.find_tool")
+import("core.base.semver")
+
+function _build()
+    local ci = (os.getenv("CI") or os.getenv("GITHUB_ACTIONS") or ""):lower()
+    if ci == "true" then
+        os.exec("xmake -rvD")
+    else
+        os.exec("xmake -r")
+    end
+end
+
+function main(t)
+    local clang = find_tool("clang")
+    if clang then
+        os.exec("xmake clean -a")
+        os.exec("xmake f --toolchain=clang -c")
+        _build()
+        os.exec("xmake clean -a")
+        os.exec("xmake f --toolchain=clang --cxxstl=\"libc++\" -c")
+        _build()
+        os.exec("xmake clean -a")
+        os.exec("xmake f --toolchain=clang --cxxstl=\"libstdc++\" -c")
+        _build()
+        if is_plat("windows") then
+            os.exec("xmake clean -a")
+            os.exec("xmake f --toolchain=clang --cxxstl=\"msstl\" -c")
+            _build()
+        end
+        os.exec("xmake clean -a")
+        os.exec("xmake f --toolchain=llvm -c")
+        _build()
+        os.exec("xmake clean -a")
+        os.exec("xmake f --toolchain=llvm --cxxstl=\"libc++\" -c")
+        _build()
+        os.exec("xmake clean -a")
+        os.exec("xmake f --toolchain=llvm --cxxstl=\"libstdc++\" -c")
+        _build()
+        if is_plat("windows") then
+            os.exec("xmake clean -a")
+            os.exec("xmake f --toolchain=llvm --cxxstl=\"msstl\" -c")
+            _build()
+        end
+    end
+end

--- a/tests/projects/c++/libc++/test.lua
+++ b/tests/projects/c++/libc++/test.lua
@@ -6,39 +6,26 @@ function _build()
     if ci == "true" then
         os.exec("xmake -rvD")
     else
-        os.exec("xmake -r")
+        os.exec("xmake -rvD")
     end
 end
 
 function main(t)
     local clang = find_tool("clang")
     if clang then
-        os.exec("xmake clean -a")
         os.exec("xmake f --toolchain=clang -c")
         _build()
         os.exec("xmake clean -a")
         os.exec("xmake f --toolchain=clang --cxxstl=\"libc++\" -c")
         _build()
-        os.exec("xmake clean -a")
-        os.exec("xmake f --toolchain=clang --cxxstl=\"libstdc++\" -c")
-        _build()
-        if is_plat("windows") then
+        if is_host("linux") or is_subhost("msys") then
             os.exec("xmake clean -a")
-            os.exec("xmake f --toolchain=clang --cxxstl=\"msstl\" -c")
+            os.exec("xmake f --toolchain=clang --cxxstl=\"libstdc++\" -c")
             _build()
         end
-        os.exec("xmake clean -a")
-        os.exec("xmake f --toolchain=llvm -c")
-        _build()
-        os.exec("xmake clean -a")
-        os.exec("xmake f --toolchain=llvm --cxxstl=\"libc++\" -c")
-        _build()
-        os.exec("xmake clean -a")
-        os.exec("xmake f --toolchain=llvm --cxxstl=\"libstdc++\" -c")
-        _build()
-        if is_plat("windows") then
+        if is_subhost("windows") then
             os.exec("xmake clean -a")
-            os.exec("xmake f --toolchain=llvm --cxxstl=\"msstl\" -c")
+            os.exec("xmake f --toolchain=clang --cxxstl=\"msstl\" -c")
             _build()
         end
     end

--- a/tests/projects/c++/libc++/xmake.lua
+++ b/tests/projects/c++/libc++/xmake.lua
@@ -1,0 +1,5 @@
+add_rules("mode.debug", "mode.release")
+target("test")
+    set_kind("binary")
+    add_files("src/*.cpp")
+

--- a/tests/projects/c++/modules/test_base.lua
+++ b/tests/projects/c++/modules/test_base.lua
@@ -26,7 +26,7 @@ function main(t)
             os.exec("xmake f --toolchain=clang -c")
             _build()
             os.exec("xmake clean -a")
-            os.exec("xmake f --toolchain=clang --cxxflags=\"-stdlib=libc++\" -c")
+            os.exec("xmake f --toolchain=clang --cxxstl=\"libc++\" -c")
             _build()
         end
     end

--- a/tests/projects/c++/modules/test_stdmodules.lua
+++ b/tests/projects/c++/modules/test_stdmodules.lua
@@ -31,15 +31,15 @@ function main(t)
             -- os.exec("xmake f -c")
             -- _build()
         -- end
-        local clang = find_tool("clang", {version = true})
+        -- local clang = find_tool("clang", {version = true})
         if clang and clang.version and semver.compare(clang.version, "14.0") >= 0 then
             -- clang don't support libstdc++ std modules atm
             -- os.exec("xmake clean -a")
             -- os.exec("xmake f --toolchain=clang -c")
             -- _build()
-            os.exec("xmake clean -a")
-            os.exec("xmake f --toolchain=clang --cxxflags=\"-stdlib=libc++\" -c")
-            _build()
+            -- os.exec("xmake clean -a")
+            -- os.exec("xmake f --toolchain=clang --cxxflags=\"-stdlib=libc++\" -c")
+            -- _build()
         end
     end
 end

--- a/xmake/modules/package/manager/conan/v2/install_package.lua
+++ b/xmake/modules/package/manager/conan/v2/install_package.lua
@@ -230,7 +230,11 @@ function _conan_generate_compiler_profile(profile, configs, opt)
             profile:print("compiler=" .. toolname)
             profile:print("compiler.cppstd=gnu17")
             if toolname == "clang" then
-                profile:print("compiler.libcxx=libc++")
+                if get_config("cxxstl") == "libc++" then
+                    profile:print("compiler.libcxx=libc++")
+                elseif get_config("cxxstl") == "libstdc++" then
+                    profile:print("compiler.libcxx=libstdc++11")
+                end
             else
                 profile:print("compiler.libcxx=libstdc++11")
             end

--- a/xmake/modules/package/tools/xmake.lua
+++ b/xmake/modules/package/tools/xmake.lua
@@ -169,6 +169,10 @@ function _get_configs_for_host_toolchain(package, configs, opt)
     if toolchain_name then
         table.insert(configs, "--toolchain=" .. toolchain_name)
     end
+    local cxxstl_name = get_config("cxxstl")
+    if cxxstl_name then
+        table.insert(configs, "--cxxstl=" .. cxxstl_name)
+    end
     _get_configs_for_qt(package, configs, opt)
     _get_configs_for_vcpkg(package, configs, opt)
 end

--- a/xmake/modules/private/xrepo/action/install.lua
+++ b/xmake/modules/private/xrepo/action/install.lua
@@ -69,6 +69,8 @@ function menu_options()
         {category = "Cross Compilation Configuration"                        },
         {nil, "sdk",           "kv", nil, "Set the SDK directory of cross toolchain." },
         {nil, "toolchain",     "kv", nil, "Set the toolchain name."          },
+        {category = "Clang/llvm toolchain Configuration"                                },
+        {nil, "cxxstl",        "kv", is_plat("windows") and "msstl" or (is_plat("macosx") and "libc++" or "libstdc++"), "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++", "msstl"}},
         {category = "MingW Configuration"                                    },
         {nil, "mingw",         "kv", nil, "Set the MingW SDK directory."     },
         {category = "XCode SDK Configuration"                                },
@@ -203,6 +205,10 @@ function _install_packages(packages)
     end
     if option.get("toolchain") then
         table.insert(config_argv, "--toolchain=" .. option.get("toolchain"))
+    end
+    -- for clang
+    if option.get("cxxstl") then
+        table.insert(config_argv, "--cxxstl=" .. option.get("cxxstl"))
     end
     -- for mingw
     if option.get("mingw") then

--- a/xmake/platforms/bsd/xmake.lua
+++ b/xmake/platforms/bsd/xmake.lua
@@ -51,6 +51,8 @@ platform("bsd")
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
+                ,   {category = "Clang/llvm toolchain Configuration"                                }
+                ,   {nil, "cxxstl",        "kv", "libstdc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++"}}
                 }
 
             ,   global =

--- a/xmake/platforms/bsd/xmake.lua
+++ b/xmake/platforms/bsd/xmake.lua
@@ -52,7 +52,7 @@ platform("bsd")
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
                 ,   {category = "Clang/llvm toolchain Configuration"                                }
-                ,   {nil, "cxxstl",        "kv", "libstdc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++"}}
+                ,   {nil, "cxxstl",        "kv", "libc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++"}}
                 }
 
             ,   global =

--- a/xmake/platforms/cygwin/xmake.lua
+++ b/xmake/platforms/cygwin/xmake.lua
@@ -43,3 +43,11 @@ platform("cygwin")
     -- set toolchains
     set_toolchains("envs", "cross", "gcc", "clang", "yasm", "gfortran")
 
+    -- set menu
+    set_menu {
+                config =
+                {
+                    {category = "Clang/llvm toolchain Configuration"                                }
+                ,   {nil, "cxxstl",        "kv", "libstdc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++"}}
+                }
+             }

--- a/xmake/platforms/iphoneos/xmake.lua
+++ b/xmake/platforms/iphoneos/xmake.lua
@@ -42,6 +42,8 @@ platform("iphoneos")
                 ,   {nil, "target_minver",           "kv", "auto",       "The Target Minimal Version"        }
                 ,   {nil, "appledev",                "kv", nil,          "The Apple Device Type",
                                                                          values = {"simulator", "iphone", "watchtv", "appletv", "catalyst"}}
+                ,   {category = "Clang/llvm toolchain Configuration"                                }
+                ,   {nil, "cxxstl",        "kv", "libc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++"}}
                 }
 
             ,   global =

--- a/xmake/platforms/linux/xmake.lua
+++ b/xmake/platforms/linux/xmake.lua
@@ -53,6 +53,8 @@ platform("linux")
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
                 ,   {category = "Vcpkg Configuration"                                               }
                 ,   {nil, "vcpkg",          "kv", "auto",       "The Vcpkg Directory"               }
+                ,   {category = "Clang/llvm toolchain Configuration"                                }
+                ,   {nil, "cxxstl",        "kv", "libstdc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++"}}
                 }
 
             ,   global =

--- a/xmake/platforms/macosx/xmake.lua
+++ b/xmake/platforms/macosx/xmake.lua
@@ -62,6 +62,8 @@ platform("macosx")
                 ,   {nil, "qt_sdkver",               "kv", "auto",       "The Qt SDK Version"                }
                 ,   {category = "Vcpkg Configuration"                                                        }
                 ,   {nil, "vcpkg",                   "kv", "auto",       "The Vcpkg Directory"               }
+                ,   {category = "Clang/llvm toolchain Configuration"                                }
+                ,   {nil, "cxxstl",        "kv", "libc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++"}}
                 }
 
             ,   global =

--- a/xmake/platforms/mingw/xmake.lua
+++ b/xmake/platforms/mingw/xmake.lua
@@ -46,6 +46,8 @@ platform("mingw")
                 {
                     {category = "MingW Configuration"                                     }
                 ,   {nil, "mingw",          "kv", nil,          "The MingW SDK Directory" }
+                ,   {category = "Clang/llvm toolchain Configuration"                                }
+                ,   {nil, "cxxstl",        "kv", "libstdc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++"}}
                 }
 
             ,   global =

--- a/xmake/platforms/msys/xmake.lua
+++ b/xmake/platforms/msys/xmake.lua
@@ -43,3 +43,13 @@ platform("msys")
     -- set toolchains
     set_toolchains("envs", "cross", "gcc", "clang", "yasm", "go", "gfortran")
 
+    -- set menu
+    set_menu {
+                config =
+                {
+                    {category = "Clang/llvm toolchain Configuration"                                }
+                ,   {nil, "cxxstl",        "kv", "libstdc++", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++"}}
+                }
+             }
+
+

--- a/xmake/platforms/windows/xmake.lua
+++ b/xmake/platforms/windows/xmake.lua
@@ -71,6 +71,8 @@ platform("windows")
                                                     end                                             }
                 ,   {category = "Vcpkg Configuration"                                               }
                 ,   {nil, "vcpkg",      "kv", "auto", "The Vcpkg Directory"                         }
+                ,   {category = "Clang/llvm toolchain Configuration"                                }
+                ,   {nil, "cxxstl",        "kv", "msstl", "The stdc++ stl library for clang/llvm toolchain", values = {"libc++", "libstdc++", "msstl"}}
                 }
 
             ,   global =

--- a/xmake/toolchains/clang/xmake.lua
+++ b/xmake/toolchains/clang/xmake.lua
@@ -60,6 +60,25 @@ toolchain("clang" .. suffix)
             toolchain:add("ldflags", march)
             toolchain:add("shflags", march)
         end
+
+        local cxxstl = get_config("cxxstl")
+        if cxxstl then
+            assert(cxxstl == "msstl" or cxxstl == "libc++" or cxxstl == "libstdc++", "cxxstl option can only be libc++|libstdc++|msstl")
+            assert((not is_plat("windows")) and cxxstl ~= "msstl", "msstl can only be used on windows plat")
+
+            if cxxstl ~= "msstl" then
+                toolchain:add("cxxflags", "-stdlib=" .. get_config("cxxstl"))
+                toolchain:add("shflags", "-stdlib=" .. get_config("cxxstl"))
+                toolchain:add("ldflags", "-stdlib=" .. get_config("cxxstl"))
+                toolchain:add("mxxflags", "-stdlib=" .. get_config("cxxstl"))
+
+                local sdkdir = toolchain:sdkdir()
+                if cxxstl == "libc++" and sdkdir then
+                    toolchain:add("cxxflags", "-isysroot=" .. sdkdir)
+                    toolchain:add("mxxflags", "-stdlib=" .. sdkdir)
+                end
+            end
+        end
     end)
 end
 toolchain_clang()

--- a/xmake/toolchains/clang/xmake.lua
+++ b/xmake/toolchains/clang/xmake.lua
@@ -64,7 +64,9 @@ toolchain("clang" .. suffix)
         local cxxstl = get_config("cxxstl")
         if cxxstl then
             assert(cxxstl == "msstl" or cxxstl == "libc++" or cxxstl == "libstdc++", "cxxstl option can only be libc++|libstdc++|msstl")
-            assert((not is_plat("windows")) and cxxstl ~= "msstl", "msstl can only be used on windows plat")
+            if not is_plat("windows") then
+                assert(cxxstl ~= "msstl", "msstl can only be used on windows plat")
+            end
 
             if cxxstl ~= "msstl" then
                 toolchain:add("cxxflags", "-stdlib=" .. get_config("cxxstl"))

--- a/xmake/toolchains/clang/xmake.lua
+++ b/xmake/toolchains/clang/xmake.lua
@@ -75,7 +75,7 @@ toolchain("clang" .. suffix)
                 local sdkdir = toolchain:sdkdir()
                 if cxxstl == "libc++" and sdkdir then
                     toolchain:add("cxxflags", "-isysroot=" .. sdkdir)
-                    toolchain:add("mxxflags", "-stdlib=" .. sdkdir)
+                    toolchain:add("mxxflags", "-isysroot=" .. sdkdir)
                 end
             end
         end

--- a/xmake/toolchains/llvm/check.lua
+++ b/xmake/toolchains/llvm/check.lua
@@ -61,7 +61,6 @@ function main(toolchain)
         bindir = try {function () return os.iorunv("llvm-config", {"--bindir"}) end}
         if bindir then
             sdkdir = path.directory(bindir)
-            print("1", sdkdir)
         elseif is_host("linux") and os.isfile("/usr/bin/llvm-ar") then
             sdkdir = "/usr"
         elseif is_host("macosx") then

--- a/xmake/toolchains/llvm/xmake.lua
+++ b/xmake/toolchains/llvm/xmake.lua
@@ -103,16 +103,21 @@ toolchain("llvm")
         end
 
         local cxxstl = get_config("cxxstl")
-        if cxxstl and cxxstl ~= "msstl" then
-            toolchain:add("cxxflags", "-stdlib=" .. get_config("cxxstl"))
-            toolchain:add("shflags", "-stdlib=" .. get_config("cxxstl"))
-            toolchain:add("ldflags", "-stdlib=" .. get_config("cxxstl"))
-            toolchain:add("mxxflags", "-stdlib=" .. get_config("cxxstl"))
+        if cxxstl then
+            assert(cxxstl == "msstl" or cxxstl == "libc++" or cxxstl == "libstdc++", "cxxstl option can only be libc++|libstdc++|msstl")
+            assert((not is_plat("windows")) and cxxstl ~= "msstl", "msstl can only be used on windows plat")
 
-            local sdkdir = toolchain:sdkdir()
-            if cxxstl == "libc++" and sdkdir then
-                toolchain:add("cxxflags", "-isysroot=" .. sdkdir)
-                toolchain:add("mxxflags", "-stdlib=" .. sdkdir)
+            if cxxstl ~= "msstl" then
+                toolchain:add("cxxflags", "-stdlib=" .. get_config("cxxstl"))
+                toolchain:add("shflags", "-stdlib=" .. get_config("cxxstl"))
+                toolchain:add("ldflags", "-stdlib=" .. get_config("cxxstl"))
+                toolchain:add("mxxflags", "-stdlib=" .. get_config("cxxstl"))
+
+                local sdkdir = toolchain:sdkdir()
+                if cxxstl == "libc++" and sdkdir then
+                    toolchain:add("cxxflags", "-isysroot=" .. sdkdir)
+                    toolchain:add("mxxflags", "-isysroot=" .. sdkdir)
+                end
             end
         end
     end)

--- a/xmake/toolchains/llvm/xmake.lua
+++ b/xmake/toolchains/llvm/xmake.lua
@@ -105,7 +105,9 @@ toolchain("llvm")
         local cxxstl = get_config("cxxstl")
         if cxxstl then
             assert(cxxstl == "msstl" or cxxstl == "libc++" or cxxstl == "libstdc++", "cxxstl option can only be libc++|libstdc++|msstl")
-            assert((not is_plat("windows")) and cxxstl ~= "msstl", "msstl can only be used on windows plat")
+            if not is_plat("windows") then
+                assert(cxxstl ~= "msstl", "msstl can only be used on windows plat")
+            end
 
             if cxxstl ~= "msstl" then
                 toolchain:add("cxxflags", "-stdlib=" .. get_config("cxxstl"))

--- a/xmake/toolchains/llvm/xmake.lua
+++ b/xmake/toolchains/llvm/xmake.lua
@@ -101,4 +101,18 @@ toolchain("llvm")
         if bindir and is_host("windows") then
             toolchain:add("runenvs", "PATH", bindir)
         end
+
+        local cxxstl = get_config("cxxstl")
+        if cxxstl and cxxstl ~= "msstl" then
+            toolchain:add("cxxflags", "-stdlib=" .. get_config("cxxstl"))
+            toolchain:add("shflags", "-stdlib=" .. get_config("cxxstl"))
+            toolchain:add("ldflags", "-stdlib=" .. get_config("cxxstl"))
+            toolchain:add("mxxflags", "-stdlib=" .. get_config("cxxstl"))
+
+            local sdkdir = toolchain:sdkdir()
+            if cxxstl == "libc++" and sdkdir then
+                toolchain:add("cxxflags", "-isysroot=" .. sdkdir)
+                toolchain:add("mxxflags", "-stdlib=" .. sdkdir)
+            end
+        end
     end)


### PR DESCRIPTION
introduce --cxxstl flag (named after ndk_cxxstl to retain consistency) to choose which stl library to use for clang

msstl is a no-op and is only here to differentiate package builded with libc++ / libstdc++ and microsoft stl