### PR TITLE
fix: reset locked repo before pulling

### DIFF
--- a/xmake/modules/private/action/require/impl/repository.lua
+++ b/xmake/modules/private/action/require/impl/repository.lua
@@ -84,6 +84,7 @@ function _get_packagedir_from_locked_repo(packagename, locked_repo)
                 if network ~= "private" then
                     -- pull the latest commit
                     local remoteurl = proxy.mirror(locked_repo.url) or locked_repo.url
+                    git.reset({verbose = option.get("verbose"), repodir = repodir_local, hard = true})
                     git.pull({verbose = option.get("verbose"), remote = remoteurl, branch = locked_repo.branch, repodir = repodir_local, force = true})
                     -- re-checkout to the given commit
                     ok = try {function () git.checkout(locked_repo.commit, {verbose = option.get("verbose"), repodir = repodir_local}); return true end}


### PR DESCRIPTION
- same as this [commit](959106bc784e0a8c218c331970afc25bed52e9c6) but for locked repos
- works around an issue where a locked repo has all it's contents deleted besides the .git folder (not sure why) and trying to pull will fail unless those local changes are cleared first. This pr does not address the potential underlying issue directly.

