### PR TITLE
Fix meson package build

### DIFF
--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -69,7 +69,7 @@ function _translate_flags(package, flags)
     if package:is_plat("android") then
         local flags_new = {}
         for _, flag in ipairs(flags) do
-            if flag:startswith("-gcc-toolchain ") or flag:startswith("-target ") or flag:startswith("-isystem ") then
+            if flag:startswith("-gcc-toolchain ") or flag:startswith("--target=") or flag:startswith("-isystem ") then
                 table.join2(flags_new, flag:split(" ", {limit = 2}))
             else
                 table.insert(flags_new, flag)
@@ -173,8 +173,8 @@ function _insert_cross_configs(package, file, opt)
         file:print("endian = 'little'")
     elseif package:is_plat("wasm") then
         file:print("system = 'emscripten'")
-        file:print("cpu_family = 'wasm32'")
-        file:print("cpu = 'wasm32'")
+        file:print("cpu_family = '%s'", package:arch())
+        file:print("cpu = '%s'", package:arch())
         file:print("endian = 'little'")
     else
         local cpu = package:arch()

--- a/xmake/toolchains/ndk/load.lua
+++ b/xmake/toolchains/ndk/load.lua
@@ -123,10 +123,10 @@ function main(toolchain)
 
         -- add ndk target
         local ndk_target = _get_target(arch, ndk_sdkver)
-        toolchain:add("cxflags", "-target " .. ndk_target)
-        toolchain:add("asflags", "-target " .. ndk_target)
-        toolchain:add("ldflags", "-target " .. ndk_target)
-        toolchain:add("shflags", "-target " .. ndk_target)
+        toolchain:add("cxflags", "--target=" .. ndk_target)
+        toolchain:add("asflags", "--target=" .. ndk_target)
+        toolchain:add("ldflags", "--target=" .. ndk_target)
+        toolchain:add("shflags", "--target=" .. ndk_target)
 
         -- add gcc toolchain
         local gcc_toolchain = toolchain:config("gcc_toolchain")


### PR DESCRIPTION
- Fix wasm arch.
https://mesonbuild.com/Reference-tables.html
- Fix android target

```console
meson.build:1:0: ERROR: Unable to detect linker for compiler `D:\a\xmake-repo\xmake-repo\ndk\android-ndk-r27\toolchains\llvm\prebuilt\windows-x86_64\bin\clang.exe -Wl,--version -llog "-target aarch64-none-linux-android30" -fPIE -pie -static-libstdc++ -lc++abi -llog "-target aarch64-none-linux-android30" -static-libstdc++ -lc++abi`
stdout: 
stderr: clang: error: unknown argument: '-target aarch64-none-linux-android30'
clang: error: unknown argument: '-target aarch64-none-linux-android30'
```