### PR TITLE
Implement os.SIGDFL and os.SIGIGN

### DIFF
--- a/xmake/core/base/os.lua
+++ b/xmake/core/base/os.lua
@@ -56,6 +56,8 @@ os.SYSERR_NOT_ACCESS  = 3
 
 -- signal code
 os.SIGINT = 1
+os.SIGDFL = 1
+os.SIGIGN = 2
 
 -- copy single file or directory
 function os._cp(src, dst, rootdir, opt)

--- a/xmake/core/sandbox/modules/os.lua
+++ b/xmake/core/sandbox/modules/os.lua
@@ -93,6 +93,8 @@ sandbox_os.SYSERR_NOT_ACCESS  = os.SYSERR_NOT_ACCESS
 
 -- signal code
 sandbox_os.SIGINT = os.SIGINT
+sandbox_os.SIGDFL = os.SIGDFL
+sandbox_os.SIGIGN = os.SIGIGN
 
 -- copy file or directory
 function sandbox_os.cp(srcpath, dstpath, opt)


### PR DESCRIPTION
Fixes: #4889 

Allows user to reset the previously overwritten `os.signal` or ignore it completely (not passed to process, same as with `{ exclusive = true }`.

Opens:
* More descriptive names like `signal_default/reset` and `signal_ignore` instead of Unix's `SIGDFL` and `SIGIGN`?
* Tests? May be tricky to test signals, would need to run xmake in a subprocess of its own.
* Add documentation