### PR TITLE
Fix incorrect pattern matching for rustc nf_frameworks()

### DIFF
--- a/xmake/modules/core/tools/rustc.lua
+++ b/xmake/modules/core/tools/rustc.lua
@@ -78,7 +78,8 @@ end
 -- make the framework flag, crate module
 function nf_framework(self, framework)
     local basename = path.basename(framework)
-    local cratename = basename:match("lib(.-)%-.-") or basename:match("lib(.-)")
+    -- return "mycrate" from libmycrate-f882feaebb8ba0ca.rlib or libmycrate.rlib
+    local cratename = basename:match("lib(.-)%-.-") or basename:match("lib(.+)")
     if cratename then
         return {"--extern", cratename .. "=" .. framework}
     end


### PR DESCRIPTION
I believe the intent is that the `nf_frameworks` logic for rust will match either format of 

libmydep.rlib -> mydep
libmydep-buildhas.rlib -> mydep

The current string:match logic isn't working if the above results are desired.