### PR TITLE
Don't treat x86_64 as cross on arm64 macOS

### DIFF
--- a/xmake/core/base/private/is_cross.lua
+++ b/xmake/core/base/private/is_cross.lua
@@ -25,9 +25,10 @@ local os = require("base/os")
 function is_cross(plat, arch)
     plat = plat or os.subhost()
     arch = arch or os.subarch()
-    if os.host() == "windows" then
-        local host_arch = os.arch()
+    local host_os = os.host()
+    if host_os == "windows" then
         if plat == "windows" then
+            local host_arch = os.arch()
             -- maybe cross-compilation for arm64 on x86/x64
             if (host_arch == "x86" or host_arch == "x64") and arch == "arm64" then
                 return true
@@ -39,6 +40,14 @@ function is_cross(plat, arch)
         elseif plat == "mingw" then
             return false
         end
+    elseif host_os == "macosx" then
+        if plat == "macosx" then
+            local host_arch = os.arch()
+            -- arm64 macOS can execute x86_64 (rosetta)
+            if host_arch == "arm64" and arch == "x86_64" then
+                return false
+            end
+        end
     end
     if plat ~= os.host() and plat ~= os.subhost() then
         return true
@@ -46,6 +55,7 @@ function is_cross(plat, arch)
     if arch ~= os.arch() and arch ~= os.subarch() then
         return true
     end
+    return false
 end
 
 return is_cross


### PR DESCRIPTION
arm64 macOS can execute x86_64 binaries

edit: though Rosetta 2 is not perfect