### PR TITLE
fix vcpkg android armeabi-v7a

### DIFF
--- a/xmake/modules/package/manager/vcpkg/configurations.lua
+++ b/xmake/modules/package/manager/vcpkg/configurations.lua
@@ -25,8 +25,8 @@ function arch(arch)
         i386            = "x86",
 
         -- android: armeabi armeabi-v7a arm64-v8a x86 x86_64 mips mip64
-        -- Offers a doc: https://github.com/microsoft/vcpkg/blob/master/docs/users/android.md
-        ["armeabi-v7a"] = "arm",
+        -- Offers a doc: https://github.com/microsoft/vcpkg/tree/master/triplets
+        ["armeabi-v7a"] = "arm-neon",
         ["arm64-v8a"]   = "arm64",
 
         -- ios: arm64 armv7 armv7s i386


### PR DESCRIPTION
vcpkg should use arm-neon-android instead of arm-android.
https://github.com/microsoft/vcpkg/tree/master/triplets