### PR TITLE
Fix syslinks error using qt static lib in mingw

### DIFF
--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -264,6 +264,7 @@ function main(target, opt)
     target:set("syslinks", nil)
 
     -- add qt links and directories
+    target:add("syslinks", target:values("qt.links"))
     local qtprldirs = {}
     for _, qt_linkdir in ipairs(target:values("qt.linkdirs")) do
         local linkdir = path.join(qt.sdkdir, qt_linkdir)
@@ -278,7 +279,6 @@ function main(target, opt)
             _add_qmakeprllibs(target, prl_file, qt.libdir)
         end
     end
-    target:add("syslinks", target:values("qt.links"))
 
     -- backup qt frameworks
     local qt_frameworks = target:get("frameworks")

--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -159,7 +159,7 @@ function _add_qmakeprllibs(target, prlfile, qtlibdir)
                 else
                     local libstr = string.gsub(lib, "%$%$%[QT_INSTALL_LIBS%]", qtlibdir)
                     if libstr:startswith("-l") then
-                        libstr = lib:sub(3)
+                        libstr = libstr:sub(3)
                     end
                     target:add("syslinks", libstr)
                 end

--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -158,6 +158,9 @@ function _add_qmakeprllibs(target, prlfile, qtlibdir)
                     target:add("linkdirs", libdir)
                 else
                     local libstr = string.gsub(lib, "%$%$%[QT_INSTALL_LIBS%]", qtlibdir)
+                    if libstr:startswith("-l") then
+                        libstr = lib:sub(3)
+                    end
                     target:add("syslinks", libstr)
                 end
             end


### PR DESCRIPTION
问题出现在使用msys/mingw环境下，使用在使用qt5静态库编译时，xmake在`_add_qmakeprllibs`函数中读取
qt lib文件夹下对应库prl文件中`QMAKE_PRL_LIBS_FOR_CMAKE`值作为syslink添加。
以Qt5Core.prl为例

```
...
QMAKE_PRL_LIBS_FOR_CMAKE = -lmpr;-luserenv;-lversion;-lz;$$[QT_INSTALL_LIBS]/libqtpcre2.a;-lzstd;-lnetapi32;-lws2_32;-ladvapi32;-lkernel32;-lole32;-lshell32;-luuid;-luser32;-lwinmm;;
```

最终添加的syslinks为 `target:add("syslinks", "-lmpr")`，`-l`重复添加，造成编译时链接失败，链接错误日志如下

```
x86_64-w64-mingw32-g++ -o build\mingw\x86_64\release\qt.exe build\.objs\qt\mingw\x86_64\release\src\main.cpp.obj build\.objs\qt\mingw\x86_64\release\src\mainwindow.cpp.obj build\.objs\qt\mingw\x86_64\release\gens\src\moc_mainwindow.cpp.obj -m64 -LD:\ProgramFilesScoop\apps\msys2\2024-05-07\mingw64\qt5-static\lib -s D:/ProgramFilesScoop/apps/msys2/2024-05-07/mingw64/qt5-static/lib/libQt5Gui.a -l-ld3d11 -l-ldxgi -l-ldxguid D:/ProgramFilesScoop/apps/msys2/2024-05-07/mingw64/qt5-static/lib/libqtlibpng.a D:/ProgramFilesScoop/apps/msys2/2024-05-07/mingw64/qt5-static/lib/libqtharfbuzz.a D:/ProgramFilesScoop/apps/msys2/2024-05-07/mingw64/qt5-static/lib/libQt5Core.a -l-luxtheme -l-ldwmapi -l-lcomdlg32 -l-loleaut32 -l-limm32 -l-lglu32 -l-lopengl32 -l-lgdi32 -l-lmpr -l-luserenv -l-lversion -l-lz D:/ProgramFilesScoop/apps/msys2/2024-05-07/mingw64/qt5-static/lib/libqtpcre2.a -l-lzstd -l-lnetapi32 -l-lws2_32 -l-ladvapi32 -l-lkernel32 -l-lole32 -l-lshell32 -l-luuid -l-luser32 -l-lwinmm -lqtfreetype -lqtharfbuzz -lqtlibjpeg -lqtlibpng -lqtmain -lqtopenwnn -lqtpcre2 -lqtpinyin -lqttcime -lqt_clip2tri -lqt_clipper -lqt_poly2tri -lmingw32 -lws2_32 -lgdi32 -lole32 -ladvapi32 -lshell32 -luser32 -liphlpapi -mwindows
```

第二处是链接时，链接顺序问题，应当先链接a文件，后链接对应prl文件中的依赖库