### PR TITLE
add clang toolchain version 19 & 20

### DIFF
--- a/xmake/toolchains/clang-19/xmake.lua
+++ b/xmake/toolchains/clang-19/xmake.lua
@@ -1,0 +1,3 @@
+includes(path.join(os.scriptdir(), "../clang/xmake.lua"))
+
+toolchain_clang("19")

--- a/xmake/toolchains/clang-20/xmake.lua
+++ b/xmake/toolchains/clang-20/xmake.lua
@@ -1,0 +1,3 @@
+includes(path.join(os.scriptdir(), "../clang/xmake.lua"))
+
+toolchain_clang("20")


### PR DESCRIPTION
> Packages are available for amd64, i386 (Debian only), s390x and arm64 (aka aarch64). This for both the stable, qualification and development branches (currently 18, **19** and **20**).