### PR TITLE
Add ldflags to export attributes loop

### DIFF
--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -86,7 +86,7 @@ function main(target)
         --
         if target:data("inherit.links.exportlinks") ~= false then
             if targetkind == "static" then
-                for _, name in ipairs({"rpathdirs", "frameworkdirs", "frameworks", "linkdirs", "links", "syslinks"}) do
+                for _, name in ipairs({"rpathdirs", "frameworkdirs", "frameworks", "linkdirs", "links", "syslinks", "ldflags"}) do
                     local values = _get_values_from_target(target, name)
                     if values and #values > 0 then
                         target:add(name, values, {public = true})


### PR DESCRIPTION
This fixes https://github.com/xmake-io/xmake-repo/issues/3224.

Verified with the example project provided in the issue on Ubuntu with GCC compiler. 

Documentation about how to contribute to xmake is poor so I dont know how to run tests locally. I just compiled xmake, modified `inherit_links.lua` and tested on my project. 