### PR TITLE
check pkgconfig for package

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2712,6 +2712,27 @@ function _instance:check_fcsnippets(snippets, opt)
     return sandbox_module.import("lib.detect.check_fcsnippets", {anonymous = true})(snippets, opt)
 end
 
+-- check the given pkgconfig file?
+--
+-- @param name      the .pc filename (without .pc extension)
+-- @param opt       the argument options
+--
+-- @return          true or false, errors
+--
+function _instance:check_pkgconfig(name, opt)
+    opt = opt or {}
+    if opt.configdirs == nil then
+        local configdirs = {}
+        local linkdirs = table.wrap(self:get("linkdirs") or "lib")
+        local installdir = self:installdir()
+        for _, linkdir in ipairs(linkdirs) do
+            table.insert(configdirs, path.join(installdir, linkdir))
+        end
+        opt.configdirs = configdirs
+    end
+    return sandbox_module.import("lib.detect.check_pkgconfig", {anonymous = true})(name or self:name(), opt)
+end
+
 -- the current mode is belong to the given modes?
 function package._api_is_mode(interp, ...)
     return config.is_mode(...)

--- a/xmake/modules/lib/detect/check_pkgconfig.lua
+++ b/xmake/modules/lib/detect/check_pkgconfig.lua
@@ -1,0 +1,40 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      ruki
+-- @file        check_pkgconfig.lua
+--
+
+-- imports
+import("core.base.option")
+import("lib.detect.pkgconfig")
+
+-- check the given pkgconfig file
+--
+-- @param name      the .pc file name
+-- @param opt       the argument options, e.g. { verbose = true, configdirs = {"lib"}}
+--
+function main(name, opt)
+    local result = pkgconfig.libinfo(name, opt)
+    if opt.verbose or option.get("verbose") or option.get("diagnosis") then
+        cprint("${dim}> checking for pkgconfig/%s.pc", name)
+        if result then
+            print(result)
+        end
+    end
+    return result
+end
+


### PR DESCRIPTION
```lua
package("libxml2")
    on_test(function (package)
        assert(package:check_pkgconfig("libxml-2.0"))
    end)

package("x264")
    on_test(function (package)
        assert(package:check_pkgconfig())
    end)
```

```console
> checking for pkgconfig/x264.pc
{
  version = "0.164.3108",
  links = {
    "x264"
  },
  defines = {
    "X264_API_IMPORTS"
  },
  linkdirs = {
    "/usr/local/Cellar/x264/r3108/lib"
  },
  includedirs = {
    "/usr/local/Cellar/x264/r3108/include"
  }
}

```

https://github.com/xmake-io/xmake/issues/5945