### PR TITLE
variable `WindowsSDKVersion` and the issues it causes

### DIFF
--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -179,27 +179,6 @@ function _load_vcvarsall(vcvarsall, vsver, arch, opt)
         end
     end
 
-    -- fix WindowsSDKVersion
-    local WindowsSDKVersion = variables["WindowsSDKVersion"]
-    if WindowsSDKVersion then
-        WindowsSDKVersion = WindowsSDKVersion:gsub("\\", ""):trim()
-        if WindowsSDKVersion ~= "" then
-            variables["WindowsSDKVersion"] = WindowsSDKVersion
-        end
-    end
-
-    WindowsSDKVersion = variables["WindowsSDKVersion"]
-    if not WindowsSDKVersion or WindowsSDKVersion == "" then
-        -- sometimes the variable `WindowsSDKVersion` is not available
-        -- then parse it from `WindowsSdkBinPath`, such as: `C:\\Program Files (x86)\\Windows Kits\\8.1\\bin`
-        local WindowsSdkBinPath = variables["WindowsSdkBinPath"]
-        if WindowsSdkBinPath then
-            WindowsSDKVersion = string.match(WindowsSdkBinPath, "\\(%d+%.%d+)\\bin$")
-            if WindowsSDKVersion then
-                variables["WindowsSDKVersion"] = WindowsSDKVersion
-            end
-        end
-    end
 
     -- fix UCRTVersion
     --
@@ -219,6 +198,28 @@ function _load_vcvarsall(vcvarsall, vsver, arch, opt)
         end
         UCRTVersion = WindowsSDKVersion
         variables["UCRTVersion"] = UCRTVersion
+    end
+
+    -- fix WindowsSDKVersion
+    local WindowsSDKVersion = variables["WindowsSDKVersion"]
+    if WindowsSDKVersion then
+        WindowsSDKVersion = WindowsSDKVersion:gsub("\\", ""):trim()
+        if WindowsSDKVersion ~= "" then
+            variables["WindowsSDKVersion"] = WindowsSDKVersion
+        end
+    end
+
+    WindowsSDKVersion = variables["WindowsSDKVersion"]
+    if not WindowsSDKVersion or WindowsSDKVersion == "" then
+        -- sometimes the variable `WindowsSDKVersion` is not available
+        -- then parse it from `WindowsSdkDir`, such as: `C:\\Program Files (x86)\\Windows Kits\\8.1\\`
+        local WindowsSdkDir = variables["WindowsSdkDir"]
+        if WindowsSdkDir then
+            WindowsSDKVersion = string.match(WindowsSdkDir, "\\(%d+%.%d+)\\$")
+            if WindowsSDKVersion then
+                variables["WindowsSDKVersion"] = WindowsSDKVersion
+            end
+        end
     end
 
     -- convert path/lib/include to PATH/LIB/INCLUDE

--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -186,7 +186,10 @@ function _load_vcvarsall(vcvarsall, vsver, arch, opt)
         if WindowsSDKVersion ~= "" then
             variables["WindowsSDKVersion"] = WindowsSDKVersion
         end
-    else
+    end
+
+    WindowsSDKVersion = variables["WindowsSDKVersion"]
+    if not WindowsSDKVersion or WindowsSDKVersion == "" then
         -- sometimes the variable `WindowsSDKVersion` is not available
         -- then parse it from `WindowsSdkBinPath`, such as: `C:\\Program Files (x86)\\Windows Kits\\8.1\\bin`
         local WindowsSdkBinPath = variables["WindowsSdkBinPath"]

--- a/xmake/modules/detect/tools/find_rc.lua
+++ b/xmake/modules/detect/tools/find_rc.lua
@@ -58,7 +58,7 @@ function main(opt)
     -- e.g. C:\Program Files (x86)\Windows Kits\10\bin\10.0.17134.0\x64
     --
     local envs = opt.envs
-    if envs and envs.WindowsSdkDir and envs.WindowsSDKVersion then
+    if envs and envs.WindowsSdkDir and envs.WindowsSDKVersion and type(envs.WindowsSDKVersion) == "string" then
         local toolchain = opt.toolchain
         local arch = toolchain and toolchain:arch() or config.arch()
         local bindir = path.join(envs.WindowsSdkDir, "bin", envs.WindowsSDKVersion, arch)


### PR DESCRIPTION
1. 在find_vstudio中有的时候调用`vcvarsall.bat`，得到的环境变量`WindowsSDKVersion`不存在或者为空
这会影响生成的vs工程的配置，例如
```
xmake f --vs_sdkver=8.1
xmake project -k vs2015
```
所以需要修复`WindowsSDKVersion`的检测函数

我们可以从`WindowsSdkDir`变量中提取`WindowsSDKVersion`，这是我的第一个更改。


2. 安装vs2015后，会存在window sdk8.1与windows sdk10共存的影响。可能是vs2015需要windows sdk 10中的UCRT环境？具体原因我不清楚，但是我的个人电脑和工作电脑都是这样，分别为win11和win10。

在更改1的基础上，这种情况会导致在提取`WindowsSDKVersion`后，后续的fix UCRTVersion代码执行不正确。它会将windows sdk10的lib环境更改为windows sdk8中的路径，这会导致c++在链接时找不到ucrt.lib。

所以我将fix UCRTVersion代码移到了fix WindowsSDKVersion前面。这是我的第二个更改。


3. 当`WindowsSDKVersion`为空时，会引起find_rc内部的envs.WindowsSDKVersion为一个空table
这导致xmake运行报错

具体引发envs.WindowsSDKVersion为一个空table的原因我定位不到，所以我简单判断了一下变量类型以保证xmake运行不报错。这是我的第三个更改。



---------


Sometimes when calling 'vcvarsall. bat', the environment variable 'Windows SDK Version' obtained does not exist or is empty
This will affect the configuration of the generated VS project, for example
```
xmake f --vs_sdkver=8.1
xmake project -k vs2015
```
So it is necessary to fix the detection function of 'Windows SDK Version'

We can extract 'Windows SDK Version' from the 'Windows SDK' variable, which is my first change.


After installing VS2015, there will be an impact of coexistence between Windows SDK 8.1 and Windows SDK 10. Could it be that VS2015 requires the UCRT environment in Windows SDK 10? I'm not sure about the specific reason, but my personal computer and work computer are both like this, with Win11 and Win10 respectively.

On the basis of changing 1, this situation will result in incorrect execution of the subsequent fix UCRTVersion code after extracting 'Windows SDK Version'. It will change the lib environment of Windows SDK 10 to the path in Windows SDK 8, which will cause C++to not find ucrt.lib when linking.

So I moved the fix UCRTVersion code before fix Windows SDK Version. This is my second change.


When 'Windows SDK Version' is empty, it will cause envs inside find_rc Windows SDK Version is an empty table
This causes xmake to run with errors

I cannot locate the reason why Windows SDK Version is an empty table, so I simply checked the variable type to ensure that xmake runs without errors. This is my third change.