### PR TITLE
[small fix] Include C++ module sources in generated CMake targets

### DIFF
--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -137,7 +137,7 @@ end
 function _sourcebatch_is_built(sourcebatch)
     -- we can only use rulename to filter them because sourcekind may be bound to multiple rules
     local rulename = sourcebatch.rulename
-    if rulename == "c.build" or rulename == "c++.build"
+    if rulename == "c.build" or rulename == "c++.build" or rulename == "c++.build.modules"
         or rulename == "asm.build" or rulename == "cuda.build"
         or rulename == "objc.build" or rulename == "objc++.build"
         or rulename == "win.sdk.resource" then


### PR DESCRIPTION
This PR proposes a fix for the following bug:

**Expected:** The `target_sources` function of the generated CMake targets would contain the sources for C++ modules.

**Actual:** The `target_sources` function of the generated CMake targets remain empty, therefore CMake fails to build / generate the project.

**Proposal:** Simply consider the `"c++.build.modules"` rule name in `_sourcebatch_is_built`