### PR TITLE
Add ARM target support for Windows in clang-cl toolchain

### DIFF
--- a/xmake/toolchains/clang-cl/load.lua
+++ b/xmake/toolchains/clang-cl/load.lua
@@ -75,16 +75,27 @@ function main(toolchain)
         end
     end
 
-    local march
+    local target
     if toolchain:is_arch("x86_64", "x64") then
+        target = "x86_64-pc"
         march = "-m64"
-    elseif toolchain:is_arch("i386", "x86") then
+    elseif toolchain:is_arch("i386", "x86", "i686") then
+        target = "i686-pc"
         march = "-m32"
+    elseif toolchain:is_arch("arm64", "aarch64") then
+        target = "aarch64"
+    elseif toolchain:is_arch("arm64ec") then
+        target = "arm64ec"
+    elseif toolchain:is_arch("arm") then
+        target = "armv7"
     end
-    if march then
-        toolchain:add("cxflags", march)
-        toolchain:add("mxflags", march)
-        toolchain:add("asflags", march)
+
+    target = target .. "-windows-msvc"
+
+    if target then
+        toolchain:add("cxflags", "--target=" .. target)
+        toolchain:add("mxflags", "--target=" .. target)
+        toolchain:add("asflags", "--target=" .. target)
     end
 end
 

--- a/xmake/toolchains/clang-cl/load.lua
+++ b/xmake/toolchains/clang-cl/load.lua
@@ -78,10 +78,8 @@ function main(toolchain)
     local target
     if toolchain:is_arch("x86_64", "x64") then
         target = "x86_64-pc"
-        march = "-m64"
     elseif toolchain:is_arch("i386", "x86", "i686") then
         target = "i686-pc"
-        march = "-m32"
     elseif toolchain:is_arch("arm64", "aarch64") then
         target = "aarch64"
     elseif toolchain:is_arch("arm64ec") then
@@ -91,7 +89,6 @@ function main(toolchain)
     end
 
     target = target .. "-windows-msvc"
-
     if target then
         toolchain:add("cxflags", "--target=" .. target)
         toolchain:add("mxflags", "--target=" .. target)


### PR DESCRIPTION
As discussed in #5980 - I added support for building ARM, ARM64, and ARM64EC for Clang Cl toolchain.

With VS 2022 and LLVM installed on a Windows host, previously, only x86/x64 worked.

- `xmake f -c -p windows -a x86 -m debug --toolchain=clang-cl && xmake -rvD`
- `xmake f -c -p windows -a x64 -m debug --toolchain=clang-cl && xmake -rvD`

These ones used to fail, but they're fixed by this PR:
- `xmake f -c -p windows -a arm -m debug --toolchain=clang-cl && xmake -rvD`
- `xmake f -c -p windows -a arm64 -m debug --toolchain=clang-cl && xmake -rvD`
- `xmake f -c -p windows -a arm64ec -m debug --toolchain=clang-cl && xmake -rvD`