### PR TITLE
fix cmake & mingw detect cross-compilation on windows

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -581,6 +581,7 @@ function _get_configs_for_mingw(package, configs, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     envs.CMAKE_MODULE_LINKER_FLAGS = _get_shflags(package, opt)
     -- @see https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html
+    -- https://github.com/xmake-io/xmake/pull/5888
     if not is_host("windows") then
         envs.CMAKE_SYSTEM_NAME = "Windows"
     end

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -580,7 +580,10 @@ function _get_configs_for_mingw(package, configs, opt)
     envs.CMAKE_EXE_LINKER_FLAGS    = _get_ldflags(package, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     envs.CMAKE_MODULE_LINKER_FLAGS = _get_shflags(package, opt)
-    envs.CMAKE_SYSTEM_NAME         = is_host("windows") and "" or "Windows"
+    -- @see https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html
+    if not is_host("windows") then
+        envs.CMAKE_SYSTEM_NAME = "Windows"
+    end
     envs.CMAKE_SYSTEM_PROCESSOR    = _get_cmake_system_processor(package)
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037
@@ -948,6 +951,13 @@ function _get_configs(package, configs, opt)
         end
     end
     _insert_configs_from_envs(configs, envs or {}, opt)
+
+    local ccache = package:data("ccache")
+    if ccache then
+        table.insert(configs, "-DCMAKE_C_COMPILER_LAUNCHER=" .. ccache)
+        table.insert(configs, "-DCMAKE_CXX_COMPILER_LAUNCHER=" .. ccache)
+    end
+
     return configs
 end
 

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -580,7 +580,7 @@ function _get_configs_for_mingw(package, configs, opt)
     envs.CMAKE_EXE_LINKER_FLAGS    = _get_ldflags(package, opt)
     envs.CMAKE_SHARED_LINKER_FLAGS = _get_shflags(package, opt)
     envs.CMAKE_MODULE_LINKER_FLAGS = _get_shflags(package, opt)
-    envs.CMAKE_SYSTEM_NAME         = "Windows"
+    envs.CMAKE_SYSTEM_NAME         = is_host("windows") and "" or "Windows"
     envs.CMAKE_SYSTEM_PROCESSOR    = _get_cmake_system_processor(package)
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037


### PR DESCRIPTION
```console
CMake Error: try_run() invoked in cross-compiling mode, please set the following cache variables appropriately:
   APSI_FOURQ_AMD64_EXITCODE (advanced)
For details see C:/Users/star/AppData/Local/.xmake/cache/packages/2411/m/microsoft-apsi/v0.12.0/source/microsoft-apsi/build_9e48a5a1/TryRunResults.cmake
-- FourQlib optimization: arch=AMD64
CMake Error: try_run() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_AVX_EXTENSIONS_EXITCODE (advanced)
For details see C:/Users/star/AppData/Local/.xmake/cache/packages/2411/m/microsoft-apsi/v0.12.0/source/microsoft-apsi/build_9e48a5a1/TryRunResults.cmake
CMake Error: try_run() invoked in cross-compiling mode, please set the following cache variables appropriately:
   HAVE_AVX2_EXTENSIONS_EXITCODE (advanced)
For details see C:/Users/star/AppData/Local/.xmake/cache/packages/2411/m/microsoft-apsi/v0.12.0/source/microsoft-apsi/build_9e48a5a1/TryRunResults.cmake
```