### PR TITLE
Add module redeclaration check

### DIFF
--- a/tests/projects/c++/modules/interface_redeclaration/src/main.cpp
+++ b/tests/projects/c++/modules/interface_redeclaration/src/main.cpp
@@ -1,0 +1,6 @@
+import test;
+
+int main() {
+    f();
+    return 0;
+}

--- a/tests/projects/c++/modules/interface_redeclaration/src/test.mpp
+++ b/tests/projects/c++/modules/interface_redeclaration/src/test.mpp
@@ -1,0 +1,3 @@
+export module test;
+
+export int f() { return 123; }

--- a/tests/projects/c++/modules/interface_redeclaration/src/test2.mpp
+++ b/tests/projects/c++/modules/interface_redeclaration/src/test2.mpp
@@ -1,0 +1,3 @@
+export module test;
+
+export int f() { return 456; }

--- a/tests/projects/c++/modules/interface_redeclaration/test.lua
+++ b/tests/projects/c++/modules/interface_redeclaration/test.lua
@@ -1,0 +1,7 @@
+import(".test_base", {alias = "test_build"})
+
+function main(t)
+    if test_build.can_build() then
+        t:will_raise(test_build, "multiple declarations of module interface detected")
+    end
+end

--- a/tests/projects/c++/modules/interface_redeclaration/xmake.lua
+++ b/tests/projects/c++/modules/interface_redeclaration/xmake.lua
@@ -1,0 +1,8 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("interface_redeclaration")
+    set_kind("binary")
+    add_files("src/*.cpp", "src/*.mpp")
+
+

--- a/tests/projects/c++/modules/interface_redeclaration/xmake.lua
+++ b/tests/projects/c++/modules/interface_redeclaration/xmake.lua
@@ -4,5 +4,3 @@ set_languages("c++20")
 target("interface_redeclaration")
     set_kind("binary")
     add_files("src/*.cpp", "src/*.mpp")
-
-

--- a/tests/projects/c++/modules/partition_redeclaration/src/main.cpp
+++ b/tests/projects/c++/modules/partition_redeclaration/src/main.cpp
@@ -1,0 +1,6 @@
+import test;
+
+int main() {
+    f();
+    return 0;
+}

--- a/tests/projects/c++/modules/partition_redeclaration/src/test.mpp
+++ b/tests/projects/c++/modules/partition_redeclaration/src/test.mpp
@@ -1,0 +1,3 @@
+export module test;
+
+export import :internal;

--- a/tests/projects/c++/modules/partition_redeclaration/src/test_internal.cpp
+++ b/tests/projects/c++/modules/partition_redeclaration/src/test_internal.cpp
@@ -1,0 +1,3 @@
+module test:internal;
+
+int f() { return 123; }

--- a/tests/projects/c++/modules/partition_redeclaration/src/test_internal.mpp
+++ b/tests/projects/c++/modules/partition_redeclaration/src/test_internal.mpp
@@ -1,0 +1,3 @@
+export module test:internal;
+
+export int f();

--- a/tests/projects/c++/modules/partition_redeclaration/test.lua
+++ b/tests/projects/c++/modules/partition_redeclaration/test.lua
@@ -1,0 +1,7 @@
+import(".test_base", {alias = "test_build"})
+
+function main(t)
+    if test_build.can_build() then
+        t:will_raise(test_build, "multiple declarations of module partition detected")
+    end
+end

--- a/tests/projects/c++/modules/partition_redeclaration/xmake.lua
+++ b/tests/projects/c++/modules/partition_redeclaration/xmake.lua
@@ -1,0 +1,8 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("partition_redeclaration")
+    set_kind("binary")
+    add_files("src/*.cpp", "src/*.mpp")
+
+

--- a/tests/projects/c++/modules/partition_redeclaration/xmake.lua
+++ b/tests/projects/c++/modules/partition_redeclaration/xmake.lua
@@ -4,5 +4,3 @@ set_languages("c++20")
 target("partition_redeclaration")
     set_kind("binary")
     add_files("src/*.cpp", "src/*.mpp")
-
-

--- a/xmake/rules/c++/modules/xmake.lua
+++ b/xmake/rules/c++/modules/xmake.lua
@@ -106,6 +106,7 @@ rule("c++.build.modules.builder")
 
             compiler_support.patch_sourcebatch(target, sourcebatch, opt)
             local modules = dependency_scanner.get_module_dependencies(target, sourcebatch, opt)
+            dependency_scanner.check_module_redeclaration(modules)
 
             if not target:is_moduleonly() then
                 -- avoid building non referenced modules
@@ -169,6 +170,7 @@ rule("c++.build.modules.builder")
 
             compiler_support.patch_sourcebatch(target, sourcebatch, opt)
             local modules = dependency_scanner.get_module_dependencies(target, sourcebatch, opt)
+            dependency_scanner.check_module_redeclaration(modules)
 
             if not target:is_moduleonly() then
                 -- avoid building non referenced modules


### PR DESCRIPTION
Add function `modules_support.dependency_scanner.check_module_redeclaration` to detect module interface / partition redeclaration before build.

Fixes #4770.
