### PR TITLE
Make target:filerule able to match package rules

### DIFF
--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -1699,7 +1699,7 @@ function _instance:filerules(sourcefile)
         if filerules then
             override = filerules.override
             for _, rulename in ipairs(table.wrap(filerules)) do
-                local r = target._project().rule(rulename) or rule.rule(rulename)
+                local r = target._project().rule(rulename) or rule.rule(rulename) or self:rule(rulename)
                 if r then
                     table.insert(rules, r)
                 end


### PR DESCRIPTION
When trying to add files with a specific package rule within a package rule:
```lua
rule("foo")
    on_config(function (target)
        target:add("files", "bar", { rule = "@package/baz" })
    end)
```

the rule wasn't found by target:filerule(file), causing an `unknown source file` error.

This can be easily fixed by using the `target:rule(file)` method, I think we could replace the whole line with it but I put it as a fallback at the end to not break anything.