### PR TITLE
After the change of h2, recompile cpp2 containing this h2

### DIFF
--- a/xmake/rules/cppfront/xmake.lua
+++ b/xmake/rules/cppfront/xmake.lua
@@ -21,8 +21,7 @@
 rule("cppfront.build.h2")
     set_extensions(".h2")
 
-    on_buildcmd_file(function (target, batchcmds, sourcefile_h2, opt)
-
+    before_buildcmd_file(function (target, batchcmds, sourcefile_h2, opt)
         -- get cppfront
         import("lib.detect.find_tool")
         local cppfront = assert(find_tool("cppfront", {check = "-h"}), "cppfront not found!")
@@ -65,7 +64,6 @@ rule("cppfront.build.cpp2")
         end
     end)
     on_buildcmd_file(function (target, batchcmds, sourcefile_cpp2, opt)
-
         -- get cppfront
         import("lib.detect.find_tool")
         local cppfront = assert(find_tool("cppfront", {check = "-h"}), "cppfront not found!")
@@ -78,6 +76,14 @@ rule("cppfront.build.cpp2")
         local objectfile = target:objectfile(sourcefile_cpp)
         table.insert(target:objectfiles(), objectfile)
 
+        -- add_depfiles for #include "xxxx/xxxx/xxx.h2" ,exclude // #include "xxxx.h2"
+        local lines = io.lines(sourcefile_cpp2)
+        for line in lines do
+            match_h2 = string.match(line, "^ -#include *\"([%w%p]+.h2)\"")
+            if match_h2 ~= nil then
+                batchcmds:add_depfiles(path.join(path.directory(sourcefile_cpp2), match_h2))
+            end
+        end
         -- add commands
         local argv = {"-o", path(sourcefile_cpp), path(sourcefile_cpp2)}
         batchcmds:show_progress(opt.progress, "${color.build.object}compiling.cpp2 %s", sourcefile_cpp2)


### PR DESCRIPTION
修复h2变化，依赖的cpp2没变化的时候，cpp2不重新编译的问题，并且将h2改为before_buildcmd_file #4938  
