### PR TITLE
feat(msys2): add `xmake.cmd` and `xmake.ps1` for better integration with Windows cmd and powershell

### DIFF
--- a/core/src/cli/xmake.sh
+++ b/core/src/cli/xmake.sh
@@ -70,6 +70,8 @@ xmake_after_install() {
     if test_eq "${project_generator}" "gmake"; then
         print "\t@if test -f ${installdir}/bin/xmake.exe; then rm ${installdir}/bin/xmake.exe; fi" >> "${xmake_sh_makefile}"
         print "\t@cp ${projectdir}/scripts/msys/xmake.sh ${installdir}/bin/xmake" >> "${xmake_sh_makefile}"
+        print "\t@cp ${projectdir}/scripts/msys/xmake.cmd ${installdir}/bin/xmake.cmd" >> "${xmake_sh_makefile}"
+        print "\t@cp ${projectdir}/scripts/msys/xmake.ps1 ${installdir}/bin/xmake.ps1" >> "${xmake_sh_makefile}"
         print "\t@cp ${buildir}/xmake.exe ${installdir}/share/xmake" >> "${xmake_sh_makefile}"
     fi
 }

--- a/scripts/msys/xmake.cmd
+++ b/scripts/msys/xmake.cmd
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+set BASEDIR=%~dp0
+if exist "%BASEDIR%..\share\xmake\xmake.exe" (
+    "%BASEDIR%..\share\xmake\xmake.exe" %*
+)
+endlocal

--- a/scripts/msys/xmake.ps1
+++ b/scripts/msys/xmake.ps1
@@ -1,0 +1,4 @@
+$BASEDIR = Split-Path -Parent $MyInvocation.MyCommand.Definition
+if (Test-Path "$BASEDIR\..\share\xmake\xmake.exe") {
+    & "$BASEDIR\..\share\xmake\xmake.exe" @args
+}


### PR DESCRIPTION
ref: https://github.com/msys2/MINGW-packages/issues/22537

Add `.ps1` and `.cmd` files to be able to call xmake directly in Windows PowerShell and cmd for better integration.