### PR TITLE
Support windows find LLVM toolchain

### DIFF
--- a/xmake/toolchains/llvm/check.lua
+++ b/xmake/toolchains/llvm/check.lua
@@ -73,6 +73,20 @@ function main(toolchain)
             if bindir then
                 sdkdir = path.directory(bindir)
             end
+        elseif is_host("windows") then
+            bindir = try {function () return path.directory(os.iorunv("where", {"llvm-ar.exe"})) end}
+            if not bindir then
+                local paths = os.getenv("PATH"):split(';')
+                for i, v in ipairs(paths) do
+                    if os.isfile(path.join(v, "llvm-ar.exe")) then
+                        bindir = v
+                        break
+                    end
+                end
+            end
+            if bindir then
+                sdkdir = path.directory(bindir)
+            end
         end
     end
 

--- a/xmake/toolchains/llvm/check.lua
+++ b/xmake/toolchains/llvm/check.lua
@@ -76,11 +76,13 @@ function main(toolchain)
         elseif is_host("windows") then
             bindir = try {function () return path.directory(os.iorunv("where", {"llvm-ar.exe"})) end}
             if not bindir then
-                local paths = os.getenv("PATH"):split(';')
-                for i, v in ipairs(paths) do
-                    if os.isfile(path.join(v, "llvm-ar.exe")) then
-                        bindir = v
-                        break
+                local pathenv = os.getenv("PATH")
+                if pathenv then
+                    for _, v in ipairs(path.splitenv(pathenv)) do
+                        if os.isfile(path.join(v, "llvm-ar.exe")) then
+                            bindir = v
+                            break
+                        end
                     end
                 end
             end


### PR DESCRIPTION
Automatically find LLVM toolchain on windows by using where.exe or iterate "PATH" environment variables.