### PR TITLE
fixbug: for cases when WindowsSDKVersion variable is not available

### DIFF
--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -191,7 +191,7 @@ function _load_vcvarsall(vcvarsall, vsver, arch, opt)
         -- then parse it from `WindowsSdkBinPath`, such as: `C:\\Program Files (x86)\\Windows Kits\\8.1\\bin`
         local WindowsSdkBinPath = variables["WindowsSdkBinPath"]
         if WindowsSdkBinPath then
-            WindowsSDKVersion = string.match(WindowsSdkBinPath, "\\(%d+%.?%d*)\\bin")
+            WindowsSDKVersion = string.match(WindowsSdkBinPath, "\\(%d+%.%d+)\\bin$")
             if WindowsSDKVersion then
                 variables["WindowsSDKVersion"] = WindowsSDKVersion
             end

--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -186,6 +186,16 @@ function _load_vcvarsall(vcvarsall, vsver, arch, opt)
         if WindowsSDKVersion ~= "" then
             variables["WindowsSDKVersion"] = WindowsSDKVersion
         end
+    else
+        -- sometimes the variable `WindowsSDKVersion` is not available
+        -- then parse it from `WindowsSdkBinPath`, such as: `C:\\Program Files (x86)\\Windows Kits\\8.1\\bin`
+        local WindowsSdkBinPath = variables["WindowsSdkBinPath"]
+        if WindowsSdkBinPath then
+            WindowsSDKVersion = string.match(WindowsSdkBinPath, "\\(%d+%.?%d*)\\bin")
+            if WindowsSDKVersion then
+                variables["WindowsSDKVersion"] = WindowsSDKVersion
+            end
+        end
     end
 
     -- fix UCRTVersion


### PR DESCRIPTION
find_vstudio.lua

for some cases, the variable `WindowsSDKVersion` is not available from `vcvarsall.bat`, i parse it from `WindowsSdkBinPath`, such as: `C:\\Program Files (x86)\\Windows Kits\\8.1\\bin`.
