### PR TITLE
Fix vstudio arm64 dectect under Developer Command Prompt

### DIFF
--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -242,9 +242,21 @@ function _find_vstudio(opt)
             local vcvarsall_x86 = _load_vcvarsall(vcvarsall, VisualStudioVersion, "x86", opt)
             local vcvarsall_x64 = _load_vcvarsall(vcvarsall, VisualStudioVersion, "x64", opt)
 
+            -- load vcvarsall for arm64
+            local arch
+            local arch_os = os.arch()
+            if arch_os == "x64" then
+                arch = "x64_arm64"
+            elseif arch_os == "x86" then
+                arch = "x86_arm64"
+            elseif arch_os == "arm64" then
+                arch = "arm64"
+            end
+            local vcvarsall_arm64 = arch and _load_vcvarsall(vcvarsall, version, arch, opt) or nil
+
             -- save results
             local results = {}
-            results[vsvers[VisualStudioVersion]] = {version = VisualStudioVersion, vcvarsall_bat = vcvarsall, vcvarsall = {x86 = vcvarsall_x86, x64 = vcvarsall_x64}}
+            results[vsvers[VisualStudioVersion]] = {version = VisualStudioVersion, vcvarsall_bat = vcvarsall, vcvarsall = {x86 = vcvarsall_x86, x64 = vcvarsall_x64, arm64 = vcvarsall_arm64}}
             return results
         end
     end


### PR DESCRIPTION
Fix find_vstudio detect arm64 toolchain under Developer Command Prompt

