### PR TITLE
fix error when generating cmake

### DIFF
--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -441,7 +441,7 @@ function _add_target_dependencies(cmakelists, target)
     local deps = {}
     for _, dep in ipairs(target:orderdeps()) do
         if not dep:is_object() then
-            deps:insert(dep:name())
+            table.insert(deps, dep:name())
         end
     end
 


### PR DESCRIPTION
fixed error when generating cmake (xmake project -k cmake) for a target that has a dependency (via add_deps) on another target.

error: method 'insert' is not callable (a nil value)

called insert as a method on a table instead of table.insert