### PR TITLE
cmake: set CMAKE_SYSTEM_PROCESSOR when cross-compiling

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -288,6 +288,22 @@ function _get_cmake_version()
     return cmake_version
 end
 
+function _get_cmake_system_processor(package)
+    -- on Windows, CMAKE_SYSTEM_PROCESSOR comes from PROCESSOR_ARCHITECTURE
+    -- on other systems it's the output of uname -m
+    if package:is_plat("windows") then
+        local archs = {
+            x86 = "x86",
+            x64 = "AMD64"
+            x86_64 = "AMD64",
+            arm = "ARM",
+            arm64 = "ARM64"
+        }
+        return archs[package:arch()] or package:arch()
+    end
+    return package:arch()
+end
+
 -- insert configs from envs
 function _insert_configs_from_envs(configs, envs, opt)
     opt = opt or {}
@@ -437,7 +453,7 @@ function _get_configs_for_appleos(package, configs, opt)
         end
     elseif package:is_cross() then
         envs.CMAKE_SYSTEM_NAME = "Darwin"
-        envs.CMAKE_SYSTEM_PROCESSOR = package:targetarch()
+        envs.CMAKE_SYSTEM_PROCESSOR = _get_cmake_system_processor(package)
     end
     envs.CMAKE_OSX_ARCHITECTURES = package:arch()
     envs.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE   = "BOTH"
@@ -469,7 +485,7 @@ function _get_configs_for_mingw(package, configs, opt)
     envs.CMAKE_EXE_LINKER_FLAGS    = _get_ldflags(package, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     envs.CMAKE_SYSTEM_NAME         = "Windows"
-    envs.CMAKE_SYSTEM_PROCESSOR    = package:targetarch()
+    envs.CMAKE_SYSTEM_PROCESSOR    = _get_cmake_system_processor(package)
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -294,7 +294,7 @@ function _get_cmake_system_processor(package)
     if package:is_plat("windows") then
         local archs = {
             x86 = "x86",
-            x64 = "AMD64"
+            x64 = "AMD64",
             x86_64 = "AMD64",
             arm = "ARM",
             arm64 = "ARM64"

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -288,7 +288,13 @@ function _get_cmake_version()
     return cmake_version
 end
 
-function _get_cmake_system_processor(package)
+function _get_cmake_system_processor(package, opt)
+    opt = opt or {}
+    local configs_str = opt._configs_str
+    if configs_str and configs_str:find("CMAKE_SYSTEM_PROCESSOR", 1, true) then
+        return
+    end
+
     -- on Windows, CMAKE_SYSTEM_PROCESSOR comes from PROCESSOR_ARCHITECTURE
     -- on other systems it's the output of uname -m
     if package:is_plat("windows") then
@@ -453,7 +459,7 @@ function _get_configs_for_appleos(package, configs, opt)
         end
     elseif package:is_cross() then
         envs.CMAKE_SYSTEM_NAME = "Darwin"
-        envs.CMAKE_SYSTEM_PROCESSOR = _get_cmake_system_processor(package)
+        envs.CMAKE_SYSTEM_PROCESSOR = _get_cmake_system_processor(package, opt)
     end
     envs.CMAKE_OSX_ARCHITECTURES = package:arch()
     envs.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE   = "BOTH"
@@ -485,7 +491,7 @@ function _get_configs_for_mingw(package, configs, opt)
     envs.CMAKE_EXE_LINKER_FLAGS    = _get_ldflags(package, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     envs.CMAKE_SYSTEM_NAME         = "Windows"
-    envs.CMAKE_SYSTEM_PROCESSOR    = _get_cmake_system_processor(package)
+    envs.CMAKE_SYSTEM_PROCESSOR    = _get_cmake_system_processor(package, opt)
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir
@@ -1209,4 +1215,3 @@ function install(package, configs, opt)
     end
     os.cd(oldir)
 end
-

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -435,8 +435,9 @@ function _get_configs_for_appleos(package, configs, opt)
         if package:is_arch("x86_64", "i386") then
             envs.CMAKE_OSX_SYSROOT = "iphonesimulator"
         end
-    elseif package:is_plat("macosx") then
+    elseif _is_cross_compilation() then
         envs.CMAKE_SYSTEM_NAME = "Darwin"
+        envs.CMAKE_SYSTEM_PROCESSOR = package:targetarch()
     end
     envs.CMAKE_OSX_ARCHITECTURES = package:arch()
     envs.CMAKE_FIND_ROOT_PATH_MODE_PACKAGE   = "BOTH"
@@ -468,6 +469,7 @@ function _get_configs_for_mingw(package, configs, opt)
     envs.CMAKE_EXE_LINKER_FLAGS    = _get_ldflags(package, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     envs.CMAKE_SYSTEM_NAME         = "Windows"
+    envs.CMAKE_SYSTEM_PROCESSOR    = package:targetarch()
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir
@@ -552,7 +554,7 @@ function _get_configs_for_cross(package, configs, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     -- we don't need to set it as cross compilation if we just pass toolchain
     -- https://github.com/xmake-io/xmake/issues/2170
-    if not package:is_plat(os.subhost()) then
+    if _is_cross_compilation() then
         local system_name = package:targetos() or "Linux"
         if system_name == "linux" then
             system_name = "Linux"
@@ -628,7 +630,7 @@ function _get_configs_for_host_toolchain(package, configs, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     -- we don't need to set it as cross compilation if we just pass toolchain
     -- https://github.com/xmake-io/xmake/issues/2170
-    if not package:is_plat(os.subhost()) then
+    if _is_cross_compilation() then
         envs.CMAKE_SYSTEM_NAME     = "Linux"
     else
         if package:config("pic") ~= false then

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -435,7 +435,7 @@ function _get_configs_for_appleos(package, configs, opt)
         if package:is_arch("x86_64", "i386") then
             envs.CMAKE_OSX_SYSROOT = "iphonesimulator"
         end
-    elseif _is_cross_compilation() then
+    elseif package:is_cross() then
         envs.CMAKE_SYSTEM_NAME = "Darwin"
         envs.CMAKE_SYSTEM_PROCESSOR = package:targetarch()
     end
@@ -554,7 +554,7 @@ function _get_configs_for_cross(package, configs, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     -- we don't need to set it as cross compilation if we just pass toolchain
     -- https://github.com/xmake-io/xmake/issues/2170
-    if _is_cross_compilation() then
+    if package:is_cross() then
         local system_name = package:targetos() or "Linux"
         if system_name == "linux" then
             system_name = "Linux"
@@ -630,7 +630,7 @@ function _get_configs_for_host_toolchain(package, configs, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     -- we don't need to set it as cross compilation if we just pass toolchain
     -- https://github.com/xmake-io/xmake/issues/2170
-    if _is_cross_compilation() then
+    if package:is_cross() then
         envs.CMAKE_SYSTEM_NAME     = "Linux"
     else
         if package:config("pic") ~= false then

--- a/xmake/modules/private/action/trybuild/cmake.lua
+++ b/xmake/modules/private/action/trybuild/cmake.lua
@@ -168,7 +168,7 @@ function _get_configs_for_appleos(configs)
         end
     elseif _is_cross_compilation() then
         envs.CMAKE_SYSTEM_NAME = "Darwin"
-        envs.CMAKE_SYSTEM_PROCESSOR = package:targetarch()
+        envs.CMAKE_SYSTEM_PROCESSOR = os.subarch()
     end
     envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   = "BOTH"

--- a/xmake/modules/private/action/trybuild/cmake.lua
+++ b/xmake/modules/private/action/trybuild/cmake.lua
@@ -166,8 +166,9 @@ function _get_configs_for_appleos(configs)
         if is_arch("x86_64", "i386") then
             envs.CMAKE_OSX_SYSROOT = "iphonesimulator"
         end
-    elseif is_plat("macosx") then
+    elseif _is_cross_compilation() then
         envs.CMAKE_SYSTEM_NAME = "Darwin"
+        envs.CMAKE_SYSTEM_PROCESSOR = package:targetarch()
     end
     envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   = "BOTH"
@@ -199,6 +200,7 @@ function _get_configs_for_mingw(configs)
     envs.CMAKE_EXE_LINKER_FLAGS    = table.concat(table.wrap(_get_buildenv("ldflags")), ' ')
     envs.CMAKE_SHARED_LINKER_FLAGS = table.concat(table.wrap(_get_buildenv("shflags")), ' ')
     envs.CMAKE_SYSTEM_NAME         = "Windows"
+    envs.CMAKE_SYSTEM_PROCESSOR    = package:targetarch()
     -- avoid find and add system include/library path
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir
     envs.CMAKE_SYSROOT             = sdkdir
@@ -321,8 +323,8 @@ function _get_configs_for_host_toolchain(configs)
     envs.CMAKE_SHARED_LINKER_FLAGS = table.concat(table.wrap(_get_buildenv("shflags")), ' ')
     -- we don't need to set it as cross compilation if we just pass toolchain
     -- https://github.com/xmake-io/xmake/issues/2170
-    if not is_plat(os.subhost()) then
-        envs.CMAKE_SYSTEM_NAME     = "Linux"
+    if _is_cross_compilation() then
+        envs.CMAKE_SYSTEM_NAME = "Linux"
     end
     for k, v in pairs(envs) do
         table.insert(configs, "-D" .. k .. "=" .. v)

--- a/xmake/modules/private/action/trybuild/cmake.lua
+++ b/xmake/modules/private/action/trybuild/cmake.lua
@@ -200,7 +200,7 @@ function _get_configs_for_mingw(configs)
     envs.CMAKE_EXE_LINKER_FLAGS    = table.concat(table.wrap(_get_buildenv("ldflags")), ' ')
     envs.CMAKE_SHARED_LINKER_FLAGS = table.concat(table.wrap(_get_buildenv("shflags")), ' ')
     envs.CMAKE_SYSTEM_NAME         = "Windows"
-    envs.CMAKE_SYSTEM_PROCESSOR    = package:targetarch()
+    envs.CMAKE_SYSTEM_PROCESSOR    = os.subarch()
     -- avoid find and add system include/library path
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir
     envs.CMAKE_SYSROOT             = sdkdir

--- a/xmake/modules/private/action/trybuild/cmake.lua
+++ b/xmake/modules/private/action/trybuild/cmake.lua
@@ -101,6 +101,22 @@ function _is_cross_compilation()
     return false
 end
 
+function _get_cmake_system_processor()
+    -- on Windows, CMAKE_SYSTEM_PROCESSOR comes from PROCESSOR_ARCHITECTURE
+    -- on other systems it's the output of uname -m
+    if is_plat("windows") then
+        local archs = {
+            x86 = "x86",
+            x64 = "AMD64",
+            x86_64 = "AMD64",
+            arm = "ARM",
+            arm64 = "ARM64"
+        }
+        return archs[os.subarch()] or os.subarch()
+    end
+    return os.subarch()
+end
+
 -- get configs for windows
 function _get_configs_for_windows(configs, opt)
     opt = opt or {}
@@ -168,7 +184,7 @@ function _get_configs_for_appleos(configs)
         end
     elseif _is_cross_compilation() then
         envs.CMAKE_SYSTEM_NAME = "Darwin"
-        envs.CMAKE_SYSTEM_PROCESSOR = os.subarch()
+        envs.CMAKE_SYSTEM_PROCESSOR = _get_cmake_system_processor()
     end
     envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   = "BOTH"
@@ -200,7 +216,7 @@ function _get_configs_for_mingw(configs)
     envs.CMAKE_EXE_LINKER_FLAGS    = table.concat(table.wrap(_get_buildenv("ldflags")), ' ')
     envs.CMAKE_SHARED_LINKER_FLAGS = table.concat(table.wrap(_get_buildenv("shflags")), ' ')
     envs.CMAKE_SYSTEM_NAME         = "Windows"
-    envs.CMAKE_SYSTEM_PROCESSOR    = os.subarch()
+    envs.CMAKE_SYSTEM_PROCESSOR    = _get_cmake_system_processor()
     -- avoid find and add system include/library path
     envs.CMAKE_FIND_ROOT_PATH      = sdkdir
     envs.CMAKE_SYSROOT             = sdkdir


### PR DESCRIPTION
Some projects use CMAKE_SYSTEM_PROCESSOR to identify target archs (see https://github.com/jrouwe/JoltPhysics/issues/1133 and https://github.com/xmake-io/xmake-repo/pull/4330).
When CMAKE_SYSTEM_NAME is set, cmake switches to cross-compiling mode and won't set CMAKE_SYSTEM_PROCESSOR by itself.