### PR TITLE
Fix clang scan deps modules mac os

### DIFF
--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -218,7 +218,7 @@ function get_clang_scan_deps(target)
             local dir = path.directory(program)
             local basename = path.basename(program)
             local extension = path.extension(program)
-            program = (basename:gsub("clang", "clang-scan-deps")) .. extension
+            program = (basename:gsub("+", ""):gsub("clang", "clang-scan-deps")) .. extension
             if dir and dir ~= "." and os.isdir(dir) then
                 program = path.join(dir, program)
             end

--- a/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/compiler_support.lua
@@ -218,7 +218,7 @@ function get_clang_scan_deps(target)
             local dir = path.directory(program)
             local basename = path.basename(program)
             local extension = path.extension(program)
-            program = (basename:gsub("+", ""):gsub("clang", "clang-scan-deps")) .. extension
+            program = (basename:rtrim("+"):gsub("clang", "clang-scan-deps")) .. extension
             if dir and dir ~= "." and os.isdir(dir) then
                 program = path.join(dir, program)
             end


### PR DESCRIPTION
on some configs, xmake will try to use clang-scan-deps++ which can't exists so the fallback will always be used

