### PR TITLE
Improve Vala support

### DIFF
--- a/tests/projects/vala/includec/src/main.vala
+++ b/tests/projects/vala/includec/src/main.vala
@@ -1,0 +1,9 @@
+extern void printer_from_c();
+
+int main (string[] args) {
+    printer_from_c();
+    printer_from_other_file();
+
+    return 0;
+}
+

--- a/tests/projects/vala/includec/src/printer.c
+++ b/tests/projects/vala/includec/src/printer.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+void printer_from_c() {
+    printf("Calling from C");
+}
+

--- a/tests/projects/vala/includec/src/printer.vala
+++ b/tests/projects/vala/includec/src/printer.vala
@@ -1,5 +1,3 @@
-using Glib;
-
 void printer_from_other_file() {
     stdout.printf("Calling from other file");
 }

--- a/tests/projects/vala/includec/src/printer.vala
+++ b/tests/projects/vala/includec/src/printer.vala
@@ -1,0 +1,5 @@
+using Glib;
+
+void printer_from_other_file() {
+    stdout.printf("Calling from other file");
+}

--- a/tests/projects/vala/includec/xmake.lua
+++ b/tests/projects/vala/includec/xmake.lua
@@ -1,0 +1,10 @@
+add_rules("mode.release", "mode.debug")
+
+add_requires("glib")
+
+target("test")
+    set_kind("binary")
+    add_rules("vala")
+    add_files("src/*.vala")
+    add_files("src/*.c")
+    add_packages("glib")

--- a/xmake/rules/vala/xmake.lua
+++ b/xmake/rules/vala/xmake.lua
@@ -116,17 +116,17 @@ rule("vala.build")
             -- if it's only a vala file
             if path.extension(sourcefile) == ".vala" then
                 table.insert(argv, path(sourcefile))
+                batchcmds:show_progress(opt.progress, "${color.build.object}compiling.vala %s", sourcefile)
             end
         end
 
-        batchcmds:show_progress(opt.progress, "${color.build.object}compiling.vala")
         batchcmds:vrunv(valac.program, argv)
     end)
 
-    on_buildcmd_file(function (target, batchcmds, sourcebatch, opt)
+    on_buildcmd_file(function (target, batchcmds, sourcefile, opt)
         -- Again, only vala files need special treatment
-        if path.extension(sourcebatch) == ".vala" then
-            local sourcefile_c = target:autogenfile((sourcebatch:gsub(".vala$", ".c")))
+        if path.extension(sourcefile) == ".vala" then
+            local sourcefile_c = target:autogenfile((sourcefile:gsub(".vala$", ".c")))
             local basedir = path.directory(sourcefile_c)
 
             batchcmds:mkdir(basedir)
@@ -134,7 +134,7 @@ rule("vala.build")
             local objectfile = target:objectfile(sourcefile_c)
             table.insert(target:objectfiles(), objectfile)
 
-            batchcmds:add_depfiles(sourcebatch)
+            batchcmds:add_depfiles(sourcefile)
             batchcmds:set_depmtime(os.mtime(objectfile))
             batchcmds:set_depcache(target:dependfile(objectfile))
 


### PR DESCRIPTION
When compiling multiple files valac fails to find symbols (i.e SomeClass from a.vala using in b.vala), changed build to process all source files at once