### PR TITLE
Fix build on msys2/mingw64

### DIFF
--- a/core/src/xmake/xmake.sh
+++ b/core/src/xmake/xmake.sh
@@ -72,6 +72,7 @@ target "xmake"
     add_files "string/*.c"
     add_files "tty/*.c"
     if is_plat "mingw"; then
+        add_defines "UNICODE" "_UNICODE"
         add_files "winos/*.c"
     fi
 

--- a/core/xmake.sh
+++ b/core/xmake.sh
@@ -38,7 +38,7 @@ option "external" "Always use external dependencies" false
 # the readline option
 option "readline"
     add_links "readline"
-    add_cincludes "readline/readline.h"
+    add_cincludes "stdio.h" "readline/readline.h"
     add_cfuncs "readline"
     add_defines "XM_CONFIG_API_HAVE_READLINE"
 option_end
@@ -52,11 +52,15 @@ option "curses"
 option_end
 
 option_find_curses() {
+    local ncurses="ncurses"
+    if is_plat "mingw"; then
+        ncurses="ncursesw"
+    fi
     local ncurses_ldflags=""
-    ncurses_ldflags=$(pkg-config --libs ncurses 2>/dev/null)
+    ncurses_ldflags=$(pkg-config --libs ${ncurses} 2>/dev/null)
     option "curses"
         if test_nz "${ncurses_ldflags}"; then
-            add_cflags `pkg-config --cflags ncurses 2>/dev/null`
+            add_cflags `pkg-config --cflags ${ncurses} 2>/dev/null`
             add_ldflags "${ncurses_ldflags}"
         else
             add_links "curses"


### PR DESCRIPTION
```
MINGW64 # pacman -Ss xmake
mingw32/mingw-w64-i686-xmake 2.9.1-1
    A cross-platform build utility based on Lua (mingw-w64)
mingw64/mingw-w64-x86_64-xmake 2.9.1-1 [installed]
    A cross-platform build utility based on Lua (mingw-w64)
ucrt64/mingw-w64-ucrt-x86_64-xmake 2.9.1-1
    A cross-platform build utility based on Lua (mingw-w64)
clang32/mingw-w64-clang-i686-xmake 2.9.1-1
    A cross-platform build utility based on Lua (mingw-w64)
clang64/mingw-w64-clang-x86_64-xmake 2.9.1-1
    A cross-platform build utility based on Lua (mingw-w64)
MINGW64 # which xmake
/mingw64/bin/xmake
MINGW64 # xmake f --menu
error: ncurses not found, please install it first
```
