### PR TITLE
Remove extra spaces from generated pkgconfig file

### DIFF
--- a/xmake/modules/target/action/install/pkgconfig_importfiles.lua
+++ b/xmake/modules/target/action/install/pkgconfig_importfiles.lua
@@ -52,6 +52,7 @@ function main(target, opt)
             libs = libs .. " -l" .. link
         end
     end
+    libs = libs:trim()
 
     -- get cflags
     local cflags = ""
@@ -61,6 +62,7 @@ function main(target, opt)
         end
     end
     cflags = cflags .. " -I${includedir}"
+    cflags = cflags:trim()
 
     -- trace
     vprint("generating %s ..", pcfile)
@@ -79,8 +81,8 @@ function main(target, opt)
         if version then
             file:print("Version: %s", version)
         end
-        file:print("Libs:%s", libs)
-        file:print("Cflags:%s", cflags)
+        file:print("Libs: %s", libs)
+        file:print("Cflags: %s", cflags)
         file:close()
     end
 end

--- a/xmake/modules/target/action/install/pkgconfig_importfiles.lua
+++ b/xmake/modules/target/action/install/pkgconfig_importfiles.lua
@@ -79,8 +79,8 @@ function main(target, opt)
         if version then
             file:print("Version: %s", version)
         end
-        file:print("Libs: %s", libs)
-        file:print("Cflags: %s", cflags)
+        file:print("Libs:%s", libs)
+        file:print("Cflags:%s", cflags)
         file:close()
     end
 end


### PR DESCRIPTION
Currently the **.pc** file generated by rule `utils.install.pkgconfig_importfiles` looks like this:

```
prefix=...
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/include

Name: Test
Description: Test
Version: 0.1.0
Libs:  -L${libdir} -lTest
Cflags:  -I${includedir}
```

Notice that there are two spaces after `Libs:` and `Cflags:`. This PR changes them to one space after the colon instead of two.