### PR TITLE
add "build.fence" policy to block all targets build in depend chain

### DIFF
--- a/tests/projects/other/autogen_codedep/xmake.lua
+++ b/tests/projects/other/autogen_codedep/xmake.lua
@@ -24,6 +24,7 @@ target("autogen")
     set_arch(os.arch())
     add_files("src/autogen.cpp")
     set_languages("c++11")
+    set_policy("build.fence", true)
 
 target("test")
     set_kind("binary")
@@ -31,5 +32,4 @@ target("test")
     add_rules("autogen")
     add_files("src/main.cpp")
     add_files("src/*.in")
-    set_policy("build.across_targets_in_parallel", false)
 

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -40,6 +40,8 @@ function policy.policies()
             ["check.auto_map_flags"]              = {description = "Enable map gcc flags to the current compiler and linker automatically.", default = true, type = "boolean"},
             -- We will check the compatibility of target and package licenses
             ["check.target_package_licenses"]     = {description = "Enable check the compatibility of target and package licenses.", default = true, type = "boolean"},
+            -- Provide a way to block all targets build that depends on self
+            ["build.fence"]                       = {description = "Block all targets build that depends on self.", default = false, type = "boolean"},
             -- We can compile the source files for each target in parallel
             ["build.across_targets_in_parallel"]  = {description = "Enable compile the source files for each target in parallel.", default = true, type = "boolean"},
             -- Merge archive intead of linking for all dependent targets


### PR DESCRIPTION
issue url: https://github.com/xmake-io/xmake/issues/5003
考虑场景 Gen <- A <- B <- C
Gen 使用了 set_policy("build.fence", true)，则 Gen 会阻塞 A、B、C 的构建，当 Gen 完成后，A、B、C 按照原先规则进行编译
