### PR TITLE
Fix clang with msvc-wine

### DIFF
--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -174,7 +174,11 @@ function find_build_tools(opt)
         if #lib ~= 0 then
             local vcvars = {
                 BUILD_TOOLS_ROOT = sdkdir,
-                INCLUDE = path.joinenv(includedirs),
+
+                -- vs runs in a windows ctx, so the envsep is always ";"
+                INCLUDE = path.joinenv(includedirs, ';'),
+                LIB = path.joinenv(lib, ';'),
+
                 WindowsSdkDir = variables.WindowsSdkDir,
                 WindowsSDKVersion = WindowsSDKVersion,
                 VCToolsInstallDir = variables.VCToolsInstallDir,
@@ -193,7 +197,6 @@ function find_build_tools(opt)
             end
 
             vcvars.VSCMD_ARG_TGT_ARCH = target_arch
-            vcvars.LIB = path.joinenv(lib)
             vcvars.BUILD_TOOLS_BIN = path.joinenv(buidl_tools_bin)
 
             local PATH = buidl_tools_bin

--- a/xmake/modules/detect/tools/find_lld_link.lua
+++ b/xmake/modules/detect/tools/find_lld_link.lua
@@ -38,7 +38,7 @@ import("lib.detect.find_programver")
 --
 function main(opt)
     opt = opt or {}
-    local program = find_program(opt.program or "lld.link", opt)
+    local program = find_program(opt.program or "lld-link", opt)
     local version = nil
     if program and opt and opt.version then
         version = find_programver(program, opt)

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -652,7 +652,7 @@ function _get_configs_for_cross(package, configs, opt)
     envs.CMAKE_CXX_COMPILER        = _translate_bin_path(package:build_getenv("cxx"))
     envs.CMAKE_ASM_COMPILER        = _translate_bin_path(package:build_getenv("as"))
     envs.CMAKE_AR                  = _translate_bin_path(package:build_getenv("ar"))
-    if package:is_plat("windows") then
+    if package:is_plat("windows") and package:has_tool("cxx", "cl") then
         envs.CMAKE_AR = path.join(path.directory(envs.CMAKE_CXX_COMPILER), "lib.exe")
     end
     _fix_cxx_compiler_cmake(package, envs)

--- a/xmake/toolchains/clang-cl/xmake.lua
+++ b/xmake/toolchains/clang-cl/xmake.lua
@@ -31,7 +31,7 @@
 --
 toolchain("clang-cl")
     set_kind("standalone")
-    set_homepage("https://visualstudio.microsoft.com")
+    set_homepage("https://clang.llvm.org/")
     set_description("LLVM Clang C/C++ Compiler compatible with msvc")
     set_runtimes("MT", "MTd", "MD", "MDd")
 


### PR DESCRIPTION
https://github.com/xmake-io/xmake/pull/5823 Make msvc can be used by xmake under non-windows platform. After my test, msvc works well, but clang is not working properly..
This PR fixes this problem. (and fixed some minor issues by the way)
