### PR TITLE
Obtain MinGW's path from LLVM_MINGW_DIR/ROOT

### DIFF
--- a/xmake/modules/detect/sdks/find_mingw.lua
+++ b/xmake/modules/detect/sdks/find_mingw.lua
@@ -41,8 +41,8 @@ function _find_mingwdir(sdkdir)
             sdkdir = "/opt/homebrew/opt/mingw-w64"
         elseif is_host("linux") then
             sdkdir = "/usr"
-        elseif is_subhost("msys") then
-            local mingw_prefix = os.getenv("MINGW_PREFIX")
+        else
+            local mingw_prefix = is_subhost("msys") and os.getenv("MINGW_PREFIX") or os.getenv("LLVM_MINGW_DIR") or os.getenv("LLVM_MINGW_ROOT")
             if mingw_prefix and os.isdir(mingw_prefix) then
                 sdkdir = mingw_prefix
             end


### PR DESCRIPTION
If either of LLVM_MINGW_DIR or LLVM_MINGW_ROOT are present as environment variables, MinGW's path will be filled automatically by them.

https://grep.app/search?q=%24ENV%7BLLVM_MINGW_DIR%7D

https://grep.app/search?q=%24ENV%7BLLVM_MINGW_ROOT%7D
