### PR TITLE
Skip root user check on Haiku OS

### DIFF
--- a/xmake/core/main.lua
+++ b/xmake/core/main.lua
@@ -266,7 +266,7 @@ function main.entry()
     end
 
     -- check run command as root
-    if not option.get("root") and os.getenv("XMAKE_ROOT") ~= 'y' then
+    if not option.get("root") and os.getenv("XMAKE_ROOT") ~= 'y' and os.host() ~= 'haiku' then
         if os.isroot() then
             errors = [[Running xmake as root is extremely dangerous and no longer supported.
 As xmake does not drop privileges on installation you would be giving all

--- a/xmake/core/main.lua
+++ b/xmake/core/main.lua
@@ -238,6 +238,11 @@ function main._exit(ok, errors)
     return retval
 end
 
+-- limit root? @see https://github.com/xmake-io/xmake/pull/4513
+function main._limit_root()
+    return not option.get("root") and os.getenv("XMAKE_ROOT") ~= 'y' and os.host() ~= 'haiku'
+end
+
 -- the main entry function
 function main.entry()
 
@@ -266,7 +271,7 @@ function main.entry()
     end
 
     -- check run command as root
-    if not option.get("root") and os.getenv("XMAKE_ROOT") ~= 'y' and os.host() ~= 'haiku' then
+    if main._limit_root() then
         if os.isroot() then
             errors = [[Running xmake as root is extremely dangerous and no longer supported.
 As xmake does not drop privileges on installation you would be giving all


### PR DESCRIPTION
Haiku OS doesn't have any non-root users, so it doesn't make sense to warn about running as the root user.
