### PR TITLE
change of objectfiles are handled for modules

### DIFF
--- a/tests/projects/c++/modules/staticlib/xmake.lua
+++ b/tests/projects/c++/modules/staticlib/xmake.lua
@@ -3,7 +3,8 @@ set_languages("c++20")
 
 target("mod")
     set_kind("static")
-    add_files("src/mod.mpp", "src/mod.cpp", {public = true})
+    add_files("src/mod.mpp", {public = true})
+    add_files("src/mod.cpp")
 
 target("hello")
     set_kind("binary")

--- a/tests/projects/c++/modules/staticlib_without_cpp/xmake.lua
+++ b/tests/projects/c++/modules/staticlib_without_cpp/xmake.lua
@@ -3,4 +3,4 @@ set_languages("c++20")
 
 target("mod")
     set_kind("static")
-    add_files("src/mod.mpp")
+    add_files("src/mod.mpp", {public = true})

--- a/xmake/rules/c++/modules/modules_support/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/builder.lua
@@ -31,7 +31,7 @@ import("dependency_scanner")
 
 -- build target modules
 function _build_modules(target, sourcebatch, modules, opt)
-    local objectfiles = dependency_scanner.sort_modules_by_dependencies(sourcebatch.objectfiles, modules)
+    local objectfiles = sourcebatch.objectfiles
     _builder(target).populate_module_map(target, modules)
 
     -- build modules

--- a/xmake/rules/c++/modules/modules_support/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/builder.lua
@@ -45,11 +45,6 @@ function _build_modules(target, sourcebatch, modules, opt)
         cppfile = cppfile or module.cppfile
 
         local fileconfig = target:fileconfig(cppfile)
-        local bmifile = provide and compiler_support.get_bmi_path(provide.bmi)
-        -- add objectfile if module is not from external dep
-        if not (fileconfig and fileconfig.external) then
-            target:add("objectfiles", objectfile)
-        end
 
         local deps = {}
         for _, dep in ipairs(table.keys(module.requires or {})) do

--- a/xmake/rules/c++/modules/modules_support/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/builder.lua
@@ -32,7 +32,6 @@ import("dependency_scanner")
 -- build target modules
 function _build_modules(target, sourcebatch, modules, opt)
     local objectfiles = dependency_scanner.sort_modules_by_dependencies(sourcebatch.objectfiles, modules)
-
     _builder(target).populate_module_map(target, modules)
 
     -- build modules

--- a/xmake/rules/c++/modules/modules_support/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/builder.lua
@@ -44,13 +44,12 @@ function _build_modules(target, sourcebatch, modules, opt)
         local name, provide, cppfile = compiler_support.get_provided_module(module)
         cppfile = cppfile or module.cppfile
 
-        local fileconfig = target:fileconfig(cppfile)
-
         local deps = {}
         for _, dep in ipairs(table.keys(module.requires or {})) do
             table.insert(deps, opt.batchjobs and target:name() .. dep or dep)
         end
 
+        local fileconfig = target:fileconfig(cppfile)
         opt.build_module(deps, module, name, provide, objectfile, cppfile, fileconfig)
 
         ::CONTINUE::

--- a/xmake/rules/c++/modules/modules_support/clang/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/builder.lua
@@ -306,9 +306,6 @@ function make_module_buildcmds(target, batchcmds, opt)
             local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {batchcmds = true, sourcefile = opt.cppfile, build_objectfile = build_objectfile, name = name})
             _batchcmds_compile(batchcmds, target, first_step, opt.cppfile, precompile and bmifile or opt.objectfile)
 
-            local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {batchcmds = true, sourcefile = opt.cppfile, external = external, name = name})
-            _batchcmds_compile(batchcmds, target, first_step, opt.cppfile, precompile and bmifile or opt.objectfile)
-
             if second_step then
                 _batchcmds_compile(batchcmds, target, second_step, opt.cppfile, opt.objectfile, {bmifile = bmifile})
             end

--- a/xmake/rules/c++/modules/modules_support/clang/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/builder.lua
@@ -242,7 +242,10 @@ function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
                         end
                     end
 
-                local build_objectfile = target:kind() == "binary"
+                local fileconfig = target:fileconfig(opt.cppfile)
+                local public = fileconfig and fileconfig.public
+                local external = fileconfig and fileconfig.external
+                local build_objectfile = target:kind() == "binary" or (not public and not external)
 
                 local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {sourcefile = opt.cppfile, build_objectfile = build_objectfile, name = name})
 
@@ -295,8 +298,13 @@ function make_module_buildcmds(target, batchcmds, opt)
             batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:name(), name or opt.cppfile)
             batchcmds:mkdir(path.directory(opt.objectfile))
 
-        local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {batchcmds = true, sourcefile = opt.cppfile, build_objectfile = build_objectfile, name = name})
-        _batchcmds_compile(batchcmds, target, first_step, opt.cppfile, precompile and bmifile or opt.objectfile)
+            local fileconfig = target:fileconfig(opt.cppfile)
+            local public = fileconfig and fileconfig.public
+            local external = fileconfig and fileconfig.external
+            local build_objectfile = target:kind() == "binary" or (not public and not external)
+
+            local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {batchcmds = true, sourcefile = opt.cppfile, build_objectfile = build_objectfile, name = name})
+            _batchcmds_compile(batchcmds, target, first_step, opt.cppfile, precompile and bmifile or opt.objectfile)
 
             local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {batchcmds = true, sourcefile = opt.cppfile, external = external, name = name})
             _batchcmds_compile(batchcmds, target, first_step, opt.cppfile, precompile and bmifile or opt.objectfile)

--- a/xmake/rules/c++/modules/modules_support/clang/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/builder.lua
@@ -38,12 +38,12 @@ function _make_modulebuildflags(target, provide, bmifile, opt)
 
     local flags
     local precompile = false
-    if module_outputflag and provide and not opt.external then -- one step compilation of named module, clang >= 16
+    if module_outputflag and provide and opt.build_objectfile then -- one step compilation of named module, clang >= 16
         flags = {{"-x", "c++-module", module_outputflag .. bmifile}}
     elseif provide then -- two step compilation of named module
         precompile = true
         flags = {{"-x", "c++-module", "--precompile"}}
-        if not opt.external then
+        if opt.build_objectfile then
            table.insert(flags, {})
         end
     else -- internal module, no bmi needed
@@ -199,7 +199,7 @@ function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
     return {
         name = job_name,
         deps = deps,
-        sourcefile = cppfile,
+        sourcefile = opt.cppfile,
         job = batchjobs:newjob(name or opt.cppfile, function(index, total)
 
             local compinst = compiler.load("cxx", {target = target})
@@ -242,10 +242,9 @@ function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
                         end
                     end
 
-                    local fileconfig = target:fileconfig(opt.cppfile)
-                    local external = fileconfig and fileconfig.external
+                local build_objectfile = target:kind() == "binary"
 
-                    local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {sourcefile = opt.cppfile, external = external, name = name})
+                local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {sourcefile = opt.cppfile, build_objectfile = build_objectfile, name = name})
 
                     _compile(target, first_step, opt.cppfile, precompile and bmifile or opt.objectfile)
 
@@ -289,14 +288,15 @@ function make_module_buildcmds(target, batchcmds, opt)
         build = should_build(target, opt.cppfile, bmifile, {objectfile = opt.objectfile, requires = opt.module.requires})
     end
 
+        local build_objectfile = target:kind() == "binary"
     if build then
         -- compile if it's a named module
         if provide or compiler_support.has_module_extension(opt.cppfile) then
             batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:name(), name or opt.cppfile)
             batchcmds:mkdir(path.directory(opt.objectfile))
 
-            local fileconfig = target:fileconfig(opt.cppfile)
-            local external = fileconfig and fileconfig.external
+        local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {batchcmds = true, sourcefile = opt.cppfile, build_objectfile = build_objectfile, name = name})
+        _batchcmds_compile(batchcmds, target, first_step, opt.cppfile, precompile and bmifile or opt.objectfile)
 
             local precompile, first_step, second_step = _make_modulebuildflags(target, provide, bmifile, {batchcmds = true, sourcefile = opt.cppfile, external = external, name = name})
             _batchcmds_compile(batchcmds, target, first_step, opt.cppfile, precompile and bmifile or opt.objectfile)

--- a/xmake/rules/c++/modules/modules_support/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/compiler_support.lua
@@ -77,7 +77,14 @@ function cull_objectfiles(target, modules, sourcebatch)
         local module = modules[objectfile]
         local _, provide, _ = get_provided_module(module)
 
-        if not provide then
+        if provide then
+            local fileconfig = target:fileconfig(sourcefile)
+            local public = fileconfig and fileconfig.public
+            local external = fileconfig and fileconfig.external
+            if not public and not external then
+                table.insert(sourcebatch.objectfiles, objectfile)
+            end
+        else
             table.insert(sourcebatch.objectfiles, objectfile)
         end
     end

--- a/xmake/rules/c++/modules/modules_support/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/compiler_support.lua
@@ -64,14 +64,20 @@ function patch_sourcebatch(target, sourcebatch)
 end
 
 -- cull sourcebatch objectfiles
-function cull_objectfiles(target, sourcebatch)
+function cull_objectfiles(target, modules, sourcebatch)
 
-    sourcebatch.sourcekind = "cxx"
+    -- don't cull for executables
+    if target:kind() == "binary" then
+        return
+    end
+
     sourcebatch.objectfiles = {}
     for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
-        local fileconfig = target:fileconfig(sourcefile)
-        if not (fileconfig and fileconfig.external) then
-            local objectfile = target:objectfile(sourcefile)
+        local objectfile = target:objectfile(sourcefile)
+        local module = modules[objectfile]
+        local _, provide, _ = get_provided_module(module)
+
+        if not provide then
             table.insert(sourcebatch.objectfiles, objectfile)
         end
     end

--- a/xmake/rules/c++/modules/modules_support/dependency_scanner.lua
+++ b/xmake/rules/c++/modules/modules_support/dependency_scanner.lua
@@ -182,7 +182,7 @@ function _get_edges(nodes, modules)
               for _, required_node in ipairs(nodes) do
                   local name, _, _ = compiler_support.get_provided_module(modules[required_node])
                   if name and name == required_name then
-                      table.insert(edges, {node, required_node})
+                      table.insert(edges, {required_node, node})
                       break
                   end
               end
@@ -398,7 +398,7 @@ end
 -- topological sort
 function sort_modules_by_dependencies(objectfiles, modules)
     local result = {}
-    local edges, nodeps_nodes = _get_edges(objectfiles, modules)
+    local edges = _get_edges(objectfiles, modules)
     local dag = graph.new(true)
     for _, e in ipairs(edges) do
         dag:add_edge(e[1], e[2])
@@ -418,6 +418,7 @@ function sort_modules_by_dependencies(objectfiles, modules)
     for _, objectfile in ipairs(objectfiles_sorted) do
         table.insert(result, objectfile)
     end
+
     local objectfiles_sorted_set = hashset.from(objectfiles_sorted)
     for _, objectfile in ipairs(objectfiles) do
         if not objectfiles_sorted_set:has(objectfile) then

--- a/xmake/rules/c++/modules/modules_support/dependency_scanner.lua
+++ b/xmake/rules/c++/modules/modules_support/dependency_scanner.lua
@@ -422,7 +422,11 @@ function sort_modules_by_dependencies(objectfiles, modules)
     local objectfiles_sorted_set = hashset.from(objectfiles_sorted)
     for _, objectfile in ipairs(objectfiles) do
         if not objectfiles_sorted_set:has(objectfile) then
-            table.insert(result, objectfile)
+            -- cull unreferenced named module but add non-module files
+            local _, provide, _ = compiler_support.get_provided_module(modules[objectfile])
+            if not provide then
+                table.insert(result, objectfile)
+            end
         end
     end
     return result

--- a/xmake/rules/c++/modules/modules_support/gcc/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/gcc/builder.lua
@@ -99,24 +99,14 @@ end
 function _get_maplines(target, module)
     local maplines = {}
 
-    local m_name, m = compiler_support.get_provided_module(module)
+    local m_name, m, cppfile = compiler_support.get_provided_module(module)
     if m then
         table.insert(maplines, m_name .. " " .. compiler_support.get_bmi_path(m.bmi))
     end
 
     for required, _ in table.orderpairs(module.requires) do
-        local dep_module
-        local dep_target
-
-        -- if not in target dep
-        if not dep_module then
-            dep_module = get_from_target_mapper(target, required)
-            if dep_module then
-                dep_target = target
-            end
-        end
-
-        assert(dep_module, "module dependency %s required for %s not found", required, m_name)
+        local dep_module = get_from_target_mapper(target, required)
+        assert(dep_module, "module dependency %s required for %s not found", required, m_name or module.cppfile)
 
         local bmifile = dep_module.bmi
         local mapline
@@ -136,7 +126,7 @@ function _get_maplines(target, module)
 
         -- append deps
         if dep_module.opt and dep_module.opt.deps then
-            local deps = _get_maplines(dep_target, { name = dep_module.name, bmi = bmifile, requires = dep_module.opt.deps })
+            local deps = _get_maplines(target, {name = dep_module.name, bmi = bmifile, requires = dep_module.opt.deps})
             table.join2(maplines, deps)
         end
     end

--- a/xmake/rules/c++/modules/modules_support/gcc/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/gcc/builder.lua
@@ -107,13 +107,6 @@ function _get_maplines(target, module)
     for required, _ in table.orderpairs(module.requires) do
         local dep_module
         local dep_target
-        for _, dep in ipairs(target:orderdeps()) do
-            dep_module = get_from_target_mapper(dep, required)
-            if dep_module then
-                dep_target = dep
-                break
-            end
-        end
 
         -- if not in target dep
         if not dep_module then
@@ -173,16 +166,6 @@ end
 
 -- populate module map
 function populate_module_map(target, modules)
-
-    -- append all modules
-    for _, module in pairs(modules) do
-        local name, provide = compiler_support.get_provided_module(module)
-        if provide then
-            add_module_to_target_mapper(target, name, provide.sourcefile, compiler_support.get_bmi_path(provide.bmi))
-        end
-    end
-
-    -- then update their deps
     for _, module in pairs(modules) do
         local name, provide = compiler_support.get_provided_module(module)
         if provide then

--- a/xmake/rules/c++/modules/modules_support/gcc/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/gcc/compiler_support.lua
@@ -99,7 +99,6 @@ end
 
 -- not supported atm
 function get_stdmodules(target)
-    return {}
 end
 
 function get_bmi_extension()

--- a/xmake/rules/c++/modules/modules_support/msvc/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/msvc/builder.lua
@@ -37,7 +37,7 @@ function _make_modulebuildflags(target, provide, bmifile, opt)
     local ifconlyflag = compiler_support.get_ifconlyflag(target)
     local interfaceflag = compiler_support.get_interfaceflag(target)
     local internalpartitionflag = compiler_support.get_internalpartitionflag(target)
-    local ifconly = (opt.external and ifconlyflag)
+    local ifconly = (not opt.build_objectfile and ifconlyflag)
 
     local flags
     if provide then -- named module
@@ -259,9 +259,8 @@ function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
                         end
                     end
 
-                    local fileconfig = target:fileconfig(opt.cppfile)
-                    local external = fileconfig and fileconfig.external
-                    local flags = _make_modulebuildflags(target, provide, bmifile, {external = external})
+                local build_objectfile = target:kind() == "binary"
+                local flags = _make_modulebuildflags(target, provide, bmifile, {build_objectfile = build_objectfile})
 
                     _compile(target, flags, opt.cppfile, opt.objectfile)
                 else
@@ -307,10 +306,9 @@ function make_module_buildcmds(target, batchcmds, should_build, mark_build, opt)
             batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:name(), name or opt.cppfile)
             batchcmds:mkdir(path.directory(opt.objectfile))
 
-            local fileconfig = target:fileconfig(opt.cppfile)
-                local external = fileconfig and fileconfig.external
-            local flags = _make_modulebuildflags(target, provide, bmifile, opt.cppfile, opt.objectfile, {batchcmds = true, external = external})
-            _batchcmds_compile(batchcmds, target, flags, opt.cppfile, objectfile)
+            local build_objectfile = target:kind() == "binary"
+            local flags = _make_modulebuildflags(target, provide, bmifile, opt.cppfile, {batchcmds = true, build_objectfile = build_objectfile})
+            _batchcmds_compile(batchcmds, target, flags, opt.cppfile, opt.objectfile)
         else
             batchcmds:rm(opt.objectfile) -- force rebuild for .cpp files
         end

--- a/xmake/rules/c++/modules/modules_support/msvc/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/msvc/builder.lua
@@ -259,7 +259,10 @@ function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
                         end
                     end
 
-                local build_objectfile = target:kind() == "binary"
+                local fileconfig = target:fileconfig(opt.cppfile)
+                local public = fileconfig and fileconfig.public
+                local external = fileconfig and fileconfig.external
+                local build_objectfile = target:kind() == "binary" or (not public and not external)
                 local flags = _make_modulebuildflags(target, provide, bmifile, {build_objectfile = build_objectfile})
 
                     _compile(target, flags, opt.cppfile, opt.objectfile)
@@ -306,7 +309,10 @@ function make_module_buildcmds(target, batchcmds, should_build, mark_build, opt)
             batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:name(), name or opt.cppfile)
             batchcmds:mkdir(path.directory(opt.objectfile))
 
-            local build_objectfile = target:kind() == "binary"
+            local fileconfig = target:fileconfig(opt.cppfile)
+            local public = fileconfig and fileconfig.public
+            local external = fileconfig and fileconfig.external
+            local build_objectfile = target:kind() == "binary" or (not public and not external)
             local flags = _make_modulebuildflags(target, provide, bmifile, opt.cppfile, {batchcmds = true, build_objectfile = build_objectfile})
             _batchcmds_compile(batchcmds, target, flags, opt.cppfile, opt.objectfile)
         else

--- a/xmake/rules/c++/modules/modules_support/msvc/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/msvc/builder.lua
@@ -259,11 +259,11 @@ function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
                         end
                     end
 
-                local fileconfig = target:fileconfig(opt.cppfile)
-                local public = fileconfig and fileconfig.public
-                local external = fileconfig and fileconfig.external
-                local build_objectfile = target:kind() == "binary" or (not public and not external)
-                local flags = _make_modulebuildflags(target, provide, bmifile, {build_objectfile = build_objectfile})
+                    local fileconfig = target:fileconfig(opt.cppfile)
+                    local public = fileconfig and fileconfig.public
+                    local external = fileconfig and fileconfig.external
+                    local build_objectfile = target:kind() == "binary" or (not public and not external)
+                    local flags = _make_modulebuildflags(target, provide, bmifile, {build_objectfile = build_objectfile})
 
                     _compile(target, flags, opt.cppfile, opt.objectfile)
                 else

--- a/xmake/rules/c++/modules/xmake.lua
+++ b/xmake/rules/c++/modules/xmake.lua
@@ -98,6 +98,9 @@ rule("c++.build.modules.builder")
             compiler_support.patch_sourcebatch(target, sourcebatch, opt)
             local modules = dependency_scanner.get_module_dependencies(target, sourcebatch, opt)
 
+            -- avoid linking culled objectfiles
+            sourcebatch.objectfiles = dependency_scanner.sort_modules_by_dependencies(sourcebatch.objectfiles, modules)
+
             -- build modules
             builder.build_modules_for_batchjobs(target, batchjobs, sourcebatch, modules, opt)
 
@@ -149,6 +152,9 @@ rule("c++.build.modules.builder")
 
             compiler_support.patch_sourcebatch(target, sourcebatch, opt)
             local modules = dependency_scanner.get_module_dependencies(target, sourcebatch, opt)
+
+            -- avoid linking culled objectfiles
+            sourcebatch.objectfiles = dependency_scanner.sort_modules_by_dependencies(sourcebatch.objectfiles, modules)
 
             -- build headerunits
             builder.build_headerunits_for_batchcmds(target, batchcmds, sourcebatch, modules, opt)

--- a/xmake/rules/c++/modules/xmake.lua
+++ b/xmake/rules/c++/modules/xmake.lua
@@ -98,8 +98,8 @@ rule("c++.build.modules.builder")
             compiler_support.patch_sourcebatch(target, sourcebatch, opt)
             local modules = dependency_scanner.get_module_dependencies(target, sourcebatch, opt)
 
-            -- avoid linking culled objectfiles
-            sourcebatch.objectfiles = dependency_scanner.sort_modules_by_dependencies(sourcebatch.objectfiles, modules)
+            -- avoid building non referenced modules
+            sourcebatch.objectfiles = dependency_scanner.sort_modules_by_dependencies(target, sourcebatch.objectfiles, modules)
 
             -- build modules
             builder.build_modules_for_batchjobs(target, batchjobs, sourcebatch, modules, opt)
@@ -153,8 +153,8 @@ rule("c++.build.modules.builder")
             compiler_support.patch_sourcebatch(target, sourcebatch, opt)
             local modules = dependency_scanner.get_module_dependencies(target, sourcebatch, opt)
 
-            -- avoid linking culled objectfiles
-            sourcebatch.objectfiles = dependency_scanner.sort_modules_by_dependencies(sourcebatch.objectfiles, modules)
+            -- avoid building non referenced modules
+            sourcebatch.objectfiles = dependency_scanner.sort_modules_by_dependencies(target, sourcebatch.objectfiles, modules)
 
             -- build headerunits
             builder.build_headerunits_for_batchcmds(target, batchcmds, sourcebatch, modules, opt)
@@ -163,7 +163,7 @@ rule("c++.build.modules.builder")
             builder.build_modules_for_batchcmds(target, batchcmds, sourcebatch, modules, opt)
 
             -- cull external modules objectfile
-            compiler_support.cull_objectfiles(target, modules, sourcebatch)
+            -- compiler_support.cull_objectfiles(target, modules, sourcebatch)
         else
             -- avoid duplicate linking of object files of non-module programs
             sourcebatch.objectfiles = {}

--- a/xmake/rules/c++/modules/xmake.lua
+++ b/xmake/rules/c++/modules/xmake.lua
@@ -100,7 +100,7 @@ rule("c++.build.modules.builder")
             builder.build_headerunits_for_batchjobs(target, batchjobs, sourcebatch, modules, opt)
 
             -- cull external modules objectfile
-            compiler_support.cull_objectfiles(target, sourcebatch)
+            compiler_support.cull_objectfiles(target, modules, sourcebatch)
         else
             -- avoid duplicate linking of object files of non-module programs
             sourcebatch.objectfiles = {}
@@ -147,7 +147,7 @@ rule("c++.build.modules.builder")
             builder.build_modules_for_batchcmds(target, batchcmds, sourcebatch, modules, opt)
 
             -- cull external modules objectfile
-            compiler_support.cull_objectfiles(target, sourcebatch)
+            compiler_support.cull_objectfiles(target, modules, sourcebatch)
         else
             -- avoid duplicate linking of object files of non-module programs
             sourcebatch.objectfiles = {}

--- a/xmake/rules/c++/modules/xmake.lua
+++ b/xmake/rules/c++/modules/xmake.lua
@@ -76,7 +76,12 @@ rule("c++.build.modules.builder")
             end
 
             -- append std module
-            table.join2(sourcebatch.sourcefiles, compiler_support.get_stdmodules(target) or {})
+            local std_modules = compiler_support.get_stdmodules(target)
+            if std_modules then
+                table.join2(sourcebatch.sourcefiles, std_modules)
+                target:fileconfig_set(std_modules[1], {external = true})
+                target:fileconfig_set(std_modules[2], {external = true})
+            end
 
             -- extract packages modules dependencies
             local package_modules_data = dependency_scanner.get_all_packages_modules(target, opt)
@@ -84,7 +89,7 @@ rule("c++.build.modules.builder")
                 -- append to sourcebatch
                 for _, package_module_data in table.orderpairs(package_modules_data) do
                     table.insert(sourcebatch.sourcefiles, package_module_data.file)
-                    target:fileconfig_add(package_module_data.file, {external = true, defines = package_module_data.metadata.defines})
+                    target:fileconfig_set(package_module_data.file, {external = true, defines = package_module_data.metadata.defines})
                 end
             end
 
@@ -123,7 +128,12 @@ rule("c++.build.modules.builder")
             end
 
             -- append std module
-            table.join2(sourcebatch.sourcefiles, compiler_support.get_stdmodules(target) or {})
+            local std_modules = compiler_support.get_stdmodules(target)
+            if std_modules then
+                table.join2(sourcebatch.sourcefiles, std_modules)
+                target:fileconfig_set(std_modules[1], {external = true})
+                target:fileconfig_set(std_modules[2], {external = true})
+            end
 
             -- extract packages modules dependencies
             local package_modules_data = dependency_scanner.get_all_packages_modules(target, opt)
@@ -131,7 +141,7 @@ rule("c++.build.modules.builder")
                 -- append to sourcebatch
                 for _, package_module_data in table.orderpairs(package_modules_data) do
                     table.insert(sourcebatch.sourcefiles, package_module_data.file)
-                    target:fileconfig_add(package_module_data.file, {external = true, defines = package_module_data.metadata.defines})
+                    target:fileconfig_set(package_module_data.file, {external = true, defines = package_module_data.metadata.defines})
                 end
             end
 


### PR DESCRIPTION
at first i taught objectfiles of modules should be merge into libraries files, but isn't the right way, so now libraries doesn't build module objectfiles, only consumer executables will build them

draft because https://github.com/xmake-io/xmake/pull/4687 should be merge before (so it will not pass de CI for now)