### PR TITLE
fix cuda linkdirs

### DIFF
--- a/xmake/modules/detect/sdks/find_cuda.lua
+++ b/xmake/modules/detect/sdks/find_cuda.lua
@@ -106,10 +106,8 @@ function _find_cuda(sdkdir)
         local subdir = is_arch("x64") and "x64" or "Win32"
         table.insert(linkdirs, path.join(sdkdir, "lib", subdir))
     elseif is_host("linux") and is_arch("x86_64") then
-        table.insert(linkdirs, path.join(sdkdir, "lib64", "stubs"))
         table.insert(linkdirs, path.join(sdkdir, "lib64"))
     else
-        table.insert(linkdirs, path.join(sdkdir, "lib", "stubs"))
         table.insert(linkdirs, path.join(sdkdir, "lib"))
     end
 


### PR DESCRIPTION
issue：https://github.com/xmake-io/xmake/issues/4686

解决 libcuda.so 引用到 /usr/local/cuda/lib64/stubs 目录的问题，使用用户 LD_LIBRARY_PATH 指定的路径搜索 cuda 动态库。

NVIDIA 官网也有对应的解释：https://forums.developer.nvidia.com/t/checkmacros-cpp-272-error-code-1-cuda-runtime-cuda-driver-is-a-stub-library/202911/9