### PR TITLE
Revert wrong change in ebc4520b6ce93e6f31d6885f5f5820f5992962ee

### DIFF
--- a/xmake/toolchains/ndk/load.lua
+++ b/xmake/toolchains/ndk/load.lua
@@ -321,8 +321,8 @@ function main(toolchain)
                 -- The NDK's libc++ now comes directly from our LLVM toolchain above 26b
                 -- https://github.com/xmake-io/xmake/issues/4614
                 if ndk_cxxstl == "c++_static" then
-                    toolchain:add("ldflags", "-static-libstdc++")
-                    toolchain:add("shflags", "-static-libstdc++")
+                    toolchain:add("ldflags", "-static-libstdc++", "-lc++abi")
+                    toolchain:add("shflags", "-static-libstdc++", "-lc++abi")
                     if arm32 then
                         toolchain:add("syslinks", "unwind", "atomic")
                     end


### PR DESCRIPTION
#5211 wrongly removed the -lc++_abi flag because my xmake version was not up to date and I didn't see it.

Sorry to notice it only after the new version 😓 