### PR TITLE
zig cc: fix wrapper not working properly in Git Bash

### DIFF
--- a/xmake/core/sandbox/modules/import/lib/detect/find_program.lua
+++ b/xmake/core/sandbox/modules/import/lib/detect/find_program.lua
@@ -83,7 +83,10 @@ function sandbox_lib_detect_find_program._check(program, opt)
     elseif os.subhost() == "msys" and os.isfile(program) and os.filesize(program) < 256 then
         -- only a sh script on msys2? e.g. c:/msys64/usr/bin/7z
         -- we need to use sh to wrap it, otherwise os.exec cannot run it
-        program = "sh " .. program
+        local program_lower = program:lower()
+        if not program_lower:endswith(".exe") and not program_lower:endswith(".cmd") and not program_lower:endswith(".bat") then
+            program = "sh " .. program
+        end
         findname = program
     end
     if sandbox_lib_detect_find_program._do_check(findname, opt) then

--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -60,7 +60,11 @@ end
 function _translate_windows_bin_path(bin_path)
     if bin_path then
         local argv = os.argv(bin_path)
-        argv[1] = path.unix(argv[1]) .. ".exe"
+        argv[1] = path.unix(argv[1])
+        local path_lower = argv[1]:lower()
+        if not path_lower:endswith(".exe") and not path_lower:endswith(".cmd") and not path_lower:endswith(".bat") then
+            argv[1] = argv[1] .. ".exe"
+        end
         return os.args(argv)
     end
 end

--- a/xmake/modules/package/tools/make.lua
+++ b/xmake/modules/package/tools/make.lua
@@ -27,7 +27,12 @@ import("private.utils.toolchain", {alias = "toolchain_utils"})
 -- translate bin path
 function _translate_bin_path(bin_path)
     if is_host("windows") and bin_path then
-        return bin_path:gsub("\\", "/") .. ".exe"
+        bin_path = bin_path:gsub("\\", "/")
+        local bin_path_lower = bin_path:lower()
+        if not bin_path_lower:endswith(".exe") and not bin_path_lower:endswith(".cmd") and not bin_path_lower:endswith(".bat") then
+            bin_path = bin_path .. ".exe"
+        end
+        return bin_path
     end
     return bin_path
 end


### PR DESCRIPTION
The `zig cc` toolchain encounters issues when installing packages via `xrepo` in `Git Bash`:
1. Attempting to run cmd scripts as sh scripts.
2. Incorrectly appending the `.exe` extension to cmd scripts.