### PR TITLE
fix Xlinker rpath linker flags deduplication

### DIFF
--- a/xmake/core/tool/builder.lua
+++ b/xmake/core/tool/builder.lua
@@ -708,7 +708,9 @@ function builder:_preprocess_flags(flags)
             local flagkey = type(flag) == "table" and table.concat(flag, "") or flag
             if flag and not unique[flagkey] then
                 table.insert(flags_new, flag)
-                unique[flagkey] = true
+                if flagkey:startswith("-l") or flagkey:startswith("-L") or flagkey:startswith("/l") or flagkey:startswith("/L") then
+                    unique[flagkey] = true
+                end
             end
         end
         flags = flags_new


### PR DESCRIPTION
got this errors when trying to compile glm package on macOS with modules enabled and homebrew llvm

```
/usr/local/opt/llvm/bin/clang++ -o /var/folders/1p/6pvxmm0j5gl7xybkqpv74f8h0000gn/T/.xmake501/241101/_888C4D64A9F04E2084417958EBCDF730.b /var/folders/1p/6pvxmm0j5gl7xybkqpv74f8h0000gn/T/.xmake501/241101/_888C4D64A9F04E2084417958EBCDF730.o -m64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk -stdlib=libc++ -L/usr/local/opt/llvm/lib -rpath -Xlinker /usr/local/opt/llvm/lib -L/Users/arthapz/.xmake/packages/g/glm/1.0.1/9ea4f932f2f3409fa948476625677342/lib -lglm
ld: warning: -rpath missing <path>
ld: warning: -rpath missing <path>
ld: file cannot be mmap()ed, errno=22 path=/usr/local/opt/llvm/lib in '/usr/local/opt/llvm/lib'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
> checking for c++ links(glm)
> checking for c++ snippet(test)
```