### PR TITLE
Fix cross compile with autotools on windows platform

### DIFF
--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -425,10 +425,12 @@ function buildenvs(package, opt)
             name = name:gsub("gcc%-", "g++-")
             envs.CXX = dir and path.join(dir, name) or name
         end
-    elseif package:is_plat("windows") and not package:config("toolchains") then
+    end
+    if package:is_plat("windows") and not package:config("toolchains") then
         envs.PATH = os.getenv("PATH") -- we need to reserve PATH on msys2
         envs = os.joinenvs(envs, _get_msvc(package):runenvs())
     end
+
     if is_host("windows") then
         envs.CC       = _translate_windows_bin_path(envs.CC)
         envs.AS       = _translate_windows_bin_path(envs.AS)


### PR DESCRIPTION
https://github.com/xmake-io/xmake-repo/pull/6104 windows-arm64
```console
error: D:\a\xmake-repo\xmake-repo\packages\f\ffmpeg\xmake.lua:221: attempt to concatenate a nil value (field 'PATH')
stack traceback:
    [D:\a\xmake-repo\xmake-repo\packages\f\ffmpeg\xmake.lua:221]: in function 'script'
    [...dir\modules\private\action\require\impl\utils\filter.lua:114]: in function 'call'
    [...\modules\private\action\require\impl\actions\install.lua:452]:

  => install ffmpeg 7.0 .. failed
```