### PR TITLE
Fix run environment for mingw

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1073,13 +1073,13 @@ function _instance:_rawenvs()
             envs.PATH = table.wrap(bindirs)
         elseif self:is_binary() then
             envs.PATH = {"bin"}
-        elseif os.host() == "windows" and self:is_plat("windows", "mingw") and self:is_arch(os.arch()) and self:config("shared") then
+        elseif os.host() == "windows" and self:is_plat("windows", "mingw") and not self:is_cross() and self:config("shared") then
             -- bin/*.dll for windows
             envs.PATH = {"bin"}
         end
 
         -- add LD_LIBRARY_PATH to load *.so directory
-        if os.host() ~= "windows" and self:is_plat(os.host()) and self:is_arch(os.arch()) and self:config("shared") then
+        if os.host() ~= "windows" and self:is_plat(os.host()) and not self:is_cross() and self:config("shared") then
             envs.LD_LIBRARY_PATH = {"lib"}
             if os.host() == "macosx" then
                 envs.DYLD_LIBRARY_PATH = {"lib"}


### PR DESCRIPTION
https://github.com/xmake-io/xmake/commit/dc64ef1360682592440852ddd3fb7d228c096820 broke the environment of some packages (to find .dll) on MinGW because the MinGW arch (x86_64) doesn't match os.arch() (x64), using is_cross that takes that into account fixes that.