### PR TITLE
improve utils.symbols.export_all to support clang/objdump

### DIFF
--- a/tests/projects/c++/shared_library_export_all/src/bar.cpp
+++ b/tests/projects/c++/shared_library_export_all/src/bar.cpp
@@ -1,0 +1,5 @@
+#include "bar.h"
+
+int bar::add(int a, int b) {
+    return a + b;
+}

--- a/tests/projects/c++/shared_library_export_all/src/bar.h
+++ b/tests/projects/c++/shared_library_export_all/src/bar.h
@@ -1,4 +1,4 @@
-class foo {
+class bar {
 public:
     static int add(int a, int b);
 };

--- a/tests/projects/c++/shared_library_export_all/src/foo.cpp
+++ b/tests/projects/c++/shared_library_export_all/src/foo.cpp
@@ -1,6 +1,5 @@
 #include "foo.h"
 
-int test::add(int a, int b)
-{
+int foo::add(int a, int b) {
     return a + b;
 }

--- a/tests/projects/c++/shared_library_export_all/src/main.cpp
+++ b/tests/projects/c++/shared_library_export_all/src/main.cpp
@@ -1,10 +1,9 @@
 #include "foo.h"
+#include "bar.h"
 #include <iostream>
 
-using namespace std;
-
-int main(int argc, char** argv)
-{
-    cout << "add(1, 2) = " << test::add(1, 2) << endl;
+int main(int argc, char** argv) {
+    std::cout << "foo::add(1, 2) = " << foo::add(1, 2) << std::endl;
+    std::cout << "bar::add(1, 2) = " << bar::add(1, 2) << std::endl;
     return 0;
 }

--- a/tests/projects/c++/shared_library_export_all/xmake.lua
+++ b/tests/projects/c++/shared_library_export_all/xmake.lua
@@ -5,9 +5,18 @@ target("foo")
     add_files("src/foo.cpp")
     add_rules("utils.symbols.export_all", {export_classes = true})
 
+target("bar")
+    set_kind("shared")
+    add_files("src/bar.cpp")
+    add_rules("utils.symbols.export_all", {export_filter = function (symbol)
+        if symbol:find("add", 1, true) then
+            return true
+        end
+    end})
+
 target("demo")
     set_kind("binary")
-    add_deps("foo")
+    add_deps("foo", "bar")
     add_files("src/main.cpp")
 
 

--- a/xmake/rules/utils/symbols/export_all/export_all.lua
+++ b/xmake/rules/utils/symbols/export_all/export_all.lua
@@ -126,7 +126,7 @@ function main(target, opt)
         if msvc:check() then
             local dumpbin = assert(find_tool("dumpbin", {envs = msvc:runenvs()}), "dumpbin not found!")
             allsymbols = _get_allsymbols_by_dumpbin(target, dumpbin.program, {export_classes = export_classes})
-        elseif target:has_tool("cc", "clang", "clang_cl", "clangxx") then
+        elseif target:has_tool("cc", "clang", "clang_cl", "clangxx", "gcc", "gxx") then
             local objdump = assert(find_tool("llvm-objdump") or find_tool("objdump"), "objdump not found!")
             allsymbols = _get_allsymbols_by_objdump(target, objdump.program, {export_classes = export_classes})
         end

--- a/xmake/rules/utils/symbols/export_all/export_all.lua
+++ b/xmake/rules/utils/symbols/export_all/export_all.lua
@@ -123,7 +123,7 @@ function main(target, opt)
         -- get all symbols
         local allsymbols
         local msvc = toolchain.load("msvc", {plat = target:plat(), arch = target:arch()})
-        if false then--msvc:check() then
+        if msvc:check() then
             local dumpbin = assert(find_tool("dumpbin", {envs = msvc:runenvs()}), "dumpbin not found!")
             allsymbols = _get_allsymbols_by_dumpbin(target, dumpbin.program, {export_classes = export_classes})
         elseif target:has_tool("cc", "clang", "clang_cl", "clangxx") then

--- a/xmake/rules/utils/symbols/export_all/export_all.lua
+++ b/xmake/rules/utils/symbols/export_all/export_all.lua
@@ -26,6 +26,44 @@ import("core.base.hashset")
 import("core.project.depend")
 import("utils.progress")
 
+-- use dumpbin to get all symbols from object files
+function _get_allsymbols_by_dumpbin(target, dumpbin, opt)
+    opt = opt or {}
+    local allsymbols = hashset.new()
+    local export_classes = opt.export_classes
+    for _, objectfile in ipairs(target:objectfiles()) do
+        local objectsymbols = try { function () return os.iorunv(dumpbin, {"/symbols", "/nologo", objectfile}) end }
+        if objectsymbols then
+            for _, line in ipairs(objectsymbols:split('\n', {plain = true})) do
+                -- https://docs.microsoft.com/en-us/cpp/build/reference/symbols
+                -- 008 00000000 SECT3  notype ()    External     | add
+                if line:find("External") and not line:find("UNDEF") then
+                    local symbol = line:match(".*External%s+| (.*)")
+                    if symbol then
+                        symbol = symbol:split('%s')[1]
+                        if not symbol:startswith("__") then
+                            -- we need ignore DllMain, https://github.com/xmake-io/xmake/issues/3992
+                            if target:is_arch("x86") and symbol:startswith("_") and not symbol:startswith("_DllMain@") then
+                                symbol = symbol:sub(2)
+                            end
+                            if export_classes or not symbol:startswith("?") then
+                                if export_classes then
+                                    if not symbol:startswith("??_G") and not symbol:startswith("??_E") then
+                                        allsymbols:insert(symbol)
+                                    end
+                                else
+                                    allsymbols:insert(symbol)
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return allsymbols
+end
+
 -- export all symbols for dynamic library
 function main(target, opt)
 
@@ -43,48 +81,19 @@ function main(target, opt)
         -- trace progress info
         progress.show(opt.progress, "${color.build.target}exporting.$(mode) %s", path.filename(target:targetfile()))
 
-        -- get dumpbin
-        local msvc = toolchain.load("msvc", {plat = target:plat(), arch = target:arch()})
-        local dumpbin = assert(find_tool("dumpbin", {envs = msvc:runenvs()}), "dumpbin not found!")
-
         -- export c++ class?
         local export_classes = target:extraconf("rules", "utils.symbols.export_all", "export_classes")
 
-        -- get all symbols from object files
-        local allsymbols = hashset.new()
-        for _, objectfile in ipairs(target:objectfiles()) do
-            local objectsymbols = try { function () return os.iorunv(dumpbin.program, {"/symbols", "/nologo", objectfile}) end }
-            if objectsymbols then
-                for _, line in ipairs(objectsymbols:split('\n', {plain = true})) do
-                    -- https://docs.microsoft.com/en-us/cpp/build/reference/symbols
-                    -- 008 00000000 SECT3  notype ()    External     | add
-                    if line:find("External") and not line:find("UNDEF") then
-                        local symbol = line:match(".*External%s+| (.*)")
-                        if symbol then
-                            symbol = symbol:split('%s')[1]
-                            if not symbol:startswith("__") then
-                                -- we need ignore DllMain, https://github.com/xmake-io/xmake/issues/3992
-                                if target:is_arch("x86") and symbol:startswith("_") and not symbol:startswith("_DllMain@") then
-                                    symbol = symbol:sub(2)
-                                end
-                                if export_classes or not symbol:startswith("?") then
-                                    if export_classes then
-                                        if not symbol:startswith("??_G") and not symbol:startswith("??_E") then
-                                            allsymbols:insert(symbol)
-                                        end
-                                    else
-                                        allsymbols:insert(symbol)
-                                    end
-                                end
-                            end
-                        end
-                    end
-                end
-            end
+        -- get all symbols
+        local allsymbols
+        local msvc = toolchain.load("msvc", {plat = target:plat(), arch = target:arch()})
+        if msvc:check() then
+            local dumpbin = assert(find_tool("dumpbin", {envs = msvc:runenvs()}), "dumpbin not found!")
+            allsymbols = _get_allsymbols_by_dumpbin(target, dumpbin.program, {export_classes = export_classes})
         end
 
         -- export all symbols
-        if allsymbols:size() > 0 then
+        if allsymbols and allsymbols:size() > 0 then
             local allsymbols_file = io.open(allsymbols_filepath, 'w')
             allsymbols_file:print("EXPORTS")
             for _, symbol in allsymbols:keys() do

--- a/xmake/rules/utils/symbols/export_all/export_all.lua
+++ b/xmake/rules/utils/symbols/export_all/export_all.lua
@@ -64,6 +64,22 @@ function _get_allsymbols_by_dumpbin(target, dumpbin, opt)
     return allsymbols
 end
 
+-- use objdump to get all symbols from object files
+function _get_allsymbols_by_objdump(target, objdump, opt)
+    opt = opt or {}
+    local allsymbols = hashset.new()
+    local export_classes = opt.export_classes
+    for _, objectfile in ipairs(target:objectfiles()) do
+        local objectsymbols = try { function () return os.iorunv(objdump, {"--syms", objectfile}) end }
+        if objectsymbols then
+            for _, line in ipairs(objectsymbols:split('\n', {plain = true})) do
+                print(line)
+            end
+        end
+    end
+    return allsymbols
+end
+
 -- export all symbols for dynamic library
 function main(target, opt)
 
@@ -90,6 +106,9 @@ function main(target, opt)
         if msvc:check() then
             local dumpbin = assert(find_tool("dumpbin", {envs = msvc:runenvs()}), "dumpbin not found!")
             allsymbols = _get_allsymbols_by_dumpbin(target, dumpbin.program, {export_classes = export_classes})
+        elseif target:has_tool("cc", "clang", "clang_cl", "clangxx") then
+            local objdump = assert(find_tool("llvm-objdump") or find_tool("objdump"), "objdump not found!")
+            allsymbols = _get_allsymbols_by_dumpbin(target, objdump.program, {export_classes = export_classes})
         end
 
         -- export all symbols


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/5117

support objdump and export filter callback

```lua
target("bar")
    set_kind("shared")
    add_files("src/bar.cpp")
    add_rules("utils.symbols.export_all", {export_filter = function (symbol)
        if symbol:find("add", 1, true) then
            return true
        end
    end})
```