### PR TITLE
force to apply -arch arm64 for autoconf

### DIFF
--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -324,6 +324,9 @@ function buildenvs(package, opt)
                 envs.CPP      = _translate_windows_bin_path(envs.CPP)
                 envs.RANLIB   = _translate_windows_bin_path(envs.RANLIB)
             end
+        elseif package:is_plat("macosx") then
+            -- force to apply shflags on macosx https://gmplib.org/manual/Known-Build-Problems
+            envs.CC = envs.CC .. " -arch " .. package:arch()
         elseif package:is_plat("cross") or package:has_tool("ar", "ar", "emar") then
             -- only for cross-toolchain
             envs.CXX = package:build_getenv("cxx")


### PR DESCRIPTION
autoconf 交叉编译到 macosx arm64 的时候经常无法正确指定 -arch ，目前需要手动指定 env，非常麻烦，这一 patch 修复这一问题。相关包：

https://github.com/xmake-io/xmake-repo/pull/3256
https://github.com/xmake-io/xmake-repo/pull/2611