### PR TITLE
Fix clang module parallel compile error.

### DIFF
--- a/xmake/rules/c++/modules/modules_support/clang/builder.lua
+++ b/xmake/rules/c++/modules/modules_support/clang/builder.lua
@@ -31,23 +31,21 @@ import("compiler_support")
 import(".builder", {inherit = true})
 
 function _compile_one_step(target, bmifile, sourcefile, objectfile, opt)
+    local module_outputflag = compiler_support.get_moduleoutputflag(target)
     if opt.is_mapped_bmi then
         -- get flags
-        local module_fileflag = compiler_support.get_modulefileflag(target)
-        if module_fileflag then
-            local flags = table.join({module_fileflag .. opt.name .. "=" .. bmifile}, opt.std and {"-Wno-include-angled-in-module-purview", "-Wno-reserved-module-identifier"} or {})
+        if module_outputflag then
+            local flags = table.join(opt.std and {"-Wno-include-angled-in-module-purview", "-Wno-reserved-module-identifier"} or {})
             if opt and opt.batchcmds then
                 _batchcmds_compile(opt.batchcmds, target, flags, bmifile, objectfile)
             else
                 _compile(target, flags, bmifile, objectfile)
             end
         else
-            _compile_bmi_step(target, bmifile, sourcefile, opt)
             _compile_objectfile_step(target, bmifile, sourcefile, objectfile, opt)
         end
     else
         -- get flags
-        local module_outputflag = compiler_support.get_moduleoutputflag(target)
         if module_outputflag then
             local flags = table.join({"-x", "c++-module", module_outputflag .. bmifile}, opt.std and {"-Wno-include-angled-in-module-purview", "-Wno-reserved-module-identifier"} or {})
             if opt and opt.batchcmds then
@@ -270,7 +268,7 @@ function make_module_buildjobs(target, batchjobs, job_name, deps, opt)
                         end
                     else
                         progress.show(jobopt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:name(), name or opt.cppfile)
-                        _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, {name = name, std = (name == "std" or name == "std.compat"), is_mapped_bmi = is_mapped_bmi})
+                        _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, {std = (name == "std" or name == "std.compat"), is_mapped_bmi = is_mapped_bmi})
                     end
                 else
                     os.tryrm(opt.objectfile) -- force rebuild for .cpp files
@@ -312,7 +310,7 @@ function make_module_buildcmds(target, batchcmds, opt)
             end
         else
             batchcmds:show_progress(opt.progress, "${color.build.target}<%s> ${clear}${color.build.object}compiling.module.$(mode) %s", target:name(), name or opt.cppfile)
-            _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, {name = name, std = (name == "std" or name == "std.compat"), batchcmds = batchcmds, is_mapped_bmi = is_mapped_bmi})
+            _compile_one_step(target, bmifile, opt.cppfile, opt.objectfile, {std = (name == "std" or name == "std.compat"), batchcmds = batchcmds, is_mapped_bmi = is_mapped_bmi})
         end
     else
         batchcmds:rm(opt.objectfile) -- force rebuild for .cpp files


### PR DESCRIPTION
Fix clang module parallel compile error due to .pcm confliction.

https://github.com/xmake-io/xmake/issues/5856
