### PR TITLE
Fix target.linkname not returning a value

### DIFF
--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -2857,6 +2857,7 @@ function target.linkname(filename, opt)
     if not filename:startswith("lib") and (filename:endswith(".so") or filename:endswith(".dylib")) then
         return filename
     end
+    return nil
 end
 
 -- new a target instance


### PR DESCRIPTION
Fixes this error:
```
finding libx11 from xmake ..
error: @programdir/modules/package/manager/xmake/find_package.lua:137: wrong number of arguments to 'insert'
stack traceback:
    [C]: in function 'insert'
    [@programdir/modules/package/manager/xmake/find_package.lua:137]: in function '_find_package_from_repo'
    [@programdir/modules/package/manager/xmake/find_package.lua:350]:
    [@programdir/modules/package/manager/find_package.lua:110]: in function '_find_package'
    [@programdir/modules/package/manager/find_package.lua:194]:
    [@programdir/modules/lib/detect/find_package.lua:109]:
    [@programdir/core/package/package.lua:1794]: in function '_fetch_library'
    [@programdir/core/package/package.lua:1947]: in function 'fetch'
    [.../modules/private/action/require/impl/actions/install.lua:426]:

  => install libx11 1.8.7 .. failed
error: @programdir/core/main.lua:329: @programdir/modules/async/runjobs.lua:322: .../modules/private/action/require/impl/actions/install.lua:506: install failed!
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:973]:
    [.../modules/private/action/require/impl/actions/install.lua:506]: in function 'catch'
    [@programdir/core/sandbox/modules/try.lua:123]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:370]:
    [...modules/private/action/require/impl/install_packages.lua:487]: in function 'jobfunc'
    [@programdir/modules/async/runjobs.lua:238]:
```


See https://github.com/xmake-io/xmake-repo/pull/3935