### PR TITLE
fix: test/.../verialtor/hello_vcd no wave file output

### DIFF
--- a/tests/projects/embed/verilator/hello_vcd/src/sim_main.cpp
+++ b/tests/projects/embed/verilator/hello_vcd/src/sim_main.cpp
@@ -22,6 +22,7 @@ int main(int argc, char** argv) {
     Verilated::traceEverOn(true);
     tfp->open(vcdfile);
     while (!contextp->gotFinish()) { top->eval(); }
+    tfp->close();
     delete top;
     delete contextp;
     return 0;


### PR DESCRIPTION
fix test/.../verialtor/hello_vcd no wave file output due to forgetting closing file
