### PR TITLE
add rule lua-native-object

### DIFF
--- a/xmake/rules/lua/native-object/xmake.lua
+++ b/xmake/rules/lua/native-object/xmake.lua
@@ -1,0 +1,51 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      Wu, Zhenyu
+-- @file        xmake.lua
+--
+
+-- usage:
+--
+-- target("foo")
+-- do
+--     add_rules("luarocks.module", "lua-native-object", "c")
+--     add_files("*.nobj.lua")
+-- end
+rule("lua.native-object")
+    set_extensions(".nobj.lua")
+    before_buildcmd_file(function(target, batchcmds, sourcefile, opt)
+        -- get c source file for lua-native-object
+        local dirname = path.join(target:autogendir(), "rules", "lua-native-object")
+        local sourcefile_c = path.join(dirname, path.basename(sourcefile) .. ".c")
+
+        -- add objectfile
+        local objectfile = target:objectfile(sourcefile_c)
+        table.insert(target:objectfiles(), objectfile)
+
+        -- add commands
+        batchcmds:show_progress(opt.progress, "${color.build.object}compiling.nobj.lua %s", sourcefile)
+        batchcmds:mkdir(path.directory(sourcefile_c))
+        batchcmds:vrunv("native_objects.lua",
+            { "-outpath", path(dirname), "-gen", "lua", path(sourcefile) })
+        -- remember to add_rules("c") if you need
+        batchcmds:compile(sourcefile_c, objectfile)
+
+        -- add deps
+        batchcmds:add_depfiles(sourcefile)
+        batchcmds:set_depmtime(os.mtime(objectfile))
+        batchcmds:set_depcache(target:dependfile(objectfile))
+    end)


### PR DESCRIPTION
[native_objects.lua](https://github.com/Neopallium/LuaNativeObjects) is a tool
to translate lua to C and LuaJIT FFI lua code.

Usage:

```lua
target("foo")
do
    add_rules("luarocks.module", "lua-native-object", "c")
    add_files("*.nobj.lua")
end
```

Related: #5941

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

