### PR TITLE
fix(cmake): Set correct c++ compiler and detect ninja for MinGW

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -1142,6 +1142,15 @@ function _get_cmake_generator(package, opt)
         if not cmake_generator then
             if package:has_tool("cc", "clang_cl") or package:has_tool("cxx", "clang_cl") then
                 cmake_generator = "Ninja"
+            elseif is_subhost("windows") and package:is_plat("mingw") then
+                -- When we are using a standalone clang/gcc toolchain without mingw, try to detect ninja automatically.
+                -- see:https://github.com/xmake-io/xmake/issues/5518
+                local mingw = package:build_getenv("mingw") or package:build_getenv("sdk") or ""
+                mingw = find_tool(mingw, {paths = mingw})
+                if not mingw then
+                    assert(find_tool("ninja"), "No mingw or ninja found!")
+                    cmake_generator = "Ninja"
+                end
             end
         end
         local cmake_generator_env = os.getenv("CMAKE_GENERATOR")

--- a/xmake/toolchains/clang/xmake.lua
+++ b/xmake/toolchains/clang/xmake.lua
@@ -30,8 +30,10 @@ toolchain("clang" .. suffix)
     set_description("A C language family frontend for LLVM" .. (version and (" (" .. version .. ")") or ""))
     set_runtimes("c++_static", "c++_shared", "stdc++_static", "stdc++_shared")
 
+    -- set clang++ first, then package:build_getenv("cxx") is always clang++ instead of clang
+    -- see:https://github.com/xmake-io/xmake/issues/5518
     set_toolset("cc", "clang" .. suffix)
-    set_toolset("cxx", "clang" .. suffix, "clang++" .. suffix)
+    set_toolset("cxx", "clang++" .. suffix, "clang" .. suffix)
     set_toolset("ld", "clang++" .. suffix, "clang" .. suffix)
     set_toolset("sh", "clang++" .. suffix, "clang" .. suffix)
     set_toolset("ar", "ar", "llvm-ar")
@@ -39,7 +41,7 @@ toolchain("clang" .. suffix)
     set_toolset("ranlib", "ranlib", "llvm-ranlib")
     set_toolset("objcopy", "objcopy", "llvm-objcopy")
     set_toolset("mm", "clang" .. suffix)
-    set_toolset("mxx", "clang" .. suffix, "clang++" .. suffix)
+    set_toolset("mxx", "clang++" .. suffix, "clang" .. suffix)
     set_toolset("as", "clang" .. suffix)
     set_toolset("mrc", "llvm-rc")
 

--- a/xmake/toolchains/gcc/xmake.lua
+++ b/xmake/toolchains/gcc/xmake.lua
@@ -30,8 +30,10 @@ toolchain("gcc" .. suffix)
     set_description("GNU Compiler Collection" .. (version and (" (" .. version .. ")") or ""))
     set_runtimes("stdc++_static", "stdc++_shared")
 
+    -- set g++ first, then package:build_getenv("cxx") is always g++ instead of gcc
+    -- see:https://github.com/xmake-io/xmake/issues/5518
     set_toolset("cc", "gcc" .. suffix)
-    set_toolset("cxx", "gcc" .. suffix, "g++" .. suffix)
+    set_toolset("cxx", "g++" .. suffix, "gcc" .. suffix)
     set_toolset("ld", "g++" .. suffix, "gcc" .. suffix)
     set_toolset("sh", "g++" .. suffix, "gcc" .. suffix)
     set_toolset("ar", "ar")
@@ -39,7 +41,7 @@ toolchain("gcc" .. suffix)
     set_toolset("objcopy", "objcopy")
     set_toolset("ranlib", "ranlib")
     set_toolset("mm", "gcc" .. suffix)
-    set_toolset("mxx", "gcc" .. suffix, "g++" .. suffix)
+    set_toolset("mxx", "g++" .. suffix, "gcc" .. suffix)
     set_toolset("as", "gcc" .. suffix)
 
     on_check(function (toolchain)


### PR DESCRIPTION
1. Set clang++ and g++ first since we use the first c++ compiler in the toolchain to build the package
2. Try to detect ninja when use a toolchain without mingw
3. see https://github.com/xmake-io/xmake/issues/5518
