### PR TITLE
Add Werror and dry-run flags for clang-format

### DIFF
--- a/xmake/plugins/format/main.lua
+++ b/xmake/plugins/format/main.lua
@@ -148,8 +148,23 @@ function main()
         table.insert(argv, "--style=" .. option.get("style"))
     end
 
-    -- inplace flag
-    table.insert(argv, "-i")
+    if option.get("dry-run") then
+        -- do not make any changes, just show the files that would be formatted
+        table.insert(argv, "--dry-run")
+    else
+        -- inplace flag
+        table.insert(argv, "-i")
+    end
+
+    -- changes formatting warnings to errors
+    if option.get("error") then
+        table.insert(argv, "--Werror")
+    end
+
+    -- print verbose information
+    if option.get("verbose") then
+        table.insert(argv, "--verbose")
+    end
 
     local targetname
     local group_pattern = option.get("group")

--- a/xmake/plugins/format/xmake.lua
+++ b/xmake/plugins/format/xmake.lua
@@ -25,24 +25,27 @@ task("format")
                 usage = "xmake format [options] [arguments]",
                 description = "Format the current project.",
                 options = {
-                    {'s', "style",  "kv", nil,  "Set the path of .clang-format file, a coding style",
-                                                values = {"LLVM", "Google", "Chromium", "Mozilla", "WebKit"}},
-                    {nil, "create", "k", nil,   "Create a .clang-format file from a coding style"},
-                    {'a', "all",    "k", nil,   "Format all targets."},
-                    {'g', "group",  "kv", nil,  "Format all targets of the given group. It support path pattern matching.",
-                                                "e.g.", 
-                                                "    xmake format -g test",
-                                                "    xmake format -g test_*",
-                                                "    xmake format --group=benchmark/*"},
-                    {'f', "files",  "kv", nil,   "Build the given source files.",
-                                                "e.g.",
-                                                "    - xmake format --files=src/main.c",
-                                                "    - xmake format --files='src/*.c' [target]",
-                                                "    - xmake format --files='src/**.c|excluded_file.c",
-                                                "    - xmake format --files='src/main.c" .. path.envsep() .. "src/test.c'" },
-                                                {},
-                    {nil, "target", "v",  nil, "The target name. It will format all default targets if this parameter is not specified."
-                                                    , values = function (complete, opt) return import("private.utils.complete_helper.targets")(complete, opt) end }
+                    {'s', "style",   "kv",  nil,  "Set the path of .clang-format file, a coding style",
+                                                  values = {"LLVM", "Google", "Chromium", "Mozilla", "WebKit"}},
+                    {nil, "create",  "k",  nil,   "Create a .clang-format file from a coding style"},
+                    {'n', "dry-run", "k",  nil,   "Do not make any changes, just show the files that would be formatted."},
+                    {'e', "error",   "k",  nil,   "If set, changes formatting warnings to errors."},
+                    {'v', "verbose", "k",  nil,   "Print verbose information."},
+                    {'a', "all",     "k",  nil,   "Format all targets."},
+                    {'g', "group",   "kv", nil,   "Format all targets of the given group. It support path pattern matching.",
+                                                  "e.g.",
+                                                  "    xmake format -g test",
+                                                  "    xmake format -g test_*",
+                                                  "    xmake format --group=benchmark/*"},
+                    {'f', "files",   "kv", nil,   "Build the given source files.",
+                                                  "e.g.",
+                                                  "    - xmake format --files=src/main.c",
+                                                  "    - xmake format --files='src/*.c' [target]",
+                                                  "    - xmake format --files='src/**.c|excluded_file.c",
+                                                  "    - xmake format --files='src/main.c" .. path.envsep() .. "src/test.c'" },
+                                                  {},
+                    {nil, "target",  "v",  nil,   "The target name. It will format all default targets if this parameter is not specified."
+                                                       , values = function (complete, opt) return import("private.utils.complete_helper.targets")(complete, opt) end }
                 }
             }
 

--- a/xmake/plugins/format/xmake.lua
+++ b/xmake/plugins/format/xmake.lua
@@ -30,7 +30,6 @@ task("format")
                     {nil, "create",  "k",  nil,   "Create a .clang-format file from a coding style"},
                     {'n', "dry-run", "k",  nil,   "Do not make any changes, just show the files that would be formatted."},
                     {'e', "error",   "k",  nil,   "If set, changes formatting warnings to errors."},
-                    {'v', "verbose", "k",  nil,   "Print verbose information."},
                     {'a', "all",     "k",  nil,   "Format all targets."},
                     {'g', "group",   "kv", nil,   "Format all targets of the given group. It support path pattern matching.",
                                                   "e.g.",


### PR DESCRIPTION
Support additional optional flags for clang-format:
```
--Werror                       - If set, changes formatting warnings to errors
--dry-run                      - If set, do not actually make the formatting changes
-n                             - Alias for --dry-run
--verbose                      - If set, shows the list of processed files
```