### PR TITLE
fix qt.qrc rule

### DIFF
--- a/xmake/rules/qt/qrc/xmake.lua
+++ b/xmake/rules/qt/qrc/xmake.lua
@@ -44,7 +44,7 @@ rule("qt.qrc")
         local rcc = target:data("qt.rcc")
 
         -- get c++ source file for qrc
-        local sourcefile_cpp = path.join(target:autogendir(), "rules", "qt", "qrc", path.basename(sourcefile_qrc) .. ".cpp")
+        local sourcefile_cpp = path.join(target:autogendir(), "rules", "qt", "qrc", path.basename(sourcefile_qrc).. "_" .. hash.uuid4(sourcefile_qrc):split('%-')[1] .. ".cpp")
         local sourcefile_dir = path.directory(sourcefile_cpp)
 
         -- add objectfile


### PR DESCRIPTION
Fix the qt.qrc rule and add multiple qrc files with the same name, which will overwrite each other.