### PR TITLE
[fix] error path escape for windows + android ndk  --sysroot= c: path…

### DIFF
--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -104,7 +104,10 @@ end
 -- escape path in flag
 -- @see https://github.com/xmake-io/xmake/issues/3161
 function _escape_path_in_flag(target, flag)
-    if is_host("windows") and target:has_tool("cc", "cl") then
+    
+    if is_host("windows") and (target:has_tool("cc", "cl") 
+        or  target:is_plat("android") -- e.g. -isystem\ c:/path/to/ndk/28.0.12674087/
+        ) then
         -- e.g. /ManifestInput:xx, /def:xxx
         if flag:find(":", 1, true) then
             flag = _escape_path(flag)

--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -104,12 +104,9 @@ end
 -- escape path in flag
 -- @see https://github.com/xmake-io/xmake/issues/3161
 function _escape_path_in_flag(target, flag)
-    
-    if is_host("windows") and (target:has_tool("cc", "cl") 
-        or  target:is_plat("android") -- e.g. -isystem\ c:/path/to/ndk/28.0.12674087/
-        ) then
-        -- e.g. /ManifestInput:xx, /def:xxx
-        if flag:find(":", 1, true) then
+    if is_host("windows") then
+        -- e.g. /ManifestInput:..\..\, /def:xxx, -isystem c:\xxx, -Ic:\..
+        if flag:find("\\", 1, true) then
             flag = _escape_path(flag)
         end
     end


### PR DESCRIPTION
When generate CMakeLists.txt for android NDK in Windows with command like:
```
# config with android
xmake f -vyc -k shared -p android -a arm64-v8a --runtimes=c++_shared
# generate CMakeLists.txt
xmake project -k cmake -a arm64-v8a -m debug
```

The CMakeLists.txt will have some errors like this:
```
...

target_compile_options(test PRIVATE
    $<$<COMPILE_LANGUAGE:CXX>:-- 
  sysroot=c:\Users\me\AppData\Local\Android\Sdk\ndk\28.0.12674087\toolchains\llvm\prebuilt\windows-x86_64\sysroot>
    $<$<COMPILE_LANGUAGE:C>:-isystem\ c:\Users\me\AppData\Local\Android\Sdk\ndk\28.0.12674087\toolchains\llvm\prebuilt\windows-x86_64\sysroot\usr\include\arm-linux-androideabi>
...
```

After fixed, it will be OK as expected:
```
...
target_compile_options(test PRIVATE
    $<$<COMPILE_LANGUAGE:CXX>:--sysroot=c:/Users/me/AppData/Local/Android/Sdk/ndk/28.0.12674087/toolchains/llvm/prebuilt/windows-x86_64/sysroot>
    $<$<COMPILE_LANGUAGE:CXX>:-isystem\ c:/Users/me/AppData/Local/Android/Sdk/ndk/28.0.12674087/toolchains/llvm/prebuilt/windows-x86_64/sysroot/usr/include/arm-linux-androideabi>
)
```
