### PR TITLE
Fix issue with fetching packages when doing cross-compilation

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1948,7 +1948,7 @@ function _instance:fetch(opt)
         end
 
         -- fetch it from the system and external package sources (disabled for cross-compilation)
-        if not fetchinfo and system ~= false and not self:is_cross() then
+        if not fetchinfo and system ~= false then
             fetchinfo = self:_fetch_library({system = true, require_version = require_ver, external = external, force = opt.force})
             if fetchinfo then
                 is_system = true


### PR DESCRIPTION
This change changes the behavior with cross compilation when using packages. Previously the package would not properly fetch or install the cross-compiled packages.

Fixes #4935