### PR TITLE
config the project when running xmake clean

### DIFF
--- a/xmake/actions/clean/main.lua
+++ b/xmake/actions/clean/main.lua
@@ -158,6 +158,9 @@ function main()
     -- lock the whole project
     project.lock()
 
+    -- config it first
+    task.run("config", {}, {disable_dump = true})
+
     -- get the target name
     local targetname = option.get("target")
 


### PR DESCRIPTION
Without this, package rules are not loaded and we get an error
```
lynix@SirDesktop:/mnt/c/Projets/Perso/NazaraNext/NazaraEngine$ xmake clean
error: unknown source file: src\Nazara\Renderer\Resources\Shaders\DebugDraw.nzsl
```

with
```lua
	if has_config("compile_shaders") then
		add_rules("@nzsl/compile.shaders", { inplace = true })
		for _, filepath in pairs(table.join(os.files("src/Nazara/" .. name .. "/Resources/**.nzsl"), os.files("src/Nazara/" .. name .. "/Resources/**.nzslb"))) do
			add_files(filepath)
		end
	end
```