### PR TITLE
fix vs_runtime

### DIFF
--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -357,6 +357,17 @@ function _get_configs(package, configs, opt)
         elseif package:has_runtime("MDd") then
             table.insert(configs, "-Db_vscrt=mdd")
         end
+    else
+        local runtime = package:config("vs_runtime")
+        if runtime == "MT" then
+            table.insert(configs, "-Db_vscrt=mt")
+        elseif runtime == "MTd" then
+            table.insert(configs, "-Db_vscrt=mtd")
+        elseif runtime == "MD" then
+            table.insert(configs, "-Db_vscrt=md")
+        elseif runtime == "MDd" then
+            table.insert(configs, "-Db_vscrt=mdd")
+        end
     end
 
     -- add cross file


### PR DESCRIPTION
如果不传递 b_vscrt 参数，meson 会用 MD 编译，然后 xmake 在 on_test 会使用 MT 造成链接错误。

不知道为什么 ci 会传递已经弃用的 vs_runtime 而不是 runtimes，但 xmake 确实没有正确处理向后兼容。

https://github.com/xmake-io/xmake-repo/actions/runs/8763357032/job/24064675920?pr=3829

---

If you don't pass the b_vscrt argument, meson will compile with MD, and then xmake will use MT at on_test causing linking errors.

I don't know why ci passes the deprecated vs_runtime instead of runtimes, but xmake really doesn't handle backwards compatibility correctly.

https://github.com/xmake-io/xmake-repo/actions/runs/8763357032/job/24064675920?pr=3829