### PR TITLE
Add armclang version judgement and automatically select assembler based on the result

### DIFF
--- a/xmake/modules/detect/sdks/find_mdk.lua
+++ b/xmake/modules/detect/sdks/find_mdk.lua
@@ -73,8 +73,6 @@ function _find_mdk(sdkdir)
     -- armclang sdk directory
     local sdkdir_armclang = path.join(sdkdir, "armclang")
     if os.isdir(sdkdir_armclang) and os.isfile(path.join(sdkdir_armclang, "bin", "armclang.exe")) then
-        local sdk_armclang_ver = os.iorun(path.join(sdkdir_armclang, "bin", "armclang.exe").." --version_number")
-        result.sdk_armclang_vernum = tonumber(sdk_armclang_ver)
         result.sdkdir_armclang = sdkdir_armclang
     end
     return result

--- a/xmake/modules/detect/sdks/find_mdk.lua
+++ b/xmake/modules/detect/sdks/find_mdk.lua
@@ -73,6 +73,8 @@ function _find_mdk(sdkdir)
     -- armclang sdk directory
     local sdkdir_armclang = path.join(sdkdir, "armclang")
     if os.isdir(sdkdir_armclang) and os.isfile(path.join(sdkdir_armclang, "bin", "armclang.exe")) then
+        local sdk_armclang_ver = os.iorun(path.join(sdkdir_armclang, "bin", "armclang.exe").." --version_number")
+        result.sdk_armclang_vernum = tonumber(sdk_armclang_ver)
         result.sdkdir_armclang = sdkdir_armclang
     end
     return result

--- a/xmake/modules/detect/tools/find_armclang.lua
+++ b/xmake/modules/detect/tools/find_armclang.lua
@@ -39,7 +39,9 @@ import("detect.sdks.find_mdk")
 function main(opt)
 
     -- init options
-    opt = opt or {}
+    opt         = opt or {}
+    opt.command = opt.command or "--version"
+    opt.parse   = opt.parse or function (output) return output:match("Arm Compiler for Embedded (%d+%.?%d+%.?%d+)%s") end
 
     -- find program
     local program = find_program(opt.program or "armclang.exe", opt)

--- a/xmake/modules/detect/tools/find_armclang.lua
+++ b/xmake/modules/detect/tools/find_armclang.lua
@@ -40,7 +40,6 @@ function main(opt)
 
     -- init options
     opt         = opt or {}
-    opt.command = opt.command or "--version"
     opt.parse   = opt.parse or function (output) return output:match("Arm Compiler for Embedded (%d+%.?%d+%.?%d+)%s") end
 
     -- find program

--- a/xmake/toolchains/armclang/xmake.lua
+++ b/xmake/toolchains/armclang/xmake.lua
@@ -57,9 +57,10 @@ toolchain("armclang")
                 arch_target  = "aarch64-arm-none-eabi"
             end
 
-            import("detect.sdks.find_mdk")
-            local mdk = find_mdk()
-            if mdk.sdk_armclang_vernum > 6140000 then
+            import("lib.detect.find_tool")
+            import("core.base.semver")
+            local armclang = find_tool("armclang", {version = true})
+            if semver.compare(armclang.version, "6.13")>0 then
                 toolchain:set("toolset", "as", "armclang")
                 toolchain:add("cxflags", "--target=" .. arch_target)
                 toolchain:add("cxflags", "-mcpu="   .. arch_cpu)

--- a/xmake/toolchains/armclang/xmake.lua
+++ b/xmake/toolchains/armclang/xmake.lua
@@ -29,7 +29,7 @@ toolchain("armclang")
     set_toolset("cxx", "armclang")
     set_toolset("ld", "armlink")
     set_toolset("ar", "armar")
-    set_toolset("as", "armasm")
+    -- different assembler choices for different versions of armclang
 
     on_check(function (toolchain)
         import("lib.detect.find_tool")
@@ -56,11 +56,24 @@ toolchain("armclang")
                 arch_cpu_ld = arch_cpu:replace("cortex-a", "Cortex-A", {plain = true})
                 arch_target  = "aarch64-arm-none-eabi"
             end
-            toolchain:add("cxflags", "-target=" .. arch_target)
-            toolchain:add("cxflags", "-mcpu="   .. arch_cpu)
-            toolchain:add("asflags", "-target=" .. arch_target)
-            toolchain:add("asflags", "--cpu="   .. arch_cpu)
-            toolchain:add("ldflags", "--cpu "   .. arch_cpu_ld)
+
+            import("detect.sdks.find_mdk")
+            local mdk = find_mdk()
+            if mdk.sdk_armclang_vernum > 6140000 then
+                toolchain:set("toolset", "as", "armclang")
+                toolchain:add("cxflags", "--target=" .. arch_target)
+                toolchain:add("cxflags", "-mcpu="   .. arch_cpu)
+                toolchain:add("asflags", "--target=" .. arch_target)
+                toolchain:add("asflags", "-mcpu="   .. arch_cpu)
+                toolchain:add("ldflags", "--cpu "   .. arch_cpu_ld)
+            else
+                toolchain:set("toolset", "as", "armasm")
+                toolchain:add("cxflags", "--target=" .. arch_target)
+                toolchain:add("cxflags", "-mcpu="   .. arch_cpu)
+                toolchain:add("asflags", "-target=" .. arch_target)
+                toolchain:add("asflags", "--cpu="   .. arch_cpu)
+                toolchain:add("ldflags", "--cpu "   .. arch_cpu_ld)
+            end
         end
     end)
 


### PR DESCRIPTION
* 增加对armclang版本的检测
* 根据不同armclang版本自动选择不同版本的汇编器（armasm/armclang），并选用不同的asflags（--cpu/-mcpu） #5071 
* 修改了armclang自动添加的cxflags为"--target="，使其自动生成的compile_commands.json在clangd中不会报错 #5244 
