### PR TITLE
Apple tvOS: Fix typo in flag

### DIFF
--- a/xmake/toolchains/xcode/load_appletvos.lua
+++ b/xmake/toolchains/xcode/load_appletvos.lua
@@ -30,7 +30,7 @@ function main(toolchain)
 
     -- init target minimal version
     local target_minver = toolchain:config("target_minver")
-    local target_minver_flags = (simulator and "-mappletv-simulator-version-min=" or "-mappletvos-version-min=") .. target_minver
+    local target_minver_flags = (simulator and "-mappletvsimulator-version-min=" or "-mappletvos-version-min=") .. target_minver
 
     -- init flags for c/c++
     toolchain:add("cxflags", "-arch", arch, target_minver_flags, "-isysroot", xcode_sysroot)


### PR DESCRIPTION
Flag is "-mappletv-simulator-version-min" not "-mappletvsimulator-version-min"
