### PR TITLE
Add riscv64 support for Android NDK projects

### DIFF
--- a/xmake/modules/detect/sdks/find_ndk.lua
+++ b/xmake/modules/detect/sdks/find_ndk.lua
@@ -34,6 +34,7 @@ function _get_triple(arch)
     ,   ["armeabi"]     = "arm-linux-androideabi"   -- removed in ndk r17
     ,   ["armeabi-v7a"] = "arm-linux-androideabi"
     ,   ["arm64-v8a"]   = "aarch64-linux-android"
+    ,   ["riscv64"]     = "riscv64-linux-android"
     ,   i386            = "i686-linux-android"      -- deprecated
     ,   x86             = "i686-linux-android"
     ,   x86_64          = "x86_64-linux-android"
@@ -90,8 +91,8 @@ function _find_ndk_sdkver(sdkdir, bindir, sysroot, arch)
 
     -- try to select the best compatible version
     local sdkver = "16"
-    if use_llvm or arch == "arm64-v8a" then
-        sdkver = "21"
+    if use_llvm or arch == "arm64-v8a" or arch == "riscv64" then
+        sdkver = (arch == "riscv64") and "35" or "21"
     end
     if sysroot then
         if os.isdir(path.join(sysroot, "usr", "lib", triple, sdkver)) then
@@ -170,6 +171,7 @@ function _find_ndk(sdkdir, arch, ndk_sdkver, ndk_toolchains_ver)
     ,   ["armeabi"]     = "arm-linux-androideabi-" -- removed in ndk r17
     ,   ["armeabi-v7a"] = "arm-linux-androideabi-"
     ,   ["arm64-v8a"]   = "aarch64-linux-android-"
+    ,   ["riscv64"]     = "riscv64-linux-android-"
     ,   i386            = "i686-linux-android-"    -- deprecated
     ,   x86             = "i686-linux-android-"
     ,   x86_64          = "x86_64-linux-android-"
@@ -186,6 +188,7 @@ function _find_ndk(sdkdir, arch, ndk_sdkver, ndk_toolchains_ver)
     ,   ["armeabi"]     = "arm-linux-androideabi-*"
     ,   ["armeabi-v7a"] = "arm-linux-androideabi-*"
     ,   ["arm64-v8a"]   = "aarch64-linux-android-*"
+    ,   ["riscv64"]     = "riscv64-linux-android-*"
     ,   i386            = "x86-*"
     ,   x86             = "x86-*"
     ,   x86_64          = "x86_64-*"

--- a/xmake/platforms/android/xmake.lua
+++ b/xmake/platforms/android/xmake.lua
@@ -29,7 +29,7 @@ platform("android")
     -- @see https://developer.android.google.cn/ndk/guides/abis
     -- @note The NDK previously supported ARMv5 (armeabi) and 32-bit and 64-bit MIPS, but this support has been removed in NDK r17.
     --
-    set_archs("armeabi", "armeabi-v7a", "arm64-v8a", "x86", "x86_64", "mips", "mip64")
+    set_archs("armeabi", "armeabi-v7a", "arm64-v8a", "riscv64", "x86", "x86_64", "mips", "mip64")
 
     set_formats("static", "lib$(name).a")
     set_formats("object", "$(name).o")

--- a/xmake/toolchains/ndk/load.lua
+++ b/xmake/toolchains/ndk/load.lua
@@ -31,6 +31,7 @@ function _get_triple(arch)
     ,   ["armeabi"]     = "arm-linux-androideabi"   -- removed in ndk r17
     ,   ["armeabi-v7a"] = "arm-linux-androideabi"
     ,   ["arm64-v8a"]   = "aarch64-linux-android"
+    ,   ["riscv64"]     = "riscv64-linux-android"
     ,   i386            = "i686-linux-android"      -- deprecated
     ,   x86             = "i686-linux-android"
     ,   x86_64          = "x86_64-linux-android"
@@ -49,6 +50,7 @@ function _get_target(arch, ndk_sdkver)
     ,   ["armv7-a"]     = "armv7-none-linux-androideabi"    -- deprecated
     ,   ["armeabi-v7a"] = "armv7-none-linux-androideabi"
     ,   ["arm64-v8a"]   = "aarch64-none-linux-android"
+    ,   ["riscv64"]     = "riscv64-none-linux-android"
     ,   ["i386"]        = "i686-none-linux-android"         -- deprecated
     ,   ["x86"]         = "i686-none-linux-android"
     ,   ["x86_64"]      = "x86_64-none-linux-android"
@@ -162,6 +164,7 @@ function main(toolchain)
         ,   ["armeabi"]     = "arch-arm"    -- removed in ndk r17
         ,   ["armeabi-v7a"] = "arch-arm"
         ,   ["arm64-v8a"]   = "arch-arm64"
+        ,   ["riscv64"]     = "arch-riscv64"
         ,   i386            = "arch-x86"    -- deprecated
         ,   x86             = "arch-x86"
         ,   x86_64          = "arch-x86_64"
@@ -264,6 +267,7 @@ function main(toolchain)
                 ,   ["armeabi"]     = "armeabi"         -- removed in ndk r17
                 ,   ["armeabi-v7a"] = "armeabi-v7a"
                 ,   ["arm64-v8a"]   = "arm64-v8a"
+                ,   ["riscv64"]     = "riscv64"
                 ,   i386            = "x86"             -- deprecated
                 ,   x86             = "x86"
                 ,   x86_64          = "x86_64"


### PR DESCRIPTION
https://opensource.googleblog.com/2023/10/android-and-risc-v-what-you-need-to-know.html

RISC-V64 is here to stay, NDK can build RISC-V64 applications, so it'd be appropriate for it to be included in Xmake.

You need [Android NDK r27c+](https://github.com/google/android-riscv64/commit/304c0c5ba6a2552fe17f6460ab27aaf4fabfe1aa) to build RISC-V64 projects.

```kt
// app/build.gradle.kts
android {
    ndkVersion = "27.2.12479018"
}
```

![image](https://github.com/user-attachments/assets/8b88887e-7121-4a6d-8d14-e9c0dd946409)
