### PR TITLE
[small fix] table.inherit2 should also set metatable in case input table (self) didn't have one

### DIFF
--- a/xmake/core/base/table.lua
+++ b/xmake/core/base/table.lua
@@ -235,6 +235,7 @@ function table.inherit2(self, ...)
             end
         end
     end
+    setmetatable(self, metainfo)
     return self
 end
 


### PR DESCRIPTION
**Expected behavior**: `table.inherit2` redirects function fields starting with `__` (double-underscores) to the metatable of the target input table `self`. Afterwards the table modified this way should have the inherited meta functions in its metatable.

**Actual behavior**: If `self` didn't happen to have a metatable already, a new one is created on the line `local metainfo = getmetatable(self) or {}`. Alleged `__` metafunctions  will be inserted into this new table, however the new table never gets assigned back to `self`, in which case we actually lose the `__` functions.

**Proposal**: Simply do `setmetatable(self, metainfo)` at the end of the function. This is safe even when `self` did have a metatable as we just re-assign the same one back to itself.

The following just demonstrates the scenario at which the bug happened for me.

```Lua
local my_object = {}
local operator_overload = {}

-- override | just for sake of demonstration
function operator_overload.__bor(left, right)
    return left
end

table.inherit2(my_object, operator_overload)
local mt = getmetatable(my_object)
local result = my_object | {}
-- before PR: mt := nil and error was thrown: "attempt to perform bitwise operation on a table value" because lua interpreter couldn't find `__bor`
-- after PR: mt is a table and result is assigned correctly (operator overloaded successfully)
```

P.S.: The real reason I submit this because this seems to be the only way to do in-place operator overloading in outermost configuration scope as getmetatable and setmetatable are removed from global there. `table.inherit` works as expected however that will always return a new table.