### PR TITLE
fix(plugin/project): Generate compile_commands for tests

### DIFF
--- a/xmake/actions/test/main.lua
+++ b/xmake/actions/test/main.lua
@@ -445,7 +445,7 @@ function main()
     task.run("config", {}, {disable_dump = true})
 
     -- get tests
-    local tests = get_tests_table()
+    local tests = get_tests()
     local test_patterns = option.get("tests")
     if test_patterns then
         local tests_new = {}

--- a/xmake/actions/test/main.lua
+++ b/xmake/actions/test/main.lua
@@ -366,8 +366,8 @@ function _try_build_target(targetname)
     return passed, errors
 end
 
--- get tests table, export this for the `project` plugin
-function get_tests_table()
+-- get tests, export this for the `project` plugin
+function get_tests()
     local tests = {}
     local group_pattern = option.get("group")
     if group_pattern then

--- a/xmake/actions/test/main.lua
+++ b/xmake/actions/test/main.lua
@@ -366,20 +366,8 @@ function _try_build_target(targetname)
     return passed, errors
 end
 
-function main()
-
-    -- do action for remote?
-    if remote_build_action.enabled() then
-        return remote_build_action()
-    end
-
-    -- lock the whole project
-    project.lock()
-
-    -- load config first
-    task.run("config", {}, {disable_dump = true})
-
-    -- get tests
+-- get tests table, export this for the `project` plugin
+function get_tests_table()
     local tests = {}
     local group_pattern = option.get("group")
     if group_pattern then
@@ -440,6 +428,24 @@ function main()
             end
         end
     end
+    return tests
+end
+
+function main()
+
+    -- do action for remote?
+    if remote_build_action.enabled() then
+        return remote_build_action()
+    end
+
+    -- lock the whole project
+    project.lock()
+
+    -- load config first
+    task.run("config", {}, {disable_dump = true})
+
+    -- get tests
+    local tests = get_tests_table()
     local test_patterns = option.get("tests")
     if test_patterns then
         local tests_new = {}
@@ -488,4 +494,3 @@ function main()
     -- unlock the whole project
     project.unlock()
 end
-

--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -28,6 +28,7 @@ import("private.utils.batchcmds")
 import("private.utils.executable_path")
 import("private.utils.rule_groups")
 import("plugins.project.utils.target_cmds", {rootdir = os.programdir()})
+import("actions.test.main", {rootdir = os.programdir(), alias = "test_action"})
 
 -- escape path
 function _escape_path(p)
@@ -288,7 +289,15 @@ end
 function _add_targets(jsonfile)
     jsonfile:print("[")
     _g.firstline = true
+
     for _, target in pairs(project.targets()) do
+        if not target:is_phony() then
+            _add_target(jsonfile, target)
+        end
+    end
+    -- https://github.com/xmake-io/xmake/issues/4750
+    for _, test in pairs(test_action.get_tests_table()) do
+        local target = test.target
         if not target:is_phony() then
             _add_target(jsonfile, target)
         end

--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -296,7 +296,7 @@ function _add_targets(jsonfile)
         end
     end
     -- https://github.com/xmake-io/xmake/issues/4750
-    for _, test in pairs(test_action.get_tests_table()) do
+    for _, test in pairs(test_action.get_tests()) do
         local target = test.target
         if not target:is_phony() then
             _add_target(jsonfile, target)


### PR DESCRIPTION
1. Implement the get_tests_table as a function
2. Generate compile_commands for tests, see https://github.com/xmake-io/xmake/issues/4750

