### PR TITLE
Fix `find_package` failed problem for CMake projects on Android platform

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -460,6 +460,7 @@ function _get_configs_for_appleos(package, configs, opt)
         envs.CMAKE_SYSTEM_NAME = "Darwin"
     end
     envs.CMAKE_OSX_ARCHITECTURES = package:arch()
+    envs.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE   = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_FRAMEWORK = "BOTH"
@@ -491,6 +492,7 @@ function _get_configs_for_mingw(package, configs, opt)
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir
+    envs.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"
@@ -585,6 +587,7 @@ function _get_configs_for_cross(package, configs, opt)
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037
     envs.CMAKE_FIND_ROOT_PATH              = sdkdir
+    envs.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -423,6 +423,13 @@ function _get_configs_for_android(package, configs, opt)
                 table.insert(configs, "-DCMAKE_MAKE_PROGRAM=" .. make)
             end
         end
+
+        -- avoid find and add system include/library path
+        -- @see https://github.com/xmake-io/xmake/issues/2037
+        table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH")
+        table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH")
+        table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH")
+        table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER")
     end
     _get_configs_for_generic(package, configs, opt)
 end

--- a/xmake/modules/private/action/trybuild/cmake.lua
+++ b/xmake/modules/private/action/trybuild/cmake.lua
@@ -134,6 +134,13 @@ function _get_configs_for_android(configs)
         if ndk_cxxstl then
             table.insert(configs, "-DANDROID_STL=" .. ndk_cxxstl)
         end
+
+        -- avoid find and add system include/library path
+        -- @see https://github.com/xmake-io/xmake/issues/2037
+        table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH")
+        table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH")
+        table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH")
+        table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER")
     end
 end
 
@@ -195,8 +202,9 @@ function _get_configs_for_mingw(configs)
     -- avoid find and add system include/library path
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir
     envs.CMAKE_SYSROOT             = sdkdir
-    envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "ONLY"
-    envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "ONLY"
+    envs.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "BOTH"
+    envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "BOTH"
+    envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"
     -- avoid add -isysroot on macOS
     envs.CMAKE_OSX_SYSROOT = ""
@@ -260,8 +268,9 @@ function _get_configs_for_cross(configs)
     -- avoid find and add system include/library path
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir
     envs.CMAKE_SYSROOT             = sdkdir
-    envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "ONLY"
-    envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "ONLY"
+    envs.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE = "BOTH"
+    envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "BOTH"
+    envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"
     -- avoid add -isysroot on macOS
     envs.CMAKE_OSX_SYSROOT = ""


### PR DESCRIPTION
相关issue: https://github.com/xmake-io/xmake/issues/2037

---

NDK环境设置了`CMAKE_FIND_ROOT_PATH`/`CMAKE_SYSROOT_PATH`, 会导致CMake工程在`find_package`时因`CMAKE_PREFIX_PATH`策略变更, 从而安装失败.

先前相关修改处理了其它交叉编译的平台, 但未处理Android平台. 且遗漏了[`CMAKE_FIND_ROOT_PATH_MODE_PACKAGE`](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_ROOT_PATH_MODE_PACKAGE.html)

---

但目前的改法仍未解决一个问题: 

CMake的Module mode比Config mode优先级更高, 导致[CMake官方提供了Module脚本的库](https://cmake.org/cmake/help/latest/manual/cmake-modules.7.html#find-modules):
1. 在系统中被找到, 不做任何处理的情况下xrepo准备的依赖会被系统库所覆盖
2. 直接报错退出

(即`CMAKE_PREFIX_PATH`被忽略了)

这我能想到的有两种方案:

1. 考虑全局设置[`CMAKE_FIND_PACKAGE_PREFER_CONFIG`](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_PACKAGE_PREFER_CONFIG.html)为`TRUE`, 但这样的话xrepo需要大规模测试

2. 设置[`CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH`](https://cmake.org/cmake/help/latest/variable/CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH.html) 为`FALSE`. 这会导致系统环境变量的工具无法被找到 (如`make`, `ninja`). 应该需要单独配置`CMAKE_MAKE_PROGRAM`的路径