### PR TITLE
ndk: use unix path even on Windows

### DIFF
--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -400,6 +400,22 @@ function buildenvs(package, opt)
         envs.LDSHARED = _translate_windows_bin_path(envs.LDSHARED)
         envs.CPP      = _translate_windows_bin_path(envs.CPP)
         envs.RANLIB   = _translate_windows_bin_path(envs.RANLIB)
+        if package:is_plat("android") then
+            -- use unix path separator on android as windows seps may not be understood by some tools (e.g. openssl's perl)
+            envs.CFLAGS    = path.unix(envs.CFLAGS)
+            envs.CXXFLAGS  = path.unix(envs.CXXFLAGS)
+            envs.CPPFLAGS  = path.unix(envs.CPPFLAGS)
+            envs.ASFLAGS   = path.unix(envs.ASFLAGS)
+            if envs.ARFLAGS then
+                envs.ARFLAGS   = path.unix(envs.ARFLAGS)
+            end
+            if envs.LDFLAGS then
+                envs.LDFLAGS   = path.unix(envs.LDFLAGS)
+            end
+            if envs.SHFLAGS then
+                envs.SHFLAGS   = path.unix(envs.SHFLAGS)
+            end
+        end
     end
     local ACLOCAL_PATH = {}
     local PKG_CONFIG_PATH = {}

--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -309,10 +309,18 @@ function buildenvs(package, opt)
         table.join2(cxxflags, package:_generate_sanitizer_configs("address", "cxx").cxxflags)
         table.join2(ldflags, package:_generate_sanitizer_configs("address").ldflags)
     end
-    envs.CFLAGS    = table.concat(_translate_paths(cflags), ' ')
-    envs.CXXFLAGS  = table.concat(_translate_paths(cxxflags), ' ')
-    envs.CPPFLAGS  = table.concat(_translate_paths(cppflags), ' ')
-    envs.ASFLAGS   = table.concat(_translate_paths(asflags), ' ')
+    if cflags then
+        envs.CFLAGS    = table.concat(_translate_paths(cflags), ' ')
+    end
+    if cxxflags then
+        envs.CXXFLAGS  = table.concat(_translate_paths(cxxflags), ' ')
+    end
+    if cppflags then
+        envs.CPPFLAGS  = table.concat(_translate_paths(cppflags), ' ')
+    end
+    if asflags then
+        envs.ASFLAGS   = table.concat(_translate_paths(asflags), ' ')
+    end
     if arflags then
         envs.ARFLAGS   = table.concat(_translate_paths(arflags), ' ')
     end

--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -28,7 +28,7 @@ import("core.cache.memcache")
 import("lib.detect.find_tool")
 
 -- translate paths
-function _translate_paths(package, paths)
+function _translate_paths(paths)
     if paths and is_host("windows") then
         if type(paths) == "string" then
             return path.unix(paths)
@@ -123,7 +123,7 @@ function _get_configs(package, configs)
 
     -- add prefix
     local configs = configs or {}
-    table.insert(configs, "--prefix=" .. _translate_paths(package, package:installdir()))
+    table.insert(configs, "--prefix=" .. _translate_paths(package:installdir()))
 
     -- add host for cross-complation
     if not configs.host and _is_cross_compilation(package) then
@@ -188,8 +188,8 @@ function _get_cflags_from_packagedeps(package, opt)
             local fetchinfo = dep:fetch({external = false})
             if fetchinfo then
                 table.join2(result, _map_compflags(package, "cxx", "define", fetchinfo.defines))
-                table.join2(result, _translate_paths(package, _map_compflags(package, "cxx", "includedir", fetchinfo.includedirs)))
-                table.join2(result, _translate_paths(package, _map_compflags(package, "cxx", "sysincludedir", fetchinfo.sysincludedirs)))
+                table.join2(result, _translate_paths(_map_compflags(package, "cxx", "includedir", fetchinfo.includedirs)))
+                table.join2(result, _translate_paths(_map_compflags(package, "cxx", "sysincludedir", fetchinfo.sysincludedirs)))
             end
         end
     end
@@ -204,9 +204,9 @@ function _get_ldflags_from_packagedeps(package, opt)
         if dep then
             local fetchinfo = dep:fetch({external = false})
             if fetchinfo then
-                table.join2(result, _translate_paths(package, _map_linkflags(package, "binary", {"cxx"}, "linkdir", fetchinfo.linkdirs)))
+                table.join2(result, _translate_paths(_map_linkflags(package, "binary", {"cxx"}, "linkdir", fetchinfo.linkdirs)))
                 table.join2(result, _map_linkflags(package, "binary", {"cxx"}, "link", fetchinfo.links))
-                table.join2(result, _translate_paths(package, _map_linkflags(package, "binary", {"cxx"}, "syslink", fetchinfo.syslinks)))
+                table.join2(result, _translate_paths(_map_linkflags(package, "binary", {"cxx"}, "syslink", fetchinfo.syslinks)))
                 table.join2(result, _map_linkflags(package, "binary", {"cxx"}, "framework", fetchinfo.frameworks))
             end
         end
@@ -578,4 +578,3 @@ function install(package, configs, opt)
     end
     make(package, argv, opt)
 end
-

--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -29,7 +29,7 @@ import("lib.detect.find_tool")
 
 -- translate paths
 function _translate_paths(package, paths)
-    if paths and is_host("windows") and package:is_plat("mingw", "msys", "cygwin") then
+    if paths and is_host("windows") then
         if type(paths) == "string" then
             return path.unix(paths)
         elseif type(paths) == "table" then
@@ -243,11 +243,6 @@ function buildenvs(package, opt)
         table.join2(cxxflags, _get_cflags_from_packagedeps(package, opt))
         table.join2(cppflags, _get_cflags_from_packagedeps(package, opt))
         table.join2(ldflags,  _get_ldflags_from_packagedeps(package, opt))
-        envs.CFLAGS    = table.concat(cflags, ' ')
-        envs.CXXFLAGS  = table.concat(cxxflags, ' ')
-        envs.CPPFLAGS  = table.concat(cppflags, ' ')
-        envs.ASFLAGS   = table.concat(asflags, ' ')
-        envs.LDFLAGS   = table.concat(ldflags, ' ')
     else
         cross = true
         cppflags = {}
@@ -314,18 +309,18 @@ function buildenvs(package, opt)
         table.join2(cxxflags, package:_generate_sanitizer_configs("address", "cxx").cxxflags)
         table.join2(ldflags, package:_generate_sanitizer_configs("address").ldflags)
     end
-    envs.CFLAGS    = table.concat(cflags, ' ')
-    envs.CXXFLAGS  = table.concat(cxxflags, ' ')
-    envs.CPPFLAGS  = table.concat(cppflags, ' ')
-    envs.ASFLAGS   = table.concat(asflags, ' ')
+    envs.CFLAGS    = table.concat(_translate_paths(cflags), ' ')
+    envs.CXXFLAGS  = table.concat(_translate_paths(cxxflags), ' ')
+    envs.CPPFLAGS  = table.concat(_translate_paths(cppflags), ' ')
+    envs.ASFLAGS   = table.concat(_translate_paths(asflags), ' ')
     if arflags then
-        envs.ARFLAGS   = table.concat(arflags, ' ')
+        envs.ARFLAGS   = table.concat(_translate_paths(arflags), ' ')
     end
     if ldflags then
-        envs.LDFLAGS   = table.concat(ldflags, ' ')
+        envs.LDFLAGS   = table.concat(_translate_paths(ldflags), ' ')
     end
     if shflags then
-        envs.SHFLAGS   = table.concat(shflags, ' ')
+        envs.SHFLAGS   = table.concat(_translate_paths(shflags), ' ')
     end
 
     -- cross-compilation? pass the full build environments
@@ -400,22 +395,6 @@ function buildenvs(package, opt)
         envs.LDSHARED = _translate_windows_bin_path(envs.LDSHARED)
         envs.CPP      = _translate_windows_bin_path(envs.CPP)
         envs.RANLIB   = _translate_windows_bin_path(envs.RANLIB)
-        if package:is_plat("android") then
-            -- use unix path separator on android as windows seps may not be understood by some tools (e.g. openssl's perl)
-            envs.CFLAGS    = path.unix(envs.CFLAGS)
-            envs.CXXFLAGS  = path.unix(envs.CXXFLAGS)
-            envs.CPPFLAGS  = path.unix(envs.CPPFLAGS)
-            envs.ASFLAGS   = path.unix(envs.ASFLAGS)
-            if envs.ARFLAGS then
-                envs.ARFLAGS   = path.unix(envs.ARFLAGS)
-            end
-            if envs.LDFLAGS then
-                envs.LDFLAGS   = path.unix(envs.LDFLAGS)
-            end
-            if envs.SHFLAGS then
-                envs.SHFLAGS   = path.unix(envs.SHFLAGS)
-            end
-        end
     end
     local ACLOCAL_PATH = {}
     local PKG_CONFIG_PATH = {}

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -169,7 +169,7 @@ function _get_cflags(package, opt)
     end
     table.join2(result, _get_cflags_from_packagedeps(package, opt))
     if #result > 0 then
-        return os.args(result)
+        return _translate_paths(os.args(result))
     end
 end
 
@@ -200,7 +200,7 @@ function _get_cxxflags(package, opt)
     end
     table.join2(result, _get_cflags_from_packagedeps(package, opt))
     if #result > 0 then
-        return os.args(result)
+        return _translate_paths(os.args(result))
     end
 end
 
@@ -219,7 +219,7 @@ function _get_asflags(package, opt)
         table.join2(result, opt.asflags)
     end
     if #result > 0 then
-        return os.args(result)
+        return _translate_paths(os.args(result))
     end
 end
 
@@ -245,7 +245,7 @@ function _get_ldflags(package, opt)
         table.join2(result, opt.ldflags)
     end
     if #result > 0 then
-        return os.args(result)
+        return _translate_paths(os.args(result))
     end
 end
 
@@ -271,7 +271,7 @@ function _get_shflags(package, opt)
         table.join2(result, opt.shflags)
     end
     if #result > 0 then
-        return os.args(result)
+        return _translate_paths(os.args(result))
     end
 end
 

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -169,7 +169,7 @@ function _get_cflags(package, opt)
     end
     table.join2(result, _get_cflags_from_packagedeps(package, opt))
     if #result > 0 then
-        return _translate_paths(os.args(result))
+        return os.args(_translate_paths(result))
     end
 end
 
@@ -200,7 +200,7 @@ function _get_cxxflags(package, opt)
     end
     table.join2(result, _get_cflags_from_packagedeps(package, opt))
     if #result > 0 then
-        return _translate_paths(os.args(result))
+        return os.args(_translate_paths(result))
     end
 end
 
@@ -219,7 +219,7 @@ function _get_asflags(package, opt)
         table.join2(result, opt.asflags)
     end
     if #result > 0 then
-        return _translate_paths(os.args(result))
+        return os.args(_translate_paths(result))
     end
 end
 
@@ -245,7 +245,7 @@ function _get_ldflags(package, opt)
         table.join2(result, opt.ldflags)
     end
     if #result > 0 then
-        return _translate_paths(os.args(result))
+        return os.args(_translate_paths(result))
     end
 end
 
@@ -271,7 +271,7 @@ function _get_shflags(package, opt)
         table.join2(result, opt.shflags)
     end
     if #result > 0 then
-        return _translate_paths(os.args(result))
+        return os.args(_translate_paths(result))
     end
 end
 

--- a/xmake/toolchains/ndk/load.lua
+++ b/xmake/toolchains/ndk/load.lua
@@ -166,8 +166,6 @@ function main(toolchain)
         -- add sysroot flags
         local ndk_sysroot = toolchain:config("ndk_sysroot")
         if ndk_sysroot and os.isdir(ndk_sysroot) then
-            -- use unix path separator on android as windows seps may not be understood by some tools (e.g. openssl's perl)
-            ndk_sysroot = path.unix(ndk_sysroot)
             local triple = _get_triple(arch)
             if ndkver and tonumber(ndkver) < 22 then
                 toolchain:add("cxflags", "-D__ANDROID_API__=" .. ndk_sdkver)
@@ -176,9 +174,9 @@ function main(toolchain)
             toolchain:add("cflags",  "--sysroot=" .. ndk_sysroot)
             toolchain:add("cxxflags","--sysroot=" .. ndk_sysroot)
             toolchain:add("asflags", "--sysroot=" .. ndk_sysroot)
-            toolchain:add("cflags",  "-isystem " .. format("%s/%s/%s/%s", ndk_sysroot, "usr", "include", triple))
-            toolchain:add("cxxflags","-isystem " .. format("%s/%s/%s/%s", ndk_sysroot, "usr", "include", triple))
-            toolchain:add("asflags", "-isystem " .. format("%s/%s/%s/%s", ndk_sysroot, "usr", "include", triple))
+            toolchain:add("cflags",  "-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
+            toolchain:add("cxxflags","-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
+            toolchain:add("asflags", "-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
         else
             local ndk_sdkdir = path.translate(format("%s/platforms/android-%d", ndk, ndk_sdkver))
             if os.isdir(ndk_sdkdir) then

--- a/xmake/toolchains/ndk/load.lua
+++ b/xmake/toolchains/ndk/load.lua
@@ -166,6 +166,8 @@ function main(toolchain)
         -- add sysroot flags
         local ndk_sysroot = toolchain:config("ndk_sysroot")
         if ndk_sysroot and os.isdir(ndk_sysroot) then
+            -- use unix path separator on android as windows seps may not be understood by some tools (e.g. openssl's perl)
+            ndk_sysroot = path.unix(ndk_sysroot)
             local triple = _get_triple(arch)
             if ndkver and tonumber(ndkver) < 22 then
                 toolchain:add("cxflags", "-D__ANDROID_API__=" .. ndk_sdkver)
@@ -174,9 +176,9 @@ function main(toolchain)
             toolchain:add("cflags",  "--sysroot=" .. ndk_sysroot)
             toolchain:add("cxxflags","--sysroot=" .. ndk_sysroot)
             toolchain:add("asflags", "--sysroot=" .. ndk_sysroot)
-            toolchain:add("cflags",  "-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
-            toolchain:add("cxxflags","-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
-            toolchain:add("asflags", "-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
+            toolchain:add("cflags",  "-isystem " .. format("%s/%s/%s/%s", ndk_sysroot, "usr", "include", triple))
+            toolchain:add("cxxflags","-isystem " .. format("%s/%s/%s/%s", ndk_sysroot, "usr", "include", triple))
+            toolchain:add("asflags", "-isystem " .. format("%s/%s/%s/%s", ndk_sysroot, "usr", "include", triple))
         else
             local ndk_sdkdir = path.translate(format("%s/platforms/android-%d", ndk, ndk_sdkver))
             if os.isdir(ndk_sdkdir) then


### PR DESCRIPTION
Fixes NDK compilation with some tools.

For example, building OpenSSL for Android on Windows fails with those buildenvs:
```
{
  SHFLAGS = "-llog -target aarch64-none-linux-android28 -static-libstdc++",
  LDFLAGS = "-llog -target aarch64-none-linux-android28 -fPIE -pie -static-libstdc++",
  ARFLAGS = "",
  CC = "E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe",
  ACLOCAL_PATH = "",
  AS = "E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe",
  CPP = "E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe -E",
  PKG_CONFIG_PATH = "",
  CFLAGS = "-target aarch64-none-linux-android28 --sysroot=E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\sysroot -isystem E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\include\aarch64-linux-android",
  ASFLAGS = "-target aarch64-none-linux-android28 --sysroot=E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\sysroot -isystem E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\include\aarch64-linux-android",
  CPPFLAGS = "",
  CXXFLAGS = "-target aarch64-none-linux-android28 --sysroot=E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\sysroot -isystem E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\include\aarch64-linux-android",
  LD = "E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\bin\ld.exe",
  LDSHARED = "E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\bin\clang++.exe",
  AR = "E:\Android\Sdk\ndk\android-ndk-r26c-windows\toolchains\llvm\prebuilt\windows-x86_64\bin\llvm-ar.exe"
}
```

using unix path fixes this