### PR TITLE
fix: fix compile_commands when args too long

### DIFF
--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -222,7 +222,7 @@ function _add_target_source_commands(jsonfile, target)
         if sourcekind and _sourcebatch_is_built(sourcebatch) then
             for index, sourcefile in ipairs(sourcebatch.sourcefiles) do
                 local objectfile = sourcebatch.objectfiles[index]
-                local arguments = table.join(compiler.compargv(sourcefile, objectfile, {target = target, sourcekind = sourcekind}))
+                local arguments = table.join(compiler.compargv(sourcefile, objectfile, {target = target, sourcekind = sourcekind, rawargs=true}))
                 _make_arguments(jsonfile, arguments, {sourcefile = sourcefile, target = target})
             end
         end


### PR DESCRIPTION
#4734 

值得注意的是，这只修复了issue中提到的windows下的参数过长变文件问题
linux下的过长参数消失问题需要另行解决