### PR TITLE
zig cc: fix wrapper in Git Bash

### DIFF
--- a/xmake/core/sandbox/modules/import/lib/detect/find_program.lua
+++ b/xmake/core/sandbox/modules/import/lib/detect/find_program.lua
@@ -83,7 +83,10 @@ function sandbox_lib_detect_find_program._check(program, opt)
     elseif os.subhost() == "msys" and os.isfile(program) and os.filesize(program) < 256 then
         -- only a sh script on msys2? e.g. c:/msys64/usr/bin/7z
         -- we need to use sh to wrap it, otherwise os.exec cannot run it
-        program = "sh " .. program
+        local program_lower = program:lower()
+        if not program_lower:endswith(".exe") and not program_lower:endswith(".cmd") and not program_lower:endswith(".bat") then
+            program = "sh " .. program
+        end
         findname = program
     end
     if sandbox_lib_detect_find_program._do_check(findname, opt) then

--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -60,7 +60,11 @@ end
 function _translate_windows_bin_path(bin_path)
     if bin_path then
         local argv = os.argv(bin_path)
-        argv[1] = path.unix(argv[1]) .. ".exe"
+        argv[1] = path.unix(argv[1])
+        local path_lower = argv[1]:lower()
+        if not path_lower:endswith(".exe") and not path_lower:endswith(".cmd") and not path_lower:endswith(".bat") then
+            argv[1] = argv[1] .. ".exe"
+        end
         return os.args(argv)
     end
 end

--- a/xmake/modules/package/tools/make.lua
+++ b/xmake/modules/package/tools/make.lua
@@ -27,7 +27,12 @@ import("private.utils.toolchain", {alias = "toolchain_utils"})
 -- translate bin path
 function _translate_bin_path(bin_path)
     if is_host("windows") and bin_path then
-        return bin_path:gsub("\\", "/") .. ".exe"
+        bin_path = bin_path:gsub("\\", "/")
+        local bin_path_lower = bin_path:lower()
+        if not bin_path_lower:endswith(".exe") and not bin_path_lower:endswith(".cmd") and not bin_path_lower:endswith(".bat") then
+            bin_path = bin_path .. ".exe"
+        end
+        return bin_path
     end
     return bin_path
 end

--- a/xmake/toolchains/zig/xmake.lua
+++ b/xmake/toolchains/zig/xmake.lua
@@ -34,7 +34,7 @@ toolchain("zig")
                 local wrapper_path = path.join(os.tmpdir(), "zigcc", tool) .. script_suffix
                 if not os.isfile(wrapper_path) then
                     if is_host("windows") then
-                        io.writefile(wrapper_path, ("@echo off\n\"%s\" %s %%*"):format(zig, tool))
+                        io.writefile(wrapper_path, ("@echo off || true\n" .. [["%s" %s %%* || exec "zig" c++ "$@"]]):format(zig, tool))
                     else
                         io.writefile(wrapper_path, ("#!/bin/bash\nexec \"%s\" %s \"$@\""):format(zig, tool))
                         os.runv("chmod", {"+x", wrapper_path})


### PR DESCRIPTION
When installing a Makefile-based package in `Git Bash` with the `zig cc` toolchain, the following error occurs:
```
checking for C:\Users\leemu\AppData\Local\Temp\.xmake\241228\zigcc\cc.cmd ... no
checking for the c compiler (cc) ... cc.cmd
checkinfo: C:\Users\leemu\AppData\Local\Temp\.xmake\241228\zigcc\cc.cmd: line 1: @echo: command not found
lld-link: error: could not open '%*': Invalid argument
```
```
C:/Users/leemu/AppData/Local/Temp/.xmake/241228/zigcc/cc.cmd.exe  -I. -Iinclude -m64 -target x86_64-windows-gnu -DL_ENDIAN -DOPENSSL_PIC -DOPENSSL_CPUID_OBJ -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DKECCAK1600_ASM -DRC4_ASM -DMD5_ASM -DAESNI_ASM -DVPAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DX25519_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/C/Users/leemu/AppData/Local/.xmake/packages/o/openssl/1.1.1-w/75058b3fb10245d58e33ad13eb444a0f\"" -DENGINESDIR="\"/C/Users/leemu/AppData/Local/.xmake/packages/o/openssl/1.1.1-w/75058b3fb10245d58e33ad13eb444a0f/lib/engines-1_1\"" -DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN -D_MT -DNDEBUG   -c -o apps/apps.o apps/apps.c
C:/Users/leemu/AppData/Local/Temp/.xmake/2/usr/bin/sh: line 1: C:/Users/leemu/AppData/Local/Temp/.xmake/241228/zigcc/cc.cmd.exe: No such file or directory
```