### PR TITLE
xmake update: clone with shallow submodules, too

### DIFF
--- a/xmake/actions/update/main.lua
+++ b/xmake/actions/update/main.lua
@@ -484,7 +484,7 @@ function main()
                             http.download(url, installerfile)
                         end
                     else
-                        git.clone(url, {depth = 1, recurse_submodules = not script_only, branch = version, outputdir = sourcedir})
+                        git.clone(url, {depth = 1, shallow_submodules = true, recurse_submodules = not script_only, branch = version, outputdir = sourcedir})
                     end
                     return true
                 end,


### PR DESCRIPTION
This signficantly cuts down on the amount of data uselessly fetched: without, the resulting .git is at present around 69 MB, while with, it's under 10 MB.