### PR TITLE
fix find_cudatools on windows

### DIFF
--- a/xmake/modules/private/detect/find_cudatool.lua
+++ b/xmake/modules/private/detect/find_cudatool.lua
@@ -49,10 +49,13 @@ function main(toolname, parse, opt)
     local program
     local toolchains = find_cuda()
     if toolchains and toolchains.bindir then
-        local file = path.join(toolchains.bindir, opt.program or toolname)
-        if os.isfile(file) then
-            program = find_program(file, opt)
-        end
+        -- prepend the toolchain's bin dir to the paths
+        local opt2 = table.join(opt) -- duplicate opt
+        local paths = table.join(opt2.paths or {}, opt2.pathes or {})
+        opt2.paths = table.join({toolchains.bindir}, paths)
+        opt2.pathes = nil
+
+        program = find_program(opt2.program or toolname, opt2)
     end
 
     -- not found? attempt to find program only

--- a/xmake/modules/private/detect/find_cudatool.lua
+++ b/xmake/modules/private/detect/find_cudatool.lua
@@ -49,12 +49,9 @@ function main(toolname, parse, opt)
     local program
     local toolchains = find_cuda()
     if toolchains and toolchains.bindir then
-        -- prepend the toolchain's bin dir to the paths
-        local opt2 = table.join(opt) -- duplicate opt
-        local paths = table.join(opt2.paths or {}, opt2.pathes or {})
-        opt2.paths = table.join({toolchains.bindir}, paths)
-        opt2.pathes = nil
-
+        local opt2 = table.clone(opt)
+        opt2.paths = opt2.paths or {}
+        table.insert(opt2.paths, toolchains.bindir)
         program = find_program(opt2.program or toolname, opt2)
     end
 


### PR DESCRIPTION
The full path to the tool was passed to find_program in find_cudatool, and a check was made to ensure that the file exists. This check returned false on windows due to the missing extension, thus ignoring the configured toolchain and the tool was searched based on the environnement PATH.