### PR TITLE
Fix CRLF issues with Git

### DIFF
--- a/xmake/modules/devel/git/clone.lua
+++ b/xmake/modules/devel/git/clone.lua
@@ -115,6 +115,15 @@ function main(url, opt)
         table.insert(argv, "core.fsmonitor=false")
     end
 
+    -- set core.autocrlf
+    if opt.autocrlf then
+        table.insert(argv, "-c")
+        table.insert(argv, "core.autocrlf=true")
+    elseif opt.autocrlf == false then
+        table.insert(argv, "-c")
+        table.insert(argv, "core.autocrlf=false")
+    end
+
     -- set outputdir
     if opt.outputdir then
         table.insert(argv, path.translate(opt.outputdir))

--- a/xmake/modules/devel/git/pull.lua
+++ b/xmake/modules/devel/git/pull.lua
@@ -46,6 +46,10 @@ function main(opt)
 
     -- init argv
     local argv = {}
+    if opt.force then
+        table.insert(argv, "-f")
+    end
+
     if opt.fsmonitor then
         table.insert(argv, "-c")
         table.insert(argv, "core.fsmonitor=true")

--- a/xmake/modules/devel/git/pull.lua
+++ b/xmake/modules/devel/git/pull.lua
@@ -46,10 +46,6 @@ function main(opt)
 
     -- init argv
     local argv = {}
-    if opt.force then
-        table.insert(argv, "-f")
-    end
-
     if opt.fsmonitor then
         table.insert(argv, "-c")
         table.insert(argv, "core.fsmonitor=true")
@@ -70,6 +66,10 @@ function main(opt)
     -- set tags
     if opt.tags then
         table.insert(argv, "--tags")
+    end
+
+    if opt.force then
+        table.insert(argv, "-f")
     end
 
     -- use proxy?

--- a/xmake/modules/private/action/require/impl/actions/patch_sources.lua
+++ b/xmake/modules/private/action/require/impl/actions/patch_sources.lua
@@ -28,7 +28,7 @@ import("devel.git")
 -- check sha256
 function _check_sha256(patch_hash, patch_file)
     local ok = (patch_hash == hash.sha256(patch_file))
-    if not ok and is_host("windows") then
+    if not ok then
         -- `git pull` maybe will replace lf to crlf in the patch text automatically on windows.
         -- so we need to attempt to fix this sha256
         --

--- a/xmake/modules/private/action/require/impl/repository.lua
+++ b/xmake/modules/private/action/require/impl/repository.lua
@@ -60,11 +60,11 @@ function _get_packagedir_from_locked_repo(packagename, locked_repo)
     local lastcommit
     if not os.isdir(repodir_local) then
         if repo_global then
-            git.clone(repo_global:directory(), {verbose = option.get("verbose"), outputdir = repodir_local})
+            git.clone(repo_global:directory(), {verbose = option.get("verbose"), outputdir = repodir_local, autocrlf = false})
             lastcommit = repo_global:commit()
         elseif network ~= "private" then
             local remoteurl = proxy.mirror(locked_repo.url) or locked_repo.url
-            git.clone(remoteurl, {verbose = option.get("verbose"), branch = locked_repo.branch, outputdir = repodir_local})
+            git.clone(remoteurl, {verbose = option.get("verbose"), branch = locked_repo.branch, outputdir = repodir_local, autocrlf = false})
         else
             wprint("we cannot lock repository(%s) in private network mode!", locked_repo.url)
             return
@@ -84,7 +84,7 @@ function _get_packagedir_from_locked_repo(packagename, locked_repo)
                 if network ~= "private" then
                     -- pull the latest commit
                     local remoteurl = proxy.mirror(locked_repo.url) or locked_repo.url
-                    git.pull({verbose = option.get("verbose"), remote = remoteurl, branch = locked_repo.branch, repodir = repodir_local})
+                    git.pull({verbose = option.get("verbose"), remote = remoteurl, branch = locked_repo.branch, repodir = repodir_local, force = true})
                     -- re-checkout to the given commit
                     ok = try {function () git.checkout(locked_repo.commit, {verbose = option.get("verbose"), repodir = repodir_local}); return true end}
                 else

--- a/xmake/plugins/repo/main.lua
+++ b/xmake/plugins/repo/main.lua
@@ -52,7 +52,7 @@ function _add(name, url, branch, is_global)
     -- clone repository
     if not os.isdir(url) then
         local remoteurl = proxy.mirror(url) or url
-        git.clone(remoteurl, {verbose = option.get("verbose"), branch = branch, outputdir = repodir})
+        git.clone(remoteurl, {verbose = option.get("verbose"), branch = branch, outputdir = repodir, autocrlf = false})
     end
 
     -- add url
@@ -115,13 +115,13 @@ function _update()
                     -- only update the local repository with the remote url
                     if not os.isdir(repo:url()) then
                         vprint("pulling repository(%s): %s to %s ..", repo:name(), repo:url(), repodir)
-                        git.pull({verbose = option.get("verbose"), branch = repo:branch(), repodir = repodir})
+                        git.pull({verbose = option.get("verbose"), branch = repo:branch(), repodir = repodir, force = true})
                         io.save(path.join(repodir, "updated"), {})
                     end
                 else
                     vprint("cloning repository(%s): %s to %s ..", repo:name(), repo:url(), repodir)
                     local remoteurl = proxy.mirror(repo:url()) or repo:url()
-                    git.clone(remoteurl, {verbose = option.get("verbose"), branch = repo:branch(), outputdir = repodir})
+                    git.clone(remoteurl, {verbose = option.get("verbose"), branch = repo:branch(), outputdir = repodir, autocrlf = false})
                     io.save(path.join(repodir, "updated"), {})
                 end
                 pulled[repodir] = true


### PR DESCRIPTION
- Disables core.autocrlf when cloning xmake repositories (to avoid checksum issues)
- When checksum fails, try to replace \r\n to \n even on other platforms (they may use a repository cloned from Windows, for example WSL)
- Pass -f when updating a repository using git pull, changes may be caused by crlf issues. This will also override any change made by the user (which I think is the expected behavior when updating the repositories)