### PR TITLE
Implement stdmodule clang detection flag

### DIFF
--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -83,8 +83,8 @@ function _get_std_module_manifest_path(target)
     local print_module_manifest_flag = get_print_library_module_manifest_path_flag(target)
     if print_module_manifest_flag then
         local compinst = target:compiler("cxx")
-        local outdata, _ = try { function() return os.iorunv(compinst:program(), {print_module_manifest_flag}, {envs = compinst:runenvs()}) end }
-        if outdata and outdata ~= "<NOT PRESENT>" then
+        local outdata, _ = try { function() return os.iorunv(compinst:program(), {"-std=c++23", "-stdlib=libc++", print_module_manifest_flag}, {envs = compinst:runenvs()}) end }
+        if outdata and not outdata:startswith("<NOT PRESENT>") then
             return outdata:trim()
         end
     end

--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -45,7 +45,7 @@ function _get_toolchain_includedirs_for_stlheaders(target, includedirs, clang)
             table.insert(argv, 1, "-stdlib=libstdc++")
         end
     end
-    local result = try {function () return os.iorunv(clang, argv) end}
+    local result = try {function () return os.iorunv(clang, argv, {envs = compinst:runenvs()}) end}
     if result then
         for _, line in ipairs(result:split("\n", {plain = true})) do
             line = line:trim()
@@ -83,7 +83,7 @@ function _get_std_module_manifest_path(target)
     local print_module_manifest_flag = get_print_library_module_manifest_path_flag(target)
     if print_module_manifest_flag then
         local compinst = target:compiler("cxx")
-        local outdata, _ = try { function() return os.iorunv(compinst:program(), {print_module_manifest_flag}) end }
+        local outdata, _ = try { function() return os.iorunv(compinst:program(), {print_module_manifest_flag}, {envs = compinst:runenvs()}) end }
         if outdata then
             return outdata:trim()
         end

--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -81,9 +81,10 @@ end
 
 function _get_std_module_manifest_path(target)
     local print_module_manifest_flag = get_print_library_module_manifest_path_flag(target)
+    local clang_path = path.directory(get_clang_path(target))
     if print_module_manifest_flag then
         local compinst = target:compiler("cxx")
-        local outdata, _ = try { function() return os.iorunv(compinst:program(), {"-std=c++23", "-stdlib=libc++", print_module_manifest_flag}, {envs = compinst:runenvs()}) end }
+        local outdata, _ = try { function() return os.iorunv(compinst:program(), {"-std=c++23", "-stdlib=libc++", "--sysroot=" .. path.join(clang_path, ".."), print_module_manifest_flag}, {envs = compinst:runenvs()}) end }
         if outdata and not outdata:startswith("<NOT PRESENT>") then
             return outdata:trim()
         end
@@ -91,7 +92,6 @@ function _get_std_module_manifest_path(target)
 
     -- fallback on custom detection
     -- manifest can be found in <llvm_path>/lib subdirectory (i.e on debian it should be <llvm_path>/lib/x86_64-unknown-linux-gnu/)
-    local clang_path = path.directory(get_clang_path(target))
     local clang_lib_path = path.join(clang_path, "..", "lib")
     local modules_json_path = path.join(clang_lib_path, "libc++.modules.json")
     if not os.isfile(modules_json_path) then

--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -84,7 +84,7 @@ function _get_std_module_manifest_path(target)
     if print_module_manifest_flag then
         local compinst = target:compiler("cxx")
         local outdata, _ = try { function() return os.iorunv(compinst:program(), {print_module_manifest_flag}, {envs = compinst:runenvs()}) end }
-        if outdata then
+        if outdata and outdata ~= "<NOT PRESENT>" then
             return outdata:trim()
         end
     end

--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -82,7 +82,8 @@ end
 function _get_std_module_manifest_path(target)
     local print_module_manifest_flag = get_print_library_module_manifest_path_flag(target)
     if print_module_manifest_flag then
-        local outdata = try { function() return os.iorun(self:program() .. " " .. print_module_manifest_flag) end }
+        local compinst = target:compiler("cxx")
+        local outdata, _ = try { function() return os.iorunv(compinst:program(), {print_module_manifest_flag}) end }
         if outdata then
             return outdata:trim()
         end

--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -80,7 +80,7 @@ function _get_cpplibrary_name(target)
 end
 
 function _get_std_module_manifest_path(target)
-    local print_module_manifest_flag = get_printlibrarymodulemanifestpathflag(target)
+    local print_module_manifest_flag = get_print_library_module_manifest_path_flag(target)
     if print_module_manifest_flag then
         local outdata = try { function() return os.iorun(self:program() .. " " .. print_module_manifest_flag) end }
         if outdata then
@@ -471,15 +471,15 @@ function get_moduleoutputflag(target)
     return moduleoutputflag or nil
 end
 
-function get_printlibrarymodulemanifestpathflag(target)
-    local printlibrarymodulemanifestpathflag = _g.printlibrarymodulemanifestpathflag
-    if printlibrarymodulemanifestpathflag == nil then
+function get_print_library_module_manifest_path_flag(target)
+    local print_library_module_manifest_path_flag = _g.print_library_module_manifest_path_flag
+    if print_library_module_manifest_path_flag == nil then
         local compinst = target:compiler("cxx")
         if compinst:has_flags("-print-library-module-manifest-path", "cxxflags", {flagskey = "clang_print_library_module_manifest_path", tryrun = true}) then
-            printlibrarymodulemanifestpathflag = "-print-library-module-manifest-path"
+            print_library_module_manifest_path_flag = "-print-library-module-manifest-path"
         end
-        _g.printlibrarymodulemanifestpathflag = printlibrarymodulemanifestpathflag or false
+        _g.print_library_module_manifest_path_flag = print_library_module_manifest_path_flag or false
     end
-    return printlibrarymodulemanifestpathflag or nil
+    return print_library_module_manifest_path_flag or nil
 end
 

--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -270,11 +270,13 @@ function get_stdmodules(target)
                 local modules_json_path = _get_std_module_manifest_path(target)
                 if modules_json_path then
                     local modules_json = json.decode(io.readfile(modules_json_path))
-                    local std_module_directory = path.directory(modules_json.modules[1]["source-path"])
-                    if not path.is_absolute(std_module_directory) then
-                        std_module_directory = path.join(path.directory(modules_json_path), std_module_directory)
+                    if modules_json and modules_json.modules and #modules_json.modules > 0 then
+                        local std_module_directory = path.directory(modules_json.modules[1]["source-path"])
+                        if not path.is_absolute(std_module_directory) then
+                            std_module_directory = path.join(path.directory(modules_json_path), std_module_directory)
+                        end
+                        return {path.join(std_module_directory, "std.cppm"), path.join(std_module_directory, "std.compat.cppm")}
                     end
-                    return {path.join(std_module_directory, "std.cppm"), path.join(std_module_directory, "std.compat.cppm")}
                 end
             elseif cpplib == "stdc++" then
                 -- libstdc++ doesn't have a std module file atm


### PR DESCRIPTION
draft because the flag got re-reverted a second time :D but it should be backported to llvm18 this week, see https://github.com/llvm/llvm-project/pull/82160
