### PR TITLE
runtimes support for package:check_cxxsnippet

### DIFF
--- a/tests/projects/c++/snippet_runtimes/my-repo/packages/b/bar/src/include/bar.hpp
+++ b/tests/projects/c++/snippet_runtimes/my-repo/packages/b/bar/src/include/bar.hpp
@@ -1,0 +1,8 @@
+#ifndef BAR_HPP
+#define BAR_HPP
+
+#include <string>
+
+std::string foo();
+
+#endif

--- a/tests/projects/c++/snippet_runtimes/my-repo/packages/b/bar/src/src/bar.cpp
+++ b/tests/projects/c++/snippet_runtimes/my-repo/packages/b/bar/src/src/bar.cpp
@@ -1,0 +1,5 @@
+#include <bar.hpp>
+
+std::string foo() {
+    return "bar";
+}

--- a/tests/projects/c++/snippet_runtimes/my-repo/packages/b/bar/src/xmake.lua
+++ b/tests/projects/c++/snippet_runtimes/my-repo/packages/b/bar/src/xmake.lua
@@ -1,0 +1,6 @@
+target("bar")
+    set_kind("$(kind)")
+    add_files("src/*.cpp")
+    add_headerfiles("include/(**.hpp)")
+    add_includedirs("include")
+

--- a/tests/projects/c++/snippet_runtimes/my-repo/packages/b/bar/xmake.lua
+++ b/tests/projects/c++/snippet_runtimes/my-repo/packages/b/bar/xmake.lua
@@ -1,0 +1,15 @@
+package("bar")
+    set_sourcedir(path.join(os.scriptdir(), "src"))
+
+    on_install(function(package)
+        import("package.tools.xmake").install(package, {})
+    end)
+
+    on_test(function(package)
+         assert(package:check_cxxsnippets({test = [[
+             #include <iostream>
+             void test() {
+                 std::cout << _LIBCPP_VERSION << std::endl;
+             }
+         ]]}, {configs = {languages = "c++17"}}))
+    end)

--- a/tests/projects/c++/snippet_runtimes/src/main.cpp
+++ b/tests/projects/c++/snippet_runtimes/src/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+#include <bar.hpp>
+
+int main() {
+    std::cout << foo();
+    return 0;
+}

--- a/tests/projects/c++/snippet_runtimes/test.lua
+++ b/tests/projects/c++/snippet_runtimes/test.lua
@@ -1,0 +1,19 @@
+import("lib.detect.find_tool")
+import("core.base.semver")
+import("utils.ci.is_running", {alias = "ci_is_running"})
+
+function _build()
+    if ci_is_running() then
+        assert(os.iorun("xmake -rvD"))
+    else
+        assert(os.iorun("xmake -r"))
+    end
+end
+
+function main(t)
+    local clang = find_tool("clang")
+    if clang and not is_subhost("windows") then
+        os.exec("xmake f --toolchain=clang --runtimes=c++_shared --yes")
+        _build()
+    end
+end

--- a/tests/projects/c++/snippet_runtimes/xmake.lua
+++ b/tests/projects/c++/snippet_runtimes/xmake.lua
@@ -1,0 +1,18 @@
+add_repositories("my-repo my-repo")
+add_requires("bar")
+
+target("foo")
+    set_kind("binary")
+    add_files("src/*.cpp")
+    
+    add_packages("bar")
+
+    on_config(function(target)
+         assert(target:check_cxxsnippets({test = [[
+             #include <iostream>
+             void test() {
+                 std::cout << _LIBCPP_VERSION << std::endl;
+             }
+         ]]}, {configs = {languages = "c++17"}}))
+    end)
+

--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2297,18 +2297,6 @@ function _instance:_generate_build_configs(configs, opt)
         local ldflags = linker:map_flags("runtime", runtimes, {target = fake_target})
         configs.ldflags = table.wrap(configs.ldflags)
         table.join2(configs.ldflags, ldflags)
-
-        -- if self:is_plat("windows") then
-        --     local ld = self:build_getenv("ld")
-        --     if ld and path.basename(ld:lower()) == "link" then -- for msvc?
-        --         configs.cxflags = table.wrap(configs.cxflags)
-        --         table.insert(configs.cxflags, "/" .. runtimes)
-        --         if runtimes:startswith("MT") then
-        --             configs.ldflags = table.wrap(configs.ldflags)
-        --             table.insert(configs.ldflags, "-nodefaultlib:msvcrt.lib")
-        --         end
-        --     end
-        -- end
     end
     if self:config("lto") then
         local configs_lto = self:_generate_lto_configs(opt.sourcekind or "cxx")

--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2271,7 +2271,7 @@ function _instance:_generate_build_configs(configs, opt)
     configs = table.join(self:fetch_librarydeps(), configs)
     -- since we are ignoring the runtimes of the headeronly library,
     -- we can only get the runtimes from the dependency library to detect the link.
-    local runtimes = self:config("runtimes") or self:runtimes()
+    local runtimes = self:runtimes()
     if self:is_headeronly() and not runtimes and self:librarydeps() then
         for _, dep in ipairs(self:librarydeps()) do
             if dep:is_plat("windows") and dep:runtimes() then

--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -39,6 +39,7 @@ local is_cross       = require("base/private/is_cross")
 local memcache       = require("cache/memcache")
 local toolchain      = require("tool/toolchain")
 local compiler       = require("tool/compiler")
+local linker         = require("tool/linker")
 local sandbox        = require("sandbox/sandbox")
 local config         = require("project/config")
 local policy         = require("project/policy")
@@ -2268,27 +2269,46 @@ end
 function _instance:_generate_build_configs(configs, opt)
     opt = opt or {}
     configs = table.join(self:fetch_librarydeps(), configs)
-    if self:is_plat("windows") then
-        local ld = self:build_getenv("ld")
-        local runtimes = self:runtimes()
-        -- since we are ignoring the runtimes of the headeronly library,
-        -- we can only get the runtimes from the dependency library to detect the link.
-        if self:is_headeronly() and not runtimes and self:librarydeps() then
-            for _, dep in ipairs(self:librarydeps()) do
-                if dep:is_plat("windows") and dep:runtimes() then
-                    runtimes = dep:runtimes()
-                    break
-                end
+    -- since we are ignoring the runtimes of the headeronly library,
+    -- we can only get the runtimes from the dependency library to detect the link.
+    local runtimes = self:config("runtimes") or self:runtimes()
+    if self:is_headeronly() and not runtimes and self:librarydeps() then
+        for _, dep in ipairs(self:librarydeps()) do
+            if dep:is_plat("windows") and dep:runtimes() then
+                runtimes = dep:runtimes()
+                break
             end
         end
-        if runtimes and ld and path.basename(ld:lower()) == "link" then -- for msvc?
-            configs.cxflags = table.wrap(configs.cxflags)
-            table.insert(configs.cxflags, "/" .. runtimes)
-            if runtimes:startswith("MT") then
-                configs.ldflags = table.wrap(configs.ldflags)
-                table.insert(configs.ldflags, "-nodefaultlib:msvcrt.lib")
-            end
+    end
+    if runtimes then
+        local sourcekind = opt.sourcekind or "cxx"
+        local tool, name = self:tool("ld")
+        local linker, errors = linker.load("binary", sourcekind, {target = package})
+        if not linker then
+            os.raise(errors)
         end
+        local fake_target = {is_shared = function(_) return false end, 
+                             sourcekinds = function(_) return sourcekind end}
+        local compiler = self:compiler(sourcekind)
+        local cxflags = compiler:map_flags("runtime", runtimes, {target = fake_target})
+        configs.cxflags = table.wrap(configs.cxflags)
+        table.join2(configs.cxflags, cxflags)
+
+        local ldflags = linker:map_flags("runtime", runtimes, {target = fake_target})
+        configs.ldflags = table.wrap(configs.ldflags)
+        table.join2(configs.ldflags, ldflags)
+
+        -- if self:is_plat("windows") then
+        --     local ld = self:build_getenv("ld")
+        --     if ld and path.basename(ld:lower()) == "link" then -- for msvc?
+        --         configs.cxflags = table.wrap(configs.cxflags)
+        --         table.insert(configs.cxflags, "/" .. runtimes)
+        --         if runtimes:startswith("MT") then
+        --             configs.ldflags = table.wrap(configs.ldflags)
+        --             table.insert(configs.ldflags, "-nodefaultlib:msvcrt.lib")
+        --         end
+        --     end
+        -- end
     end
     if self:config("lto") then
         local configs_lto = self:_generate_lto_configs(opt.sourcekind or "cxx")

--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -268,8 +268,9 @@ function nf_runtime(self, runtime, opt)
                 maps["c++_shared"] = table.join(maps["c++_shared"], "-cxx-isystem" .. path.join(llvm_rootdir, "include", "c++", "v1"))
             end
         elseif kind == "ld" or kind == "sh" then
-            local target = opt.target
-            if target and target.sourcekinds and table.contains(table.wrap(target:sourcekinds()), "cxx") then
+            local target = opt.target or opt
+            local is_cxx = target and (target.sourcekinds and table.contains(table.wrap(target:sourcekinds()), "cxx"))
+            if is_cxx then
                 maps["c++_static"]    = "-stdlib=libc++"
                 maps["c++_shared"]    = "-stdlib=libc++"
                 maps["stdc++_static"] = "-stdlib=libstdc++"


### PR DESCRIPTION
support passing runtime flags to check_cxxsnippet, this is a POC just to get ur opinion and suggestions
this is needed because if a package is built with libc++ and linked to a snippet which use libstdc++, this will result in a link error
