### PR TITLE
[feature] [project] [cmake]  Forward compatibility way, can specify file name v…

### DIFF
--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -19,6 +19,7 @@
 --
 
 -- imports
+import("core.base.option")
 import("core.base.colors")
 import("core.project.project")
 import("core.project.config")
@@ -1337,8 +1338,10 @@ function make(outputdir)
     -- enter project directory
     local oldir = os.cd(os.projectdir())
 
+    -- determine the filename
+    local filename = option.get("outputfile") or "CMakeLists.txt"
     -- open the cmakelists
-    local cmakelists = io.open(path.join(outputdir, "CMakeLists.txt"), "w")
+    local cmakelists = io.open(path.join(outputdir, filename), "w")
 
     -- generate cmakelists
     _generate_cmakelists(cmakelists, outputdir)

--- a/xmake/plugins/project/xmake.lua
+++ b/xmake/plugins/project/xmake.lua
@@ -66,6 +66,7 @@ task("project")
                                                         ,   "    - xmake project -k compile_commands --lsp=clangd"
                                                         ,   values = {"clangd", "cpptools", "ccls"}}
                 ,   {nil, "outputdir", "v"  , "."       ,   "Set the output directory."                                                     }
+                ,   {nil, "outputfile", "v"  , nil       ,  "Set the output file (cmake only) ."                                                     }
                 }
             }
 


### PR DESCRIPTION

I'm trying to use Android Studio to debug native code using CMake bridge via xmake.  The command `xmake project -k cmake` will overwrite CMakeLists.txt.  

After adding this feature, I can use xmake to specify a filename like CMakeLists_arm64-v8a.txt, and then, in the CMakeLists.txt, to include CMakeLists_arm64-v8a.txt.

By this way, I can use AS to debug native code step by step. All code managed by xmake.lua.

I think this feature is usable for others.
