### PR TITLE
Fix VS toolset v144

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -288,27 +288,6 @@ function _get_cmake_version()
     return cmake_version
 end
 
--- get vs toolset
-function _get_vs_toolset(package)
-    local toolset_ver = nil
-    local vs_toolset = _get_msvc(package):config("vs_toolset") or config.get("vs_toolset")
-    if vs_toolset then
-        local verinfo = vs_toolset:split('%.')
-        if #verinfo >= 2 then
-            toolset_ver = "v" .. verinfo[1] .. (verinfo[2]:sub(1, 1) or "0")
-        end
-    end
-    -- cmake does not support vs toolset v144 below 3.29.3, we can only use v143
-    -- @see https://github.com/xmake-io/xmake/issues/4772
-    if toolset_ver and toolset_ver >= "v144" then
-        local cmake_version = _get_cmake_version()
-        if cmake_version and cmake_version:le("3.29.3") then
-            toolset_ver = "v143"
-        end
-    end
-    return toolset_ver
-end
-
 -- insert configs from envs
 function _insert_configs_from_envs(configs, envs, opt)
     opt = opt or {}
@@ -366,7 +345,7 @@ function _get_configs_for_windows(package, configs, opt)
         else
             table.insert(configs, "x64")
         end
-        local vs_toolset = _get_vs_toolset(package)
+        local vs_toolset = toolchain_utils.get_vs_toolset_ver(_get_msvc(package):config("vs_toolset") or config.get("vs_toolset"))
         if vs_toolset then
             table.insert(configs, "-DCMAKE_GENERATOR_TOOLSET=" .. vs_toolset)
         end

--- a/xmake/modules/private/utils/toolchain.lua
+++ b/xmake/modules/private/utils/toolchain.lua
@@ -31,18 +31,18 @@ function is_compatible_with_host(name)
     end
 end
 
--- toolset v144 doesn't exist and will cause issues with cmake/vs generation
-local vs_toolset_mapping = {
-    ["v144"] = "v143"
-}
-
+-- get vs toolset version, e.g. v143, v144, ..
 function get_vs_toolset_ver(vs_toolset)
     local toolset_ver
     if vs_toolset then
         local verinfo = vs_toolset:split('%.')
         if #verinfo >= 2 then
             toolset_ver = "v" .. verinfo[1] .. (verinfo[2]:sub(1, 1) or "0")
-            toolset_ver = vs_toolset_mapping[toolset_ver] or toolset_ver
+        end
+
+        -- @see https://github.com/xmake-io/xmake/pull/5176
+        if toolset_ver and toolset_ver == "v144" and vs_toolset:startswith("14.40.") then
+            toolset_ver = "v143"
         end
     end
     return toolset_ver

--- a/xmake/modules/private/utils/toolchain.lua
+++ b/xmake/modules/private/utils/toolchain.lua
@@ -31,3 +31,19 @@ function is_compatible_with_host(name)
     end
 end
 
+-- toolset v144 doesn't exist and will cause issues with cmake/vs generation
+local vs_toolset_mapping = {
+    ["v144"] = "v143"
+}
+
+function get_vs_toolset_ver(vs_toolset)
+    local toolset_ver
+    if vs_toolset then
+        local verinfo = vs_toolset:split('%.')
+        if #verinfo >= 2 then
+            toolset_ver = "v" .. verinfo[1] .. (verinfo[2]:sub(1, 1) or "0")
+            toolset_ver = vs_toolset_mapping[toolset_ver] or toolset_ver
+        end
+    end
+    return toolset_ver
+end

--- a/xmake/modules/private/utils/upgrade_vsproj.lua
+++ b/xmake/modules/private/utils/upgrade_vsproj.lua
@@ -22,6 +22,7 @@
 import("core.base.option")
 import("core.tool.toolchain")
 import("plugins.project.vstudio.impl.vsinfo", {rootdir = os.programdir()})
+import("private.utils.toolchain", {alias = "toolchain_utils"})
 
 -- the options
 local options = {
@@ -30,18 +31,6 @@ local options = {
 ,   {nil, "vs_sdkver",       "kv", nil, "Set the vs sdk version."                    }
 ,   {nil, "vs_projectfiles", "vs", nil, "Set the solution or project files."         }
 }
-
--- get toolset version
-function _get_toolset_ver(vs_toolset)
-    local toolset_ver = nil
-    if vs_toolset then
-        local verinfo = vs_toolset:split('%.')
-        if #verinfo >= 2 then
-            toolset_ver = "v" .. verinfo[1] .. (verinfo[2]:sub(1, 1) or "0")
-        end
-    end
-    return toolset_ver
-end
 
 -- upgrade *.sln
 function _upgrade_sln(projectfile, opt)
@@ -61,7 +50,7 @@ function _upgrade_vcxproj(projectfile, opt)
     local vs_version = opt.vs or msvc:config("vs")
     local vs_info = assert(vsinfo(tonumber(vs_version)), "unknown vs version!")
     local vs_sdkver = opt.vs_sdkver or msvc:config("vs_sdkver") or vs_info.sdk_version
-    local vs_toolset = _get_toolset_ver(opt.vs_toolset or msvc:config("vs_toolset")) or vs_info.toolset_version
+    local vs_toolset = toolchain_utils.get_vs_toolset_ver(opt.vs_toolset or msvc:config("vs_toolset")) or vs_info.toolset_version
     local vs_toolsver = vs_info.project_version
     io.gsub(projectfile, "<PlatformToolset>v%d+</PlatformToolset>",
         "<PlatformToolset>" .. vs_toolset .. "</PlatformToolset>")

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -29,6 +29,7 @@ import("private.utils.batchcmds")
 import("detect.sdks.find_cuda")
 import("vsfile")
 import("vsutils")
+import("private.utils.toolchain", {alias = "toolchain_utils"})
 
 function _make_dirs(dir, vcxprojdir)
     dir = dir:trim()
@@ -62,16 +63,9 @@ end
 
 -- get toolset version
 function _get_toolset_ver(targetinfo, vsinfo)
-
     -- get toolset version from vs version
-    local toolset_ver = nil
     local vs_toolset = toolchain.load("msvc"):config("vs_toolset") or config.get("vs_toolset")
-    if vs_toolset then
-        local verinfo = vs_toolset:split('%.')
-        if #verinfo >= 2 then
-            toolset_ver = "v" .. verinfo[1] .. (verinfo[2]:sub(1, 1) or "0")
-        end
-    end
+    local toolset_ver = toolchain_utils.get_vs_toolset_ver(vs_toolset)
     if not toolset_ver then
         toolset_ver = vsinfo.toolset_version
     end


### PR DESCRIPTION
Visual Studio toolset v144 doesn't exist, updating to Visual Studio 17.10 will make XMake fail to generate vs projects with the following error:
```
The builds tools for v144 (Platform Toolset = 'v144') cannot be found. To build using the v144 build tools, either click the Project menu or right-click the solution, and then select "Update VC++ Projects...". Install v144 to build using the v144 build tools.
```

There are no v144 tools, but VS stills reports it in detect.sdks.find_vstudio:
```
          VCToolsVersion = "14.40.33807",
``` 

<details>
  <summary>detect.sdks.find_vstudio</summary>
  
  ```lua
  {
    "2022" = {
      version = "17.0",
      vcvarsall_bat = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat",
      vcvarsall = {
        arm64 = {
          VS170COMNTOOLS = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\",
          LIBPATH = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\lib\x86\store\references;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10\References\10.0.22621.0;C:\Windows\Microsoft.NET\Framework64\v4.0.30319",
          UniversalCRTSdkDir = "C:\Program Files (x86)\Windows Kits\10\",
          VCInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\",
          DevEnvdir = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\",
          LIB = "C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\arm64;C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\arm64",
          VCToolsVersion = "14.40.33807",
          ExtensionSdkDir = "C:\Program Files (x86)\Microsoft SDKs\Windows Kits\10\ExtensionSDKs",
          VSCMD_ARG_app_plat = "Desktop",
          PATH = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\bin\HostX64\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\VCPackages;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer;C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\bin\Roslyn;C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;C:\Program Files\Microsoft Visual Studio\2022\Community\Team Tools\DiagnosticsHub\Collector;C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\\x64;C:\Program Files (x86)\Windows Kits\10\bin\\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\\MSBuild\Current\Bin\amd64;C:\Windows\Microsoft.NET\Framework64\v4.0.30319;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\;C:\Program Files (x86)\Common Files\Oracle\Java\javapath;C:\VulkanSDK\1.3.261.1\Bin;C:\Program Files (x86)\SCE\Common\SceVSI-VS17\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Program Files\dotnet\;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\NVIDIA Corporation\NVIDIA NvDLISR;C:\Program Files\nodejs\;C:\Program Files\Git\cmd;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Program Files\xmake;C:\Program Files (x86)\Gpg4win\..\GnuPG\bin;C:\Program Files\CMake\bin;C:\Program Files\GitHub CLI\;C:\Users\lynix\AppData\Local\Programs\Python\Launcher\;C:\Users\lynix\.cargo\bin;C:\Users\lynix\AppData\Local\Microsoft\WindowsApps;C:\Users\lynix\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\lynix\AppData\Local\GitHubDesktop\bin;C:\Users\lynix\.dotnet\tools;C:\Program Files\OpenCppCoverage;C:\Users\lynix\AppData\Roaming\npm;c:\users\lynix\appdata\local\microsoft\visualstudio\17.0_8427cfbf\extensions\kixyskqi.kly;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\Linux\bin\ConnectionManagerExe;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\vcpkg",
          VSCMD_ARG_TGT_ARCH = "arm64",
          VSCMD_VER = "17.10.1",
          UCRTVersion = "10.0.22621.0",
          VCIDEInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\",
          WindowsSdkDir = "C:\Program Files (x86)\Windows Kits\10\",
          VisualStudioVersion = "17.0",
          VSCMD_ARG_HOST_ARCH = "x64",
          VSInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\",
          VCToolsRedistDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Redist\MSVC\14.40.33807\",
          WindowsSDKVersion = "10.0.22621.0",
          WindowsSdkVerBinPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\",
          VCToolsInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\",
          WindowsLibPath = "C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10\References\10.0.22621.0",
          WindowsSdkBinPath = "C:\Program Files (x86)\Windows Kits\10\bin\",
          INCLUDE = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\include;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\ATLMFC\include;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\VS\include;C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um"
        },
        x64 = {
          VS170COMNTOOLS = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\",
          LIBPATH = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\ATLMFC\lib\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\lib\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\lib\x86\store\references;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10\References\10.0.22621.0;C:\Windows\Microsoft.NET\Framework64\v4.0.30319",
          UniversalCRTSdkDir = "C:\Program Files (x86)\Windows Kits\10\",
          VCInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\",
          DevEnvdir = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\",
          LIB = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\ATLMFC\lib\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\lib\x64;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x64;C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x64;C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x64",
          VCToolsVersion = "14.40.33807",
          ExtensionSdkDir = "C:\Program Files (x86)\Microsoft SDKs\Windows Kits\10\ExtensionSDKs",
          VSCMD_ARG_app_plat = "Desktop",
          PATH = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\bin\HostX64\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\VCPackages;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer;C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\bin\Roslyn;C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;C:\Program Files\Microsoft Visual Studio\2022\Community\Team Tools\DiagnosticsHub\Collector;C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\\x64;C:\Program Files (x86)\Windows Kits\10\bin\\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\\MSBuild\Current\Bin\amd64;C:\Windows\Microsoft.NET\Framework64\v4.0.30319;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\;C:\Program Files (x86)\Common Files\Oracle\Java\javapath;C:\VulkanSDK\1.3.261.1\Bin;C:\Program Files (x86)\SCE\Common\SceVSI-VS17\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Program Files\dotnet\;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\NVIDIA Corporation\NVIDIA NvDLISR;C:\Program Files\nodejs\;C:\Program Files\Git\cmd;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Program Files\xmake;C:\Program Files (x86)\Gpg4win\..\GnuPG\bin;C:\Program Files\CMake\bin;C:\Program Files\GitHub CLI\;C:\Users\lynix\AppData\Local\Programs\Python\Launcher\;C:\Users\lynix\.cargo\bin;C:\Users\lynix\AppData\Local\Microsoft\WindowsApps;C:\Users\lynix\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\lynix\AppData\Local\GitHubDesktop\bin;C:\Users\lynix\.dotnet\tools;C:\Program Files\OpenCppCoverage;C:\Users\lynix\AppData\Roaming\npm;c:\users\lynix\appdata\local\microsoft\visualstudio\17.0_8427cfbf\extensions\kixyskqi.kly;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\Linux\bin\ConnectionManagerExe;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\vcpkg",
          VSCMD_ARG_TGT_ARCH = "x64",
          VSCMD_VER = "17.10.1",
          UCRTVersion = "10.0.22621.0",
          VCIDEInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\",
          WindowsSdkDir = "C:\Program Files (x86)\Windows Kits\10\",
          VisualStudioVersion = "17.0",
          VSCMD_ARG_HOST_ARCH = "x64",
          VSInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\",
          VCToolsRedistDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Redist\MSVC\14.40.33807\",
          WindowsSDKVersion = "10.0.22621.0",
          WindowsSdkVerBinPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\",
          VCToolsInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\",
          WindowsLibPath = "C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10\References\10.0.22621.0",
          WindowsSdkBinPath = "C:\Program Files (x86)\Windows Kits\10\bin\",
          INCLUDE = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\include;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\ATLMFC\include;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\VS\include;C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um"
        },
        x86 = {
          VS170COMNTOOLS = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\",
          LIBPATH = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\ATLMFC\lib\x86;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\lib\x86;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\lib\x86\store\references;C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10\References\10.0.22621.0;C:\Windows\Microsoft.NET\Framework64\v4.0.30319",
          UniversalCRTSdkDir = "C:\Program Files (x86)\Windows Kits\10\",
          VCInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\",
          DevEnvdir = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\",
          LIB = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\ATLMFC\lib\x86;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\lib\x86;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\x86;C:\Program Files (x86)\Windows Kits\10\lib\10.0.22621.0\ucrt\x86;C:\Program Files (x86)\Windows Kits\10\\lib\10.0.22621.0\\um\x86",
          VCToolsVersion = "14.40.33807",
          ExtensionSdkDir = "C:\Program Files (x86)\Microsoft SDKs\Windows Kits\10\ExtensionSDKs",
          VSCMD_ARG_app_plat = "Desktop",
          PATH = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\bin\HostX64\x86;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\bin\HostX64\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\VCPackages;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TeamFoundation\Team Explorer;C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\bin\Roslyn;C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\x64\;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\FSharp\Tools;C:\Program Files\Microsoft Visual Studio\2022\Community\Team Tools\DiagnosticsHub\Collector;C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\\x64;C:\Program Files (x86)\Windows Kits\10\bin\\x64;C:\Program Files\Microsoft Visual Studio\2022\Community\\MSBuild\Current\Bin\amd64;C:\Windows\Microsoft.NET\Framework64\v4.0.30319;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\;C:\Program Files (x86)\Common Files\Oracle\Java\javapath;C:\VulkanSDK\1.3.261.1\Bin;C:\Program Files (x86)\SCE\Common\SceVSI-VS17\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\Program Files\dotnet\;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\NVIDIA Corporation\NVIDIA NvDLISR;C:\Program Files\nodejs\;C:\Program Files\Git\cmd;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Program Files\xmake;C:\Program Files (x86)\Gpg4win\..\GnuPG\bin;C:\Program Files\CMake\bin;C:\Program Files\GitHub CLI\;C:\Users\lynix\AppData\Local\Programs\Python\Launcher\;C:\Users\lynix\.cargo\bin;C:\Users\lynix\AppData\Local\Microsoft\WindowsApps;C:\Users\lynix\AppData\Local\Programs\Microsoft VS Code\bin;C:\Users\lynix\AppData\Local\GitHubDesktop\bin;C:\Users\lynix\.dotnet\tools;C:\Program Files\OpenCppCoverage;C:\Users\lynix\AppData\Roaming\npm;c:\users\lynix\appdata\local\microsoft\visualstudio\17.0_8427cfbf\extensions\kixyskqi.kly;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja;C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\Linux\bin\ConnectionManagerExe;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\vcpkg",
          VSCMD_ARG_TGT_ARCH = "x86",
          VSCMD_VER = "17.10.1",
          UCRTVersion = "10.0.22621.0",
          VCIDEInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VC\",
          WindowsSdkDir = "C:\Program Files (x86)\Windows Kits\10\",
          VisualStudioVersion = "17.0",
          VSCMD_ARG_HOST_ARCH = "x64",
          VSInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\",
          VCToolsRedistDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Redist\MSVC\14.40.33807\",
          WindowsSDKVersion = "10.0.22621.0",
          WindowsSdkVerBinPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\",
          VCToolsInstallDir = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\",
          WindowsLibPath = "C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.22621.0;C:\Program Files (x86)\Windows Kits\10\References\10.0.22621.0",
          WindowsSdkBinPath = "C:\Program Files (x86)\Windows Kits\10\bin\",
          INCLUDE = "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\include;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\ATLMFC\include;C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\VS\include;C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt;C:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt;C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um"
        }
      }
    }
  }
  ```
</details>

I have no idea what happened on Microsoft side, or maybe Visual Studio toolset shouldn't be extracted from `VCToolsVersion`.

Anyway, here's a fix where we force v143 if v144 is detected, I used a map in case more values are expected in the future.