### PR TITLE
add gentoo to linuxos

### DIFF
--- a/xmake/core/base/linuxos.lua
+++ b/xmake/core/base/linuxos.lua
@@ -101,6 +101,8 @@ function linuxos.name()
                     name = "ubuntu"
                 elseif os_release:find("debian", 1, true) then
                     name = "debian"
+                elseif os_release:find("gentoo linux", 1, true) then
+                    name = "gentoo"
                 elseif os_release:find("opensuse", 1, true) then
                     name = "opensuse"
                 elseif os_release:find("manjaro", 1, true) then


### PR DESCRIPTION
add gentoo linux support for `xmake l linuxos.name`

```
% cat /etc/os-release
NAME=Gentoo
ID=gentoo
PRETTY_NAME="Gentoo Linux"
ANSI_COLOR="1;32"
HOME_URL="https://www.gentoo.org/"
SUPPORT_URL="https://www.gentoo.org/support/"
BUG_REPORT_URL="https://bugs.gentoo.org/"
VERSION_ID="2.15"
% xmake l linuxos.name
"gentoo"
```