### PR TITLE
add client parameter to rule `utils.glsl2spv`

### DIFF
--- a/xmake/rules/utils/glsl2spv/xmake.lua
+++ b/xmake/rules/utils/glsl2spv/xmake.lua
@@ -58,12 +58,13 @@ rule("utils.glsl2spv")
 
         -- glsl to spv
         local targetenv = target:extraconf("rules", "utils.glsl2spv", "targetenv") or "vulkan1.0"
+        local client = target:extraconf("rules", "utils.glsl2spv", "client") or "vulkan100"
         local outputdir = target:extraconf("rules", "utils.glsl2spv", "outputdir") or path.join(target:autogendir(), "rules", "utils", "glsl2spv")
         local spvfilepath = path.join(outputdir, path.filename(sourcefile_glsl) .. ".spv")
         batchcmds:show_progress(opt.progress, "${color.build.object}generating.glsl2spv %s", sourcefile_glsl)
         batchcmds:mkdir(outputdir)
         if glslangValidator then
-            batchcmds:vrunv(glslangValidator.program, {"--target-env", targetenv, "-o", path(spvfilepath), path(sourcefile_glsl)})
+            batchcmds:vrunv(glslangValidator.program, {"--target-env", targetenv, "--client", client, "-o", path(spvfilepath), path(sourcefile_glsl)})
         else
             batchcmds:vrunv(glslc.program, {"--target-env", targetenv, "-o", path(spvfilepath), path(sourcefile_glsl)})
         end


### PR DESCRIPTION
My project uses xmake to compile OpenGL GLSL, but by default, xmake validates GLSL using Vulkan semantics. This parameter has been added to allow developers to avoid validation errors caused by differences in source semantics.