### PR TITLE
fixbug: config 'vs_sdkver' has no effect when generate vs project

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -167,14 +167,16 @@ end
 function _make_targetinfo(mode, arch, target, vcxprojdir)
 
     -- init target info
-    local targetinfo = { mode = mode, arch = vsutils.vsarch(arch) }
+    local targetinfo = { mode = mode, arch = vsutils.vsarch(arch), sdkver=config.get("vs_sdkver") }
 
     -- get sdk version
-    local msvc = toolchain.load("msvc")
-    if msvc then
-        local vcvars = msvc:config("vcvars")
-        if vcvars then
-            targetinfo.sdkver = vcvars.WindowsSDKVersion
+    if targetinfo.sdkver == nil then
+        local msvc = toolchain.load("msvc")
+        if msvc then
+            local vcvars = msvc:config("vcvars")
+            if vcvars then
+                targetinfo.sdkver = vcvars.WindowsSDKVersion
+            end
         end
     end
 


### PR DESCRIPTION
config vs_sdkver

```sh
xmake f --vs_sdkver=14.0
```

but it has no effect when generate a vs project

```sh
xmake project -k vs2015
```

this pull request fix this bug~