### PR TITLE
fix dummy cmakelist generated wrong default ms_runtime parameters.

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -822,6 +822,8 @@ function _get_default_flags(package, configs, buildtype, opt)
         local tmpdir = path.join(os.tmpfile() .. ".dir", package:displayname(), package:mode())
         local dummy_cmakelist = path.join(tmpdir, "CMakeLists.txt")
 
+        -- About the minimum cmake version requirement
+        -- @see https://github.com/xmake-io/xmake/pull/6032
         io.writefile(dummy_cmakelist, format([[
     cmake_minimum_required(VERSION 3.15)
     project(XMakeDummyProject)

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -823,6 +823,9 @@ function _get_default_flags(package, configs, buildtype, opt)
         local dummy_cmakelist = path.join(tmpdir, "CMakeLists.txt")
 
         io.writefile(dummy_cmakelist, format([[
+    cmake_minimum_required(VERSION 3.15)
+    project(XMakeDummyProject)
+
     message(STATUS "CMAKE_C_FLAGS is ${CMAKE_C_FLAGS}")
     message(STATUS "CMAKE_C_FLAGS_%s is ${CMAKE_C_FLAGS_%s}")
 


### PR DESCRIPTION
I spent a lot of time debugging this problem... 💀️

Since clang with msvc-wine became available recently on xmake, I looked for some projects to compile (for testing)

I found that the compilation always failed when linking to the static library:
```
/failifmismatch: mismatch detected for 'RuntimeLibrary'
>>> xxx.obj has value MT_StaticRelease
>>> xxx.lib(xxx.cc.obj) has value MD_DynamicRelease
```
It seems that xmake always forcibly sets the library product to MD runtime.

so I checked the compile options, xmake always adds for the compile options:
```
-D_DLL -D_MT -Xclang --dependent-lib=msvcrt
```

I searched the source code with the keyword "--dependent-lib". In fact, all these options were obtained from cmake by "dummy_cmakelists" (hence the long waste of time)

But why cmake generates these options still puzzles me. I tried to make a minimal reproduction of pure cmake, but it was completely unreproducible! The commands generated by my cmakelists are normal, but the commands generated by xmake calling cmake are always wrong.

(after wasting a lot of time) I had to read the [cmake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html#variable:CMAKE_MSVC_RUNTIME_LIBRARY), and one sentence caught my attention:
> Note
> This variable has effect only when policy [CMP0091](https://cmake.org/cmake/help/latest/policy/CMP0091.html#policy:CMP0091) is set to NEW prior to the first [project()](https://cmake.org/cmake/help/latest/command/project.html#command:project) or [enable_language()](https://cmake.org/cmake/help/latest/command/enable_language.html#command:enable_language) command that enables a language using a compiler targeting the MSVC ABI.

It suddenly occurred to me that xmake's dummy_cmakelists do not specify a minimum cmake version (while I was used to declare it for my lists), so the behavior is different.

In general, cmake before 3.15 always generates "MD" C/CXX compilation commands for clang by default.
Therefore, it is necessary to specify the minimum cmake version.