### PR TITLE
support wdk 10.0.22621.0 on windows

### DIFF
--- a/xmake/modules/os/winver.lua
+++ b/xmake/modules/os/winver.lua
@@ -63,6 +63,14 @@ function ntddi_version(name)
     ,   rs1    = "0002"
     ,   rs2    = "0003"
     ,   rs3    = "0004"
+    ,   rs4    = "0005"
+    ,   rs5    = "0006"
+    ,   h1     = "0007"
+    ,   vb     = "0008"
+    ,   nm     = "0009"
+    ,   fe     = "000A"
+    ,   co     = "000B"
+    ,   ni     = "000C"
     }
 
     -- get subvalue


### PR DESCRIPTION
example:

xmake f --wdk_winver=win10_ni -v
configure
{
    ccache = true
    wdk_sdkver = 10.0.22621.0
    wdk = C:\Program Files (x86)\Windows Kits\10\
    plat = windows
    vs = 2022
    host = windows
    ndk_stdcxx = true
    mode = debug
    buildir = build
    arch = x64
    kind = static
    wdk_winver = win10_ni
}

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

