### PR TITLE
get.ps1: Update method to get temp path to avoid failure in 8.3 path #5255

### DIFF
--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -38,7 +38,7 @@ param (
         throw 'Unsupported platform'
     }
 
-    $temppath = ($env:TMP, $env:TEMP, "$(Get-Location)" -ne $null)[0]
+    $temppath = ([System.IO.Path]::GetTempPath(), $env:TMP, $env:TEMP, "$(Get-Location)" -ne $null)[0]
     [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
 
     if ($null -eq $installdir -or $installdir -match '^\s*$') {


### PR DESCRIPTION
This PR addresses the issue of the installation script failing when the `TMP`/`TEMP` path contains 8.3 format by using the built-in PowerShell function `[System.IO.Path]::GetTempPath()` to retrieve the temp path.

https://github.com/xmake-io/xmake/issues/5255

<!--- 
* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

--->