### PR TITLE
feat(rules/iverilog): Improve the iverilog build rules

### DIFF
--- a/xmake/rules/iverilog/xmake.lua
+++ b/xmake/rules/iverilog/xmake.lua
@@ -32,7 +32,6 @@ rule("iverilog.binary")
     end)
 
     on_linkcmd(function (target, batchcmds, opt)
-        import("core.project.project")
         local toolchain = assert(target:toolchain("iverilog"), 'we need set_toolchains("iverilog") in target("%s")', target:name())
         local iverilog = assert(toolchain:config("iverilog"), "iverilog not found!")
 

--- a/xmake/rules/iverilog/xmake.lua
+++ b/xmake/rules/iverilog/xmake.lua
@@ -20,7 +20,6 @@
 
 -- @see https://github.com/xmake-io/xmake/issues/3257
 rule("iverilog.binary")
-    -- support SystemVerilog
     set_extensions(".v", ".sv", ".vhd")
     on_load(function (target)
         target:set("kind", "binary")
@@ -82,7 +81,7 @@ rule("iverilog.binary")
         end
 
         -- get defines
-        for _, define in ipairs(target:get_from("defines", "*") or {}) do
+        for _, define in ipairs((target:get_from("defines", "*"))) do
             table.insert(argv, "-D" .. define)
         end
 
@@ -113,7 +112,5 @@ rule("iverilog.binary")
     on_run(function (target)
         local toolchain = assert(target:toolchain("iverilog"), 'we need set_toolchains("iverilog") in target("%s")', target:name())
         local vvp = assert(toolchain:config("vvp"), "vvp not found!")
-
-        -- some oscilloscopes do not support lxt2
         os.execv(vvp, {"-n", target:targetfile()})
     end)

--- a/xmake/rules/iverilog/xmake.lua
+++ b/xmake/rules/iverilog/xmake.lua
@@ -82,16 +82,8 @@ rule("iverilog.binary")
         end
 
         -- get defines
-        local add_defines = function(defines)
-            for _, define in ipairs(defines or {}) do
-                table.insert(argv, "-D" .. define)
-            end
-        end
-        add_defines(target:get("defines"))
-        -- support add_defines in options
-        for _, option_name in ipairs(target:get("options") or {}) do
-            local option = project.option(option_name)
-            add_defines(option:enabled() and option:get("defines"))
+        for _, define in ipairs(target:get_from("defines", "*") or {}) do
+            table.insert(argv, "-D" .. define)
         end
 
         -- get includedirs


### PR DESCRIPTION
1. Add System Verilog support
2. Support add_defines by add_options
3. Use vcd format instead of lxt2 to support WaveTrace plugin
