### PR TITLE
fix: Passing `is_debug` to gn

### DIFF
--- a/xmake/modules/package/tools/gn.lua
+++ b/xmake/modules/package/tools/gn.lua
@@ -66,7 +66,7 @@ function _get_configs(package, configs, opt)
     elseif package:is_arch("arm.*") then
         configs.target_cpu = "arm"
     end
-    configs.is_debug = package:is_debug()
+    configs.is_debug = package:is_debug() and "true" or "false"
     return configs
 end
 


### PR DESCRIPTION
I've tried to build v8, failing because a few errors.
I encountered that gn wouldn't take `is_debug` in some cases, thus needing a ternary check to always pass true or false.

Without fix:

```
gn.bat gen out.gn "--args=target_cpu=\"x64\" use_custom_libcxx=false target_os=\"win\" is_clang=false treat_warnings_as_errors=false is_official_build=false v8_enable_test_features=false is_shared_library=false is_component_build=false v8_enable_i18n_support=false extra_cflags=[\"/MT\"] v8_monolithic=true v8_use_external_startup_data=false symbol_level=0 v8_static_library=true"
```
With fix:

```
gn.bat gen out.gn "--args=v8_enable_test_features=false is_component_build=false treat_warnings_as_errors=false is_clang=false extra_cflags=[\"/MT\"] v8_enable_i18n_support=false is_official_build=false target_cpu=\"x64\" is_shared_library=false symbol_level=0 target_os=\"win\" v8_monolithic=true v8_static_library=true use_custom_libcxx=false is_debug=false v8_use_external_startup_data=false"
```

Relevant part: `is_debug=`

It would never put the `is_debug=false` even if it was defined in the config.

An update to v8 will be posted soon.