### PR TITLE
Fix /sourceDependencies <path> not on one line when using msvc-wine

### DIFF
--- a/xmake/core/base/winos.lua
+++ b/xmake/core/base/winos.lua
@@ -192,7 +192,7 @@ function winos.cmdargv(argv, opt)
                 -- if host is not Windows, paths may start with '/', which conflicts with '/<argname>'
                 -- note that checking if the next argument ends with '.json' will only work for /sourceDependencies
                 -- other arguments will remain broken, perhaps we should discuss a better solution
-                if idx + 1 <= #argv and arg:find("^[-/]") and (os.is_host("windows") and (not arg1:find("^[-/]")) or (arg1:find("%.json$"))) then
+                if idx + 1 <= #argv and arg:find("^[-/]") and (os.is_host("windows") and (not arg1:find("^[-/]")) or (arg1:endswith(".json"))) then
                     f:write(os.args(arg, {escape = opt.escape}) .. " ")
                     f:write(os.args(arg1, {escape = opt.escape}) .. "\n")
                     idx = idx + 2

--- a/xmake/core/base/winos.lua
+++ b/xmake/core/base/winos.lua
@@ -188,7 +188,11 @@ function winos.cmdargv(argv, opt)
                 -- -Dxxx
                 -- foo.obj
                 --
-                if idx + 1 <= #argv and arg:find("^[-/]") and not arg1:find("^[-/]") then
+
+                -- if host is not Windows, paths may start with '/', which conflicts with '/<argname>'
+                -- note that checking if the next argument ends with '.json' will only work for /sourceDependencies
+                -- other arguments will remain broken, perhaps we should discuss a better solution
+                if idx + 1 <= #argv and arg:find("^[-/]") and (os.is_host("windows") and (not arg1:find("^[-/]")) or (arg1:find("%.json$"))) then
                     f:write(os.args(arg, {escape = opt.escape}) .. " ")
                     f:write(os.args(arg1, {escape = opt.escape}) .. "\n")
                     idx = idx + 2


### PR DESCRIPTION
When using a cross-compiler like [msvc-wine](https://github.com/mstorsjo/msvc-wine), the logic for detecting whether the next argument is actually a value (for example: `"/sourceDependencies /unix/path"`) wasn't good enough when cross-compiling for Windows on a host that uses paths that can start with `/`.

This PR attempts to fix this, but the fix is not the best because it only takes into account arguments that take a json file like `/sourceDependencies`, not any other arguments that use the same `/name value` format.
Feel free to suggest a better way to fix this.