### PR TITLE
Fix incorrect Zig-CC toolchain wrapper path on Windows

### DIFF
--- a/xmake/toolchains/zig/xmake.lua
+++ b/xmake/toolchains/zig/xmake.lua
@@ -29,11 +29,12 @@ toolchain("zig")
 
         -- @see https://github.com/xmake-io/xmake/issues/5610
         function _setup_zigcc_wrapper(zig)
+            local script_suffix = is_host("windows") and ".cmd" or ""
             for _, tool in ipairs({"cc", "c++", "ar", "ranlib", "objcopy"}) do
-                local wrapper_path = path.join(os.tmpdir(), "zigcc", tool)
+                local wrapper_path = path.join(os.tmpdir(), "zigcc", tool) .. script_suffix
                 if not os.isfile(wrapper_path) then
                     if is_host("windows") then
-                        io.writefile(wrapper_path .. ".cmd", ("@echo off\n\"%s\" %s %%*"):format(zig, tool))
+                        io.writefile(wrapper_path, ("@echo off\n\"%s\" %s %%*"):format(zig, tool))
                     else
                         io.writefile(wrapper_path, ("#!/bin/bash\nexec \"%s\" %s \"$@\""):format(zig, tool))
                         os.runv("chmod", {"+x", wrapper_path})


### PR DESCRIPTION
Fixed an issue where Zig-CC wrapper paths on Windows were incorrectly configured. For instance, the wrapper was written to `wrapper_path .. ".cmd"` (e.g., `cc.cmd`), but `toolset_cc` was set to `wrapper_path` (e.g., `cc`), causing path mismatches.

![图片](https://github.com/user-attachments/assets/f2b0c3bb-3107-4dd5-a975-76dd9f765f44)
