### PR TITLE
fixbug:nsis pack only support ascii path without blank space

### DIFF
--- a/xmake/plugins/pack/nsis/main.lua
+++ b/xmake/plugins/pack/nsis/main.lua
@@ -268,9 +268,7 @@ function _pack_nsis(makensis, package)
     local specvars_values = {}
     io.gsub(specfile, "(" .. pattern .. ")", function(_, name)
         table.insert(specvars_names, name)
-    end,
-        {encoding="ansi"}
-    )
+    end,{encoding="ansi"})
     for _, name in ipairs(specvars_names) do
         name = name:trim()
         if specvars_values[name] == nil then
@@ -290,9 +288,7 @@ function _pack_nsis(makensis, package)
     io.gsub(specfile, "(" .. pattern .. ")", function(_, name)
         name = name:trim()
         return specvars_values[name]
-    end, 
-        {encoding="ansi"}
-    )
+    end, {encoding="ansi"})
 
     -- make package
     os.vrunv(makensis, {specfile})

--- a/xmake/plugins/pack/nsis/main.lua
+++ b/xmake/plugins/pack/nsis/main.lua
@@ -268,7 +268,7 @@ function _pack_nsis(makensis, package)
     local specvars_values = {}
     io.gsub(specfile, "(" .. pattern .. ")", function(_, name)
         table.insert(specvars_names, name)
-    end,{encoding="ansi"})
+    end, {encoding = "ansi"})
     for _, name in ipairs(specvars_names) do
         name = name:trim()
         if specvars_values[name] == nil then
@@ -288,7 +288,7 @@ function _pack_nsis(makensis, package)
     io.gsub(specfile, "(" .. pattern .. ")", function(_, name)
         name = name:trim()
         return specvars_values[name]
-    end, {encoding="ansi"})
+    end, {encoding = "ansi"})
 
     -- make package
     os.vrunv(makensis, {specfile})

--- a/xmake/plugins/pack/nsis/main.lua
+++ b/xmake/plugins/pack/nsis/main.lua
@@ -113,7 +113,7 @@ function _get_command_strings(package, cmd, opt)
             local dstname = path.filename(dstfile)
             local dstdir = path.normalize(path.directory(dstfile))
             table.insert(result, string.format("SetOutPath \"%s\"", dstdir))
-            table.insert(result, string.format("File /oname=%s \"%s\"", dstname, srcfile))
+            table.insert(result, string.format("File \"/oname=%s\" \"%s\"", dstname, srcfile))
         end
     elseif kind == "rm" then
         local filepath = _translate_filepath(package, cmd.filepath)
@@ -268,7 +268,9 @@ function _pack_nsis(makensis, package)
     local specvars_values = {}
     io.gsub(specfile, "(" .. pattern .. ")", function(_, name)
         table.insert(specvars_names, name)
-    end)
+    end,
+        {encoding="ansi"}
+    )
     for _, name in ipairs(specvars_names) do
         name = name:trim()
         if specvars_values[name] == nil then
@@ -288,7 +290,9 @@ function _pack_nsis(makensis, package)
     io.gsub(specfile, "(" .. pattern .. ")", function(_, name)
         name = name:trim()
         return specvars_values[name]
-    end)
+    end, 
+        {encoding="ansi"}
+    )
 
     -- make package
     os.vrunv(makensis, {specfile})


### PR DESCRIPTION
when using xpack with nsis format, it will not work if there is path with chinese character or blank space.

for the first problem, i fix it by using ansi encoding. Since nsis is not supported in linux-like os, we do not need to consider conditions for linux?

And the second problem is fixed according to the grammar tips given by nsis.