### PR TITLE
Intel has changed its default path for icx

### DIFF
--- a/xmake/modules/detect/sdks/find_icxenv.lua
+++ b/xmake/modules/detect/sdks/find_icxenv.lua
@@ -123,6 +123,7 @@ function _find_intel_on_linux(opt)
     paths = {}
     for _, rootdir in ipairs(oneapi_rootdirs) do
         table.insert(paths, path.join(rootdir, "*", is_host("macosx") and "mac" or "linux", "bin"))
+        table.insert(paths, path.join(rootdir, "*", "bin"))
     end
     if #paths > 0 then
         local icx = find_file("icx", paths)


### PR DESCRIPTION
 there is no "linux" anymore, for example: \\wsl.localhost\Ubuntu-24.04\opt\intel\oneapi\compiler\2024.1\bin

![image](https://github.com/xmake-io/xmake/assets/139891033/2686cce9-ba81-4c20-a44d-081e82aea9c5)
