### PR TITLE
Add support for libstdc++ standard library modules

### DIFF
--- a/xmake/rules/c++/modules/modules_support/gcc/compiler_support.lua
+++ b/xmake/rules/c++/modules/modules_support/gcc/compiler_support.lua
@@ -137,7 +137,6 @@ end
 
 function _get_std_module_manifest_path(target)
     local compinst = target:compiler("cxx")
-
     local modules_json_path, _ = try {
         function()
             return os.iorunv(compinst:program(), {"-print-file-name=libstdc++.modules.json"}, {envs = compinst:runenvs()})
@@ -154,8 +153,7 @@ function _get_std_module_manifest_path(target)
     -- fallback on custom detection
     -- manifest can be found alongside libstdc++.so
 
-    -- @TODO
-
+    -- TODO
 end
 
 function get_stdmodules(target)
@@ -193,7 +191,7 @@ function get_modulesflag(target)
         local compinst = target:compiler("cxx")
         local gcc_version = get_gcc_version(target)
         -- GCC 12 and earlier version has a option '-fmodules' for Modula-2
-        if semver.compare(gcc_version, "12") > 0 then
+        if gcc_version and semver.compare(gcc_version, "12") > 0 then
             if compinst:has_flags("-fmodules", "cxxflags", {flagskey = "gcc_modules"}) then
                 modulesflag = "-fmodules"
             elseif compinst:has_flags("-fmodules-ts", "cxxflags", {flagskey = "gcc_modules_ts"}) then


### PR DESCRIPTION
An installed source form of module std and std.compat has been merged into gcc trunk branch. It's time to add support for them.
[ \[Bug 106852\]\(c++lib-std-module\) - Implement C++23 P2465R3 Standard Library Modules std and std.compat](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106852)

GCC provides a `libstdc++.modules.json` file alongside `libstdc++.so`, which tells the build system where the files are. We can also find this file with :
```shell
gcc -print-file-name=libstdc++.modules.json
```

Content in the json may looks like this:
```json
{
  "version": 1,
  "revision": 1,
  "modules": [
    {
      "logical-name": "std",
      "source-path": "../include/c++/15/bits/std.cc",
      "is-std-library": true
    },
    {
      "logical-name": "std.compat",
      "source-path": "../include/c++/15/bits/std.compat.cc",
      "is-std-library": true
    }
  ]
}
```

The structure of this json file is basicly the same as the one provided by llvm.

## Known issue

Currently, these two files cannot compile with `-D_GLIBCXX_USE_CXX11_ABI=0` option, so I set ths macro to `1` if a target is compile with std modules. This issue may related to #2716 and #3855 .
