### PR TITLE
add read_timeout to net.http.download

### DIFF
--- a/xmake/modules/net/http/download.lua
+++ b/xmake/modules/net/http/download.lua
@@ -105,6 +105,14 @@ function _curl_download(tool, url, outputfile, opt)
         table.insert(argv, tostring(opt.timeout))
     end
 
+    -- set read timeout
+    if opt.read_timeout then
+        table.insert(argv, "--speed-limit")
+        table.insert(argv, "0")
+        table.insert(argv, "--speed-time")
+        table.insert(argv, tostring(opt.read_timeout))
+    end
+
     -- set url
     table.insert(argv, url)
 
@@ -179,6 +187,11 @@ function _wget_download(tool, url, outputfile, opt)
     -- set timeout
     if opt.timeout then
         table.insert(argv, "--timeout=" .. tostring(opt.timeout))
+    end
+
+    -- set read timeout
+    if opt.read_timeout then
+        table.insert(argv, "--read-timeout=" .. tostring(opt.read_timeout))
     end
 
     -- set outputfile


### PR DESCRIPTION
Stops the connection if the download is 0 and the maximum `read_timeout` duration has been reached, alternative to timeout since `read_timeout` does not stop after `timeout` duration (https://github.com/xmake-io/xmake/issues/5186)

(`speed-limit` checks less than or equal to)
