### PR TITLE
Improve test output

### DIFF
--- a/xmake/actions/test/main.lua
+++ b/xmake/actions/test/main.lua
@@ -256,7 +256,7 @@ function _show_output(testinfo, kind)
     if output then
         if option.get("diagnosis") then
             local target = testinfo.target
-            local logfile = path.join(target:autogendir(), "tests", testinfo.name .. ".log")
+            local logfile = path.join(target:autogendir(), "tests", testinfo.name .. "." .. kind .. ".log")
             io.writefile(logfile, output)
             print("%s: %s", kind, logfile)
         elseif option.get("verbose") then


### PR DESCRIPTION
https://github.com/xmake-io/xmake/pull/5314

### Normal output

```console
$ xmake test
[ 50%]: cache compiling.release src/compile_1.cpp
[ 50%]: cache compiling.release src/compile_2.cpp
running tests ...
[  2%]: running.test test_1/args
[  4%]: running.test test_1/default
[  7%]: running.test test_1/fail_output
[  9%]: running.test test_1/pass_output
[ 11%]: running.test test_10/compile_fail
[ 14%]: running.test test_11/compile_pass
[ 16%]: running.test test_13/stub_1
[ 19%]: running.test test_14/stub_2
[ 21%]: running.test test_15/stub_n
[ 23%]: running.test test_2/args
[ 26%]: running.test test_2/default
[ 28%]: running.test test_2/fail_output
[ 30%]: running.test test_2/pass_output
[ 33%]: running.test test_3/args
[ 35%]: running.test test_3/default
[ 38%]: running.test test_3/fail_output
[ 40%]: running.test test_3/pass_output
[ 42%]: running.test test_4/args
[ 45%]: running.test test_4/default
[ 47%]: running.test test_4/fail_output
[ 50%]: running.test test_4/pass_output
[ 52%]: running.test test_5/args
[ 54%]: running.test test_5/default
[ 57%]: running.test test_5/fail_output
[ 59%]: running.test test_5/pass_output
[ 61%]: running.test test_6/args
[ 64%]: running.test test_6/default
[ 66%]: running.test test_6/fail_output
[ 69%]: running.test test_6/pass_output
[ 71%]: running.test test_7/args
[ 73%]: running.test test_7/default
[ 76%]: running.test test_7/fail_output
[ 78%]: running.test test_7/pass_output
[ 80%]: running.test test_8/args
[ 83%]: running.test test_8/default
[ 85%]: running.test test_8/fail_output
[ 88%]: running.test test_8/pass_output
[ 90%]: running.test test_9/args
[ 92%]: running.test test_9/default
[ 95%]: running.test test_9/fail_output
[ 97%]: running.test test_9/pass_output
[100%]: running.test test_timeout/run_timeout

report of tests:
[  2%]: test_10/compile_fail     .................................... passed 0.000s
[  4%]: test_11/compile_pass     .................................... failed 0.001s
[  7%]: test_1/args              .................................... passed 0.029s
[  9%]: test_1/default           .................................... passed 0.027s
[ 11%]: test_1/fail_output       .................................... passed 0.026s
[ 14%]: test_1/pass_output       .................................... passed 0.023s
[ 16%]: test_13/stub_1           .................................... passed 0.020s
[ 19%]: test_14/stub_2           .................................... passed 0.019s
[ 21%]: test_15/stub_n           .................................... passed 0.016s
[ 23%]: test_2/args              .................................... passed 0.014s
[ 26%]: test_2/default           .................................... passed 0.046s
[ 28%]: test_2/fail_output       .................................... passed 0.044s
[ 30%]: test_2/pass_output       .................................... passed 0.036s
[ 33%]: test_3/args              .................................... passed 0.034s
[ 35%]: test_3/default           .................................... passed 0.032s
[ 38%]: test_3/fail_output       .................................... passed 0.029s
[ 40%]: test_3/pass_output       .................................... passed 0.022s
[ 42%]: test_4/args              .................................... passed 0.014s
[ 45%]: test_4/default           .................................... passed 0.037s
[ 47%]: test_4/fail_output       .................................... passed 0.035s
[ 50%]: test_4/pass_output       .................................... passed 0.028s
[ 52%]: test_5/args              .................................... passed 0.025s
[ 54%]: test_5/default           .................................... passed 0.023s
[ 57%]: test_5/fail_output       .................................... failed 0.021s
[ 59%]: test_5/pass_output       .................................... failed 0.018s
[ 61%]: test_6/args              .................................... passed 0.014s
[ 64%]: test_6/default           .................................... passed 0.035s
[ 66%]: test_6/fail_output       .................................... passed 0.035s
[ 69%]: test_6/pass_output       .................................... passed 0.026s
[ 71%]: test_7/args              .................................... failed 0.024s
[ 73%]: test_7/default           .................................... failed 0.023s
[ 76%]: test_7/fail_output       .................................... failed 0.020s
[ 78%]: test_7/pass_output       .................................... failed 0.018s
[ 80%]: test_8/args              .................................... passed 0.017s
[ 83%]: test_8/default           .................................... passed 0.033s
[ 85%]: test_8/fail_output       .................................... passed 0.031s
[ 88%]: test_8/pass_output       .................................... failed 0.021s
[ 90%]: test_9/args              .................................... passed 0.019s
[ 92%]: test_9/default           .................................... passed 0.016s
[ 95%]: test_9/fail_output       .................................... passed 0.014s
[ 97%]: test_9/pass_output       .................................... passed 0.011s
[100%]: test_timeout/run_timeout .................................... failed 1.005s
78% tests passed, 9 tests failed out of 42, spent 1.158s
```

### Verbose output

```console
i$ xmake test -v
[ 50%]: cache compiling.release src/compile_1.cpp
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -c -Qunused-arguments -target x86_64-apple-macos14.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -fvisibility=hidden -fvisibility-inlines-hidden -O3 -DNDEBUG -o build/.objs/test_10/macosx/x86_64/release/src/compile_1.cpp.o src/compile_1.cpp
[ 50%]: cache compiling.release src/compile_2.cpp
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -c -Qunused-arguments -target x86_64-apple-macos14.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -fvisibility=hidden -fvisibility-inlines-hidden -O3 -DNDEBUG -o build/.objs/test_11/macosx/x86_64/release/src/compile_2.cpp.o src/compile_2.cpp
running tests ...
[  2%]: running.test test_1/args
[  4%]: running.test test_1/default
[  7%]: running.test test_1/fail_output
[  9%]: running.test test_1/pass_output
[ 11%]: running.test test_10/compile_fail
[ 14%]: running.test test_11/compile_pass
src/compile_2.cpp:4:5: error: static assertion failed: error
    static_assert(0, "error");
    ^             ~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__config:477:32: note: expanded from macro 'static_assert'
#    define static_assert(...) _Static_assert(__VA_ARGS__)
                               ^              ~~~~~~~~~~~
1 error generated.
[ 16%]: running.test test_13/stub_1
[ 19%]: running.test test_14/stub_2
[ 21%]: running.test test_15/stub_n
[ 23%]: running.test test_2/args
[ 26%]: running.test test_2/default
[ 28%]: running.test test_2/fail_output
[ 30%]: running.test test_2/pass_output
[ 33%]: running.test test_3/args
[ 35%]: running.test test_3/default
[ 38%]: running.test test_3/fail_output
[ 40%]: running.test test_3/pass_output
[ 42%]: running.test test_4/args
[ 45%]: running.test test_4/default
[ 47%]: running.test test_4/fail_output
[ 50%]: running.test test_4/pass_output
[ 52%]: running.test test_5/args
[ 54%]: running.test test_5/default
[ 57%]: running.test test_5/fail_output
[ 59%]: running.test test_5/pass_output
[ 61%]: running.test test_6/args
[ 64%]: running.test test_6/default
[ 66%]: running.test test_6/fail_output
[ 69%]: running.test test_6/pass_output
[ 71%]: running.test test_7/args
[ 73%]: running.test test_7/default
[ 76%]: running.test test_7/fail_output
[ 78%]: running.test test_7/pass_output
[ 80%]: running.test test_8/args
[ 83%]: running.test test_8/default
[ 85%]: running.test test_8/fail_output
[ 88%]: running.test test_8/pass_output
[ 90%]: running.test test_9/args
[ 92%]: running.test test_9/default
[ 95%]: running.test test_9/fail_output
[ 97%]: running.test test_9/pass_output
[100%]: running.test test_timeout/run_timeout

report of tests:
[  2%]: test_10/compile_fail     .................................... passed 0.001s
[  4%]: test_11/compile_pass     .................................... failed 0.000s
errors: src/compile_2.cpp:4:5: error: static assertion failed: error
    static_assert(0, "error");
    ^             ~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__config:477:32: note: expanded from macro 'static_assert'
#    define static_assert(...) _Static_assert(__VA_ARGS__)
                               ^              ~~~~~~~~~~~
1 error generated.
[  7%]: test_1/args              .................................... passed 0.028s
stdout: hello foo

[  9%]: test_1/default           .................................... passed 0.026s
stdout: hello xmake

[ 11%]: test_1/fail_output       .................................... passed 0.024s
stdout: hello xmake

[ 14%]: test_1/pass_output       .................................... passed 0.022s
stdout: hello foo

[ 16%]: test_13/stub_1           .................................... passed 0.019s
stdout: hello xmake

[ 19%]: test_14/stub_2           .................................... passed 0.018s
stdout: hello xmake

[ 21%]: test_15/stub_n           .................................... passed 0.016s
stdout: hello xmake

[ 23%]: test_2/args              .................................... passed 0.014s
stdout: hello foo

[ 26%]: test_2/default           .................................... passed 0.045s
stdout: hello xmake

[ 28%]: test_2/fail_output       .................................... passed 0.043s
stdout: hello xmake

[ 30%]: test_2/pass_output       .................................... passed 0.036s
stdout: hello foo

[ 33%]: test_3/args              .................................... passed 0.034s
stdout: hello foo

[ 35%]: test_3/default           .................................... passed 0.033s
stdout: hello xmake

[ 38%]: test_3/fail_output       .................................... passed 0.031s
stdout: hello xmake

[ 40%]: test_3/pass_output       .................................... passed 0.016s
stdout: hello foo

[ 42%]: test_4/args              .................................... passed 0.015s
stdout: hello foo

[ 45%]: test_4/default           .................................... passed 0.039s
stdout: hello xmake

[ 47%]: test_4/fail_output       .................................... passed 0.036s
stdout: hello xmake

[ 50%]: test_4/pass_output       .................................... passed 0.028s
stdout: hello foo

[ 52%]: test_5/args              .................................... passed 0.026s
stdout: hello2 foo

[ 54%]: test_5/default           .................................... passed 0.023s
stdout: hello2 xmake

[ 57%]: test_5/fail_output       .................................... failed 0.021s
stdout: hello2 xmake

errors: matched failed output: hello2 .*, actual output: hello2 xmake

[ 59%]: test_5/pass_output       .................................... failed 0.019s
stdout: hello2 foo

errors: not matched passed output: hello foo, actual output: hello2 foo
[ 61%]: test_6/args              .................................... passed 0.017s
stdout: hello foo

[ 64%]: test_6/default           .................................... passed 0.038s
stdout: hello xmake

[ 66%]: test_6/fail_output       .................................... passed 0.035s
stdout: hello xmake

[ 69%]: test_6/pass_output       .................................... passed 0.026s
stdout: hello foo

[ 71%]: test_7/args              .................................... failed 0.024s
stdout: hello foo

errors: run test_7/args failed, exit code: 255
[ 73%]: test_7/default           .................................... failed 0.022s
stdout: hello xmake

errors: run test_7/default failed, exit code: 255
[ 76%]: test_7/fail_output       .................................... failed 0.019s
stdout: hello xmake

errors: run test_7/fail_output failed, exit code: 255
[ 78%]: test_7/pass_output       .................................... failed 0.017s
stdout: hello foo

errors: run test_7/pass_output failed, exit code: 255
[ 80%]: test_8/args              .................................... passed 0.016s
stdout: hello xmake

[ 83%]: test_8/default           .................................... passed 0.031s
stdout: hello xmake

[ 85%]: test_8/fail_output       .................................... passed 0.029s
stdout: hello xmake

[ 88%]: test_8/pass_output       .................................... failed 0.018s
stdout: hello xmake

errors: not matched passed output: hello foo, actual output: hello xmake
[ 90%]: test_9/args              .................................... passed 0.017s
stdout: hello foo

[ 92%]: test_9/default           .................................... passed 0.015s
stdout: hello xmake

[ 95%]: test_9/fail_output       .................................... passed 0.013s
stdout: hello xmake

[ 97%]: test_9/pass_output       .................................... passed 0.011s
stdout: hello foo

[100%]: test_timeout/run_timeout .................................... failed 1.007s
errors: run test_timeout/run_timeout failed, exit code: -1, exit error: wait process timeout
78% tests passed, 9 tests failed out of 42, spent 1.157s
```

### Diagnosis output

It will redirect all output to log file

```console
$ xmake test -vD
[ 50%]: cache compiling.release src/compile_1.cpp
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -c -Qunused-arguments -target x86_64-apple-macos14.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -fvisibility=hidden -fvisibility-inlines-hidden -O3 -DNDEBUG -o build/.objs/test_10/macosx/x86_64/release/src/compile_1.cpp.o src/compile_1.cpp
[ 50%]: cache compiling.release src/compile_2.cpp
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -c -Qunused-arguments -target x86_64-apple-macos14.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk -fvisibility=hidden -fvisibility-inlines-hidden -O3 -DNDEBUG -o build/.objs/test_11/macosx/x86_64/release/src/compile_2.cpp.o src/compile_2.cpp

build cache stats:
cache directory: /Users/ruki/projects/personal/xmake/tests/actions/test/build/.build_cache
cache hit rate: 0%
cache hit: 0
cache hit total time: 0.000s
cache miss: 2
cache miss total time: 0.000s
new cached files: 0
remote cache hit: 0
remote new cached files: 0
preprocess failed: 0
compile fallback count: 0
compile total time: 0.000s

running tests ...
[  2%]: running.test test_1/args
[  4%]: running.test test_1/default
[  7%]: running.test test_1/fail_output
[  9%]: running.test test_1/pass_output
[ 11%]: running.test test_10/compile_fail
[ 14%]: running.test test_11/compile_pass
@programdir/actions/build/main.lua:148: @programdir/modules/async/runjobs.lua:325: @programdir/modules/private/action/build/object.lua:91: @programdir/modules/core/tools/gcc.lua:916: src/compile_2.cpp:4:5: error: static assertion failed: error
    static_assert(0, "error");
    ^             ~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/usr/include/c++/v1/__config:477:32: note: expanded from macro 'static_assert'
#    define static_assert(...) _Static_assert(__VA_ARGS__)
                               ^              ~~~~~~~~~~~
1 error generated.
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:973]:
    [@programdir/modules/core/tools/gcc.lua:916]: in function 'catch'
    [@programdir/core/sandbox/modules/try.lua:123]: in function 'try'
    [@programdir/modules/core/tools/gcc.lua:857]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:275]:
    [@programdir/core/tool/compiler.lua:278]: in function 'compile'
    [@programdir/modules/private/action/build/object.lua:91]: in function 'script'
    [@programdir/modules/private/action/build/object.lua:122]: in function 'build_object'
    [@programdir/modules/private/action/build/object.lua:147]: in function 'jobfunc'
    [@programdir/modules/async/runjobs.lua:241]:
    [C]: in function 'xpcall'
    [@programdir/core/base/utils.lua:275]: in function 'trycall'
    [@programdir/core/sandbox/modules/try.lua:117]: in function 'try'
    [@programdir/modules/async/runjobs.lua:223]: in function 'cotask'
    [@programdir/core/base/scheduler.lua:406]:

[ 16%]: running.test test_13/stub_1
[ 19%]: running.test test_14/stub_2
[ 21%]: running.test test_15/stub_n
[ 23%]: running.test test_2/args
[ 26%]: running.test test_2/default
[ 28%]: running.test test_2/fail_output
[ 30%]: running.test test_2/pass_output
[ 33%]: running.test test_3/args
[ 35%]: running.test test_3/default
[ 38%]: running.test test_3/fail_output
[ 40%]: running.test test_3/pass_output
[ 42%]: running.test test_4/args
[ 45%]: running.test test_4/default
[ 47%]: running.test test_4/fail_output
[ 50%]: running.test test_4/pass_output
[ 52%]: running.test test_5/args
[ 54%]: running.test test_5/default
[ 57%]: running.test test_5/fail_output
[ 59%]: running.test test_5/pass_output
[ 61%]: running.test test_6/args
[ 64%]: running.test test_6/default
[ 66%]: running.test test_6/fail_output
[ 69%]: running.test test_6/pass_output
[ 71%]: running.test test_7/args
[ 73%]: running.test test_7/default
[ 76%]: running.test test_7/fail_output
[ 78%]: running.test test_7/pass_output
[ 80%]: running.test test_8/args
[ 83%]: running.test test_8/default
[ 85%]: running.test test_8/fail_output
[ 88%]: running.test test_8/pass_output
[ 90%]: running.test test_9/args
[ 92%]: running.test test_9/default
[ 95%]: running.test test_9/fail_output
[ 97%]: running.test test_9/pass_output
[100%]: running.test test_timeout/run_timeout

report of tests:
[  2%]: test_10/compile_fail     .................................... passed 0.001s
[  4%]: test_11/compile_pass     .................................... failed 0.001s
errors: build/.gens/test_11/macosx/x86_64/release/tests/test_11/compile_pass.log
[  7%]: test_1/args              .................................... passed 0.032s
stdout: build/.gens/test_1/macosx/x86_64/release/tests/test_1/args.log
[  9%]: test_1/default           .................................... passed 0.030s
stdout: build/.gens/test_1/macosx/x86_64/release/tests/test_1/default.log
[ 11%]: test_1/fail_output       .................................... passed 0.028s
stdout: build/.gens/test_1/macosx/x86_64/release/tests/test_1/fail_output.log
[ 14%]: test_1/pass_output       .................................... passed 0.026s
stdout: build/.gens/test_1/macosx/x86_64/release/tests/test_1/pass_output.log
[ 16%]: test_13/stub_1           .................................... passed 0.022s
stdout: build/.gens/test_13_stub_1/macosx/x86_64/release/tests/test_13/stub_1.log
[ 19%]: test_14/stub_2           .................................... passed 0.019s
stdout: build/.gens/test_14_stub_2/macosx/x86_64/release/tests/test_14/stub_2.log
[ 21%]: test_15/stub_n           .................................... passed 0.018s
stdout: build/.gens/test_15_stub_n/macosx/x86_64/release/tests/test_15/stub_n.log
[ 23%]: test_2/args              .................................... passed 0.015s
stdout: build/.gens/test_2/macosx/x86_64/release/tests/test_2/args.log
[ 26%]: test_2/default           .................................... passed 0.051s
stdout: build/.gens/test_2/macosx/x86_64/release/tests/test_2/default.log
[ 28%]: test_2/fail_output       .................................... passed 0.050s
stdout: build/.gens/test_2/macosx/x86_64/release/tests/test_2/fail_output.log
[ 30%]: test_2/pass_output       .................................... passed 0.041s
stdout: build/.gens/test_2/macosx/x86_64/release/tests/test_2/pass_output.log
[ 33%]: test_3/args              .................................... passed 0.040s
stdout: build/.gens/test_3/macosx/x86_64/release/tests/test_3/args.log
[ 35%]: test_3/default           .................................... passed 0.032s
stdout: build/.gens/test_3/macosx/x86_64/release/tests/test_3/default.log
[ 38%]: test_3/fail_output       .................................... passed 0.023s
stdout: build/.gens/test_3/macosx/x86_64/release/tests/test_3/fail_output.log
[ 40%]: test_3/pass_output       .................................... passed 0.021s
stdout: build/.gens/test_3/macosx/x86_64/release/tests/test_3/pass_output.log
[ 42%]: test_4/args              .................................... passed 0.018s
stdout: build/.gens/test_4/macosx/x86_64/release/tests/test_4/args.log
[ 45%]: test_4/default           .................................... passed 0.044s
stdout: build/.gens/test_4/macosx/x86_64/release/tests/test_4/default.log
[ 47%]: test_4/fail_output       .................................... passed 0.040s
stdout: build/.gens/test_4/macosx/x86_64/release/tests/test_4/fail_output.log
[ 50%]: test_4/pass_output       .................................... passed 0.029s
stdout: build/.gens/test_4/macosx/x86_64/release/tests/test_4/pass_output.log
[ 52%]: test_5/args              .................................... passed 0.027s
stdout: build/.gens/test_5/macosx/x86_64/release/tests/test_5/args.log
[ 54%]: test_5/default           .................................... passed 0.025s
stdout: build/.gens/test_5/macosx/x86_64/release/tests/test_5/default.log
[ 57%]: test_5/fail_output       .................................... failed 0.022s
stdout: build/.gens/test_5/macosx/x86_64/release/tests/test_5/fail_output.log
errors: build/.gens/test_5/macosx/x86_64/release/tests/test_5/fail_output.log
[ 59%]: test_5/pass_output       .................................... failed 0.020s
stdout: build/.gens/test_5/macosx/x86_64/release/tests/test_5/pass_output.log
errors: build/.gens/test_5/macosx/x86_64/release/tests/test_5/pass_output.log
[ 61%]: test_6/args              .................................... passed 0.018s
stdout: build/.gens/test_6/macosx/x86_64/release/tests/test_6/args.log
[ 64%]: test_6/default           .................................... passed 0.042s
stdout: build/.gens/test_6/macosx/x86_64/release/tests/test_6/default.log
[ 66%]: test_6/fail_output       .................................... passed 0.038s
stdout: build/.gens/test_6/macosx/x86_64/release/tests/test_6/fail_output.log
[ 69%]: test_6/pass_output       .................................... passed 0.029s
stdout: build/.gens/test_6/macosx/x86_64/release/tests/test_6/pass_output.log
[ 71%]: test_7/args              .................................... failed 0.027s
stdout: build/.gens/test_7/macosx/x86_64/release/tests/test_7/args.log
errors: build/.gens/test_7/macosx/x86_64/release/tests/test_7/args.log
[ 73%]: test_7/default           .................................... failed 0.024s
stdout: build/.gens/test_7/macosx/x86_64/release/tests/test_7/default.log
errors: build/.gens/test_7/macosx/x86_64/release/tests/test_7/default.log
[ 76%]: test_7/fail_output       .................................... failed 0.022s
stdout: build/.gens/test_7/macosx/x86_64/release/tests/test_7/fail_output.log
errors: build/.gens/test_7/macosx/x86_64/release/tests/test_7/fail_output.log
[ 78%]: test_7/pass_output       .................................... failed 0.019s
stdout: build/.gens/test_7/macosx/x86_64/release/tests/test_7/pass_output.log
errors: build/.gens/test_7/macosx/x86_64/release/tests/test_7/pass_output.log
[ 80%]: test_8/args              .................................... passed 0.016s
stdout: build/.gens/test_8/macosx/x86_64/release/tests/test_8/args.log
[ 83%]: test_8/default           .................................... passed 0.034s
stdout: build/.gens/test_8/macosx/x86_64/release/tests/test_8/default.log
[ 85%]: test_8/fail_output       .................................... passed 0.032s
stdout: build/.gens/test_8/macosx/x86_64/release/tests/test_8/fail_output.log
[ 88%]: test_8/pass_output       .................................... failed 0.024s
stdout: build/.gens/test_8/macosx/x86_64/release/tests/test_8/pass_output.log
errors: build/.gens/test_8/macosx/x86_64/release/tests/test_8/pass_output.log
[ 90%]: test_9/args              .................................... passed 0.020s
stdout: build/.gens/test_9/macosx/x86_64/release/tests/test_9/args.log
[ 92%]: test_9/default           .................................... passed 0.017s
stdout: build/.gens/test_9/macosx/x86_64/release/tests/test_9/default.log
[ 95%]: test_9/fail_output       .................................... passed 0.014s
stdout: build/.gens/test_9/macosx/x86_64/release/tests/test_9/fail_output.log
[ 97%]: test_9/pass_output       .................................... passed 0.012s
stdout: build/.gens/test_9/macosx/x86_64/release/tests/test_9/pass_output.log
[100%]: test_timeout/run_timeout .................................... failed 1.008s
errors: build/.gens/test_timeout/macosx/x86_64/release/tests/test_timeout/run_timeout.log
78% tests passed, 9 tests failed out of 42, spent 1.176s
```