### PR TITLE
Add native Windows on ARM64 builds for CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
           if ("${{ matrix.arch }}" -eq "x64") {
             Write-Output "RELEASE_NAME=win64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           } elseif ("${{ matrix.arch }}" -eq "arm64") {
-            Write-Output "RELEASE_NAME=winarm64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
+            Write-Output "RELEASE_NAME=arm64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           } else {
             Write-Output "RELEASE_NAME=win32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -76,6 +76,7 @@ jobs:
           cd ..
 
       - name: Tests
+        if: matrix.arch != 'arm64'
         run: |
           Copy-Item ./core/build/xmake.exe ./xmake
           Copy-Item ./scripts/xrepo.bat ./xmake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
-        arch: [x64, x86]
+        arch: [x64, x86, arm64]
 
     runs-on: ${{ matrix.os }}
 
@@ -50,6 +50,8 @@ jobs:
         run: |
           if ("${{ matrix.arch }}" -eq "x64") {
             Write-Output "RELEASE_NAME=win64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
+          } elseif ("${{ matrix.arch }}" -eq "arm64") {
+            Write-Output "RELEASE_NAME=winarm64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           } else {
             Write-Output "RELEASE_NAME=win32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           }
@@ -204,4 +206,3 @@ jobs:
           asset_path: artifacts/${{env.RELEASE_NAME}}/xmake.exe
           asset_name: xmake-${{ steps.tagName.outputs.tag }}.${{ env.RELEASE_NAME }}xp.exe
           asset_content_type: application/zip
-

--- a/.github/workflows/windows_luajit.yml
+++ b/.github/workflows/windows_luajit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
-        arch: [x64, x86, arm64]
+        arch: [x64, x86]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/windows_luajit.yml
+++ b/.github/workflows/windows_luajit.yml
@@ -40,7 +40,7 @@ jobs:
           if ("${{ matrix.arch }}" -eq "x64") {
             Write-Output "RELEASE_NAME=win64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           } elseif ("${{ matrix.arch }}" -eq "arm64") {
-            Write-Output "RELEASE_NAME=winarm64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
+            Write-Output "RELEASE_NAME=arm64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           } else {
             Write-Output "RELEASE_NAME=win32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           }

--- a/.github/workflows/windows_luajit.yml
+++ b/.github/workflows/windows_luajit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
-        arch: [x64, x86]
+        arch: [x64, x86, arm64]
 
     runs-on: ${{ matrix.os }}
 
@@ -39,6 +39,8 @@ jobs:
         run: |
           if ("${{ matrix.arch }}" -eq "x64") {
             Write-Output "RELEASE_NAME=win64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
+          } elseif ("${{ matrix.arch }}" -eq "arm64") {
+            Write-Output "RELEASE_NAME=winarm64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           } else {
             Write-Output "RELEASE_NAME=win32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf-8 -Append
           }
@@ -91,5 +93,3 @@ jobs:
         with:
           name: xmake-latest.${{ env.RELEASE_NAME }}.sha256
           path: artifacts/${{env.RELEASE_NAME}}/shafile
-
-


### PR DESCRIPTION
The x64 version runs under emulation, but won't use HostARM64 tools, having a native arm version would make more sense.

[xmake-winarm64.zip](https://github.com/user-attachments/files/18383664/xmake-winarm64.zip)
