### PR TITLE
Set CMAKE_OSX_ARCHITECTURES on macosx

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -429,6 +429,7 @@ function _get_configs_for_appleos(package, configs, opt)
     elseif package:is_plat("macosx") then
         envs.CMAKE_SYSTEM_NAME = "Darwin"
     end
+    envs.CMAKE_OSX_ARCHITECTURES = package:arch()
     envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK = "BOTH"


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/prop_tgt/OSX_ARCHITECTURES.html

macosx上尤其是交叉编译时需要设置目标target -arch，否则会报错 building for macOS-arm64 but attempting to link with file built for unknown-x86_64