### PR TITLE
Improve Android

### DIFF
--- a/xmake/modules/detect/sdks/find_ndk.lua
+++ b/xmake/modules/detect/sdks/find_ndk.lua
@@ -86,6 +86,7 @@ function _find_ndk_sdkver(sdkdir, bindir, sysroot, arch)
 
     -- get triple
     local triple = _get_triple(arch)
+    assert(triple, "no triple found for arch %s (wrong arch?)", arch)
 
     -- try to select the best compatible version
     local sdkver = "16"

--- a/xmake/toolchains/ndk/load.lua
+++ b/xmake/toolchains/ndk/load.lua
@@ -171,21 +171,24 @@ function main(toolchain)
                 toolchain:add("cxflags", "-D__ANDROID_API__=" .. ndk_sdkver)
                 toolchain:add("asflags", "-D__ANDROID_API__=" .. ndk_sdkver)
             end
-            toolchain:add("cflags",  "--sysroot=" .. ndk_sysroot)
-            toolchain:add("cxxflags","--sysroot=" .. ndk_sysroot)
-            toolchain:add("asflags", "--sysroot=" .. ndk_sysroot)
-            toolchain:add("cflags",  "-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
-            toolchain:add("cxxflags","-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
-            toolchain:add("asflags", "-isystem " .. path.join(ndk_sysroot, "usr", "include", triple))
+            local flag_sysroot = "--sysroot=" .. os.args(ndk_sysroot)
+            local flag_isystem = "-isystem " .. os.args(path.join(ndk_sysroot, "usr", "include", triple))
+            toolchain:add("cflags",   flag_sysroot)
+            toolchain:add("cxxflags", flag_sysroot)
+            toolchain:add("asflags",  flag_sysroot)
+            toolchain:add("cflags",   flag_isystem)
+            toolchain:add("cxxflags", flag_isystem)
+            toolchain:add("asflags",  flag_isystem)
         else
             local ndk_sdkdir = path.translate(format("%s/platforms/android-%d", ndk, ndk_sdkver))
             if os.isdir(ndk_sdkdir) then
                 if sysroot_arch then
-                    toolchain:add("cflags",   format("--sysroot=%s/%s", ndk_sdkdir, sysroot_arch))
-                    toolchain:add("cxxflags", format("--sysroot=%s/%s", ndk_sdkdir, sysroot_arch))
-                    toolchain:add("asflags",  format("--sysroot=%s/%s", ndk_sdkdir, sysroot_arch))
-                    toolchain:add("ldflags", format("--sysroot=%s/%s", ndk_sdkdir, sysroot_arch))
-                    toolchain:add("shflags", format("--sysroot=%s/%s", ndk_sdkdir, sysroot_arch))
+                    local flag_sysroot = "--sysroot=" .. os.args(path.join(ndk_sdkdir, sysroot_arch))
+                    toolchain:add("cflags",   flag_sysroot)
+                    toolchain:add("cxxflags", flag_sysroot)
+                    toolchain:add("asflags",  flag_sysroot)
+                    toolchain:add("ldflags",  flag_sysroot)
+                    toolchain:add("shflags",  flag_sysroot)
                 end
             end
         end
@@ -318,8 +321,8 @@ function main(toolchain)
                 -- The NDK's libc++ now comes directly from our LLVM toolchain above 26b
                 -- https://github.com/xmake-io/xmake/issues/4614
                 if ndk_cxxstl == "c++_static" then
-                    toolchain:add("ldflags", "-static-libstdc++", "-lc++abi")
-                    toolchain:add("shflags", "-static-libstdc++", "-lc++abi")
+                    toolchain:add("ldflags", "-static-libstdc++")
+                    toolchain:add("shflags", "-static-libstdc++")
                     if arm32 then
                         toolchain:add("syslinks", "unwind", "atomic")
                     end


### PR DESCRIPTION
ndk: fix error if ndk has spaces
also add a better error if a wrong arch is specified