### PR TITLE
config: fix is_* and has_* returning nil

### DIFF
--- a/xmake/core/project/config.lua
+++ b/xmake/core/project/config.lua
@@ -291,6 +291,8 @@ function config.is_value(name, ...)
             return true
         end
     end
+
+    return false
 end
 
 -- has the given configs?
@@ -300,6 +302,8 @@ function config.has(...)
             return true
         end
     end
+
+    return false
 end
 
 -- dump the configure


### PR DESCRIPTION
This fix some unexpected behavior, for example:
```lua
add_requireconfs("libsdl", "**.libsdl", {configs = { sdlmain = is_mode("distrib") }})
```

you would expect sdlmain to be false in debug mode, but `is_mode` returns nil instead, which sets sdlmain as `true` is the default option.