### PR TITLE
fix rust local path resolution on windows

### DIFF
--- a/xmake/modules/package/manager/cargo/install_package.lua
+++ b/xmake/modules/package/manager/cargo/install_package.lua
@@ -40,6 +40,7 @@ function _translate_local_path_in_deps(cargotoml, rootdir)
         if not path.is_absolute(localpath) then
             localpath = path.absolute(localpath, rootdir)
         end
+        localpath = localpath:gsub("\\", "/")
         return "path = \"" .. localpath .. "\""
     end)
     io.writefile(cargotoml, content)


### PR DESCRIPTION
This commit fixes local path resolution for rust Cargo.toml crates on
windows

The issue occured when a rust `Cargo.toml` file used local paths to specify a dependency, e.g.

```toml
[dependencies]
patternsleuth = { path = "../patternsleuth/patternsleuth", features = ["process-internal"] }
```

In this case, xmake would resolve the path to contain a single backslash on windows, and try to give that to cargo. While trying to parse this, cargo would consider `\` to be an escaping character and try to read an escape sequence, producing the following error message:

```
Caused by:
  could not parse input as TOML

Caused by:
  TOML parse error at line 7, column 31
    |
  7 | patternsleuth = { path = "F:\ue4sswork\RE-UE4SS\deps\first\patternsleuth\patternsleuth", features = ["process-internal"] }
    |                               ^
  invalid unicode 4-digit hex code
```
