### PR TITLE
fix Qt static compilation issue

### DIFF
--- a/xmake/modules/core/tools/link.lua
+++ b/xmake/modules/core/tools/link.lua
@@ -102,7 +102,7 @@ end
 
 -- make the link flag
 function nf_link(self, lib)
-    if not lib:endswith(".lib") then
+    if not lib:endswith(".lib") and not lib:endswith(".obj") then
         lib = lib .. ".lib"
     end
     return lib


### PR DESCRIPTION
* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

fix append .lib when link .obj file.
fix static qt link macro.
------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

修复：链接obj文件的时候xmake默认加了.lib后缀。
修复：使用静态qt库的时候xmake替换qt宏不完全。
