### PR TITLE
Fix toolchain ld path

### DIFF
--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -195,7 +195,7 @@ end
 function _get_llvm_rootdir(self)
     local llvm_rootdir = _g._LLVM_ROOTDIR
     if llvm_rootdir == nil then
-        local outdata = try { function() return os.iorun(self:program() .. " -print-resource-dir") end }
+        local outdata = try { function() return os.iorunv(self:program(), {"-print-resource-dir"}, {envs = self:runenvs()}) end }
         if outdata then
             llvm_rootdir = path.normalize(path.join(outdata:trim(), "..", "..", ".."))
             if not os.isdir(llvm_rootdir) then
@@ -211,7 +211,7 @@ end
 function _get_llvm_target_triple(self)
     local llvm_targettriple = _g._LLVM_TARGETTRIPLE
     if llvm_targettriple == nil then
-        local outdata = try { function() return os.iorun(self:program() .. " -print-target-triple") end }
+        local outdata = try { function() return os.iorunv(self:program(), {"-print-target-triple"}, {envs = self:runenvs()}) end }
         if outdata then
             llvm_targettriple = outdata:trim()
         end

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -295,9 +295,9 @@ function nf_runtime(self, runtime, opt)
                     if triple_libdir then
                         maps["c++_shared"] = table.join(maps["c++_shared"], nf_rpathdir(self, triple_libdir))
                     end
-                    if target:kind() == "shared" and self:is_plat("macosx", "iphoneos", "watchos") then
+                    if target:is_shared() and self:is_plat("macosx", "iphoneos", "watchos") then
                         maps["c++_shared"] = table.join(maps["c++_shared"], "-install_name")
-                        maps["c++_shared"] = table.join(maps["c++_shared"], "@rpath/" .. path.filename(target:filename()))
+                        maps["c++_shared"] = table.join(maps["c++_shared"], "@rpath/" .. target:filename())
                     end
                 end
                 if runtime:endswith("_static") and _has_static_libstdcxx(self) then

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -314,6 +314,10 @@ function nf_runtime(self, runtime, opt)
                         end
                     end
                     if rpath_flags then
+                        if target:kind() == "shared" and self:is_plat("macosx", "iphoneos", "watchos") then
+                            table.insert(rpath_flags, "-install_name")
+                            table.insert(rpath_flags, "@rpath/" .. path.filename(target:filename()))
+                        end
                         maps["c++_shared"] = table.join(maps["c++_shared"], rpath_flags)
                     end
                 end

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -291,7 +291,7 @@ function nf_runtime(self, runtime, opt)
                         maps["c++_shared"] = table.join(maps["c++_shared"], "-L" .. triple_libdir)
                     end
                     -- add rpath to avoid the user need to set LD_LIBRARY_PATH by hand
-                    if not self:is_plat("windows") and not self:is_plat("mingw") then
+                    if not self:is_plat("windows", "mingw") then
                         maps["c++_shared"] = table.join(maps["c++_shared"], "-Wl,-rpath=" .. libdir)
                         if triple_libdir then
                             maps["c++_shared"] = table.join(maps["c++_shared"], "-Wl,-rpath=" .. triple_libdir)

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -280,7 +280,7 @@ function nf_runtime(self, runtime, opt)
                     llvm_rootdir = _get_llvm_rootdir(self)
                 end
                 if llvm_rootdir then
-                    local libdir = path.join(llvm_rootdir, "lib")
+                    local libdir = path.absolute(path.join(llvm_rootdir, "lib"))
                     maps["c++_static"] = table.join(maps["c++_static"], "-L" .. libdir)
                     maps["c++_shared"] = table.join(maps["c++_shared"], "-L" .. libdir)
                     -- sometimes llvm runtimes are located in a target-triple subfolder

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -221,7 +221,7 @@ function _get_llvm_target_triple(self)
 end
 
 -- make the rpathdir flag
-function rpathdir(self, dir)
+function _rpathdir(self, dir)
     dir = path.translate(dir)
     if self:has_flags("-Wl,-rpath=" .. dir, "ldflags") then
         local flags = {"-Wl,-rpath=" .. (dir:gsub("@[%w_]+", function (name)
@@ -309,13 +309,13 @@ function nf_runtime(self, runtime, opt)
                         maps["c++_shared"] = table.join(maps["c++_shared"], "-L" .. triple_libdir)
                     end
                     -- add rpath to avoid the user need to set LD_LIBRARY_PATH by hand
-                    maps["c++_shared"] = table.join(maps["c++_shared"], rpathdir(self, libdir))
+                    maps["c++_shared"] = table.join(maps["c++_shared"], _rpathdir(self, libdir))
                     if triple_libdir then
-                        maps["c++_shared"] = table.join(maps["c++_shared"], rpathdir(self, triple_libdir))
+                        maps["c++_shared"] = table.join(maps["c++_shared"], _rpathdir(self, triple_libdir))
                     end
                     if target:kind() == "shared" and self:is_plat("macosx", "iphoneos", "watchos") then
-                        table.join2(maps["c++_shared"], "-install_name")
-                        table.join2(maps["c++_shared"], "@rpath/" .. path.filename(target:filename()))
+                        maps["c++_shared"] = table.join(maps["c++_shared"], "-install_name")
+                        maps["c++_shared"] = table.join(maps["c++_shared"], "@rpath/" .. path.filename(target:filename()))
                     end
                 end
                 if runtime:endswith("_static") and _has_static_libstdcxx(self) then


### PR DESCRIPTION
when using --sdk alongside of --runtimes="c++" to build with a non-system llvm, we need to fix rpath to allow executables ton find libc++
