### PR TITLE
Add `qt_host` Option to Enable Cross-Platform Qt Builds Using Host SDK Tools

### DIFF
--- a/xmake/platforms/bsd/xmake.lua
+++ b/xmake/platforms/bsd/xmake.lua
@@ -39,6 +39,7 @@ platform("bsd")
                 ,   {nil, "cuda",           "kv", "auto",       "The Cuda SDK Directory"            }
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
+                ,   {nil, "qt_host",        "kv", "auto",       "The Qt Host SDK Directory"         }
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
                 }
 
@@ -48,6 +49,7 @@ platform("bsd")
                 ,   {nil, "cuda",           "kv", "auto",       "The Cuda SDK Directory"            }
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
+                ,   {nil, "qt_host",        "kv", "auto",       "The Qt Host SDK Directory"         }
                 }
             }
 

--- a/xmake/platforms/haiku/xmake.lua
+++ b/xmake/platforms/haiku/xmake.lua
@@ -37,6 +37,7 @@ platform("haiku")
                 ,   {nil, "cuda",           "kv", "auto",       "The Cuda SDK Directory"            }
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
+                ,   {nil, "qt_host",        "kv", "auto",       "The Qt Host SDK Directory"         }
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
                 }
 
@@ -46,6 +47,7 @@ platform("haiku")
                 ,   {nil, "cuda",           "kv", "auto",       "The Cuda SDK Directory"            }
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
+                ,   {nil, "qt_host",        "kv", "auto",       "The Qt Host SDK Directory"         }
                 }
             }
 

--- a/xmake/platforms/linux/xmake.lua
+++ b/xmake/platforms/linux/xmake.lua
@@ -38,6 +38,7 @@ platform("linux")
                 ,   {nil, "cuda",           "kv", "auto",       "The Cuda SDK Directory"            }
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
+                ,   {nil, "qt_host",        "kv", "auto",       "The Qt Host SDK Directory"         }
                 ,   {nil, "qt_sdkver",      "kv", "auto",       "The Qt SDK Version"                }
                 ,   {category = "Vcpkg Configuration"                                               }
                 ,   {nil, "vcpkg",          "kv", "auto",       "The Vcpkg Directory"               }
@@ -49,6 +50,7 @@ platform("linux")
                 ,   {nil, "cuda",           "kv", "auto",       "The Cuda SDK Directory"            }
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",             "kv", "auto",       "The Qt SDK Directory"              }
+                ,   {nil, "qt_host",        "kv", "auto",       "The Qt Host SDK Directory"         }
                 ,   {category = "Vcpkg Configuration"                                               }
                 ,   {nil, "vcpkg",          "kv", "auto",       "The Vcpkg Directory"               }
                 }

--- a/xmake/platforms/macosx/xmake.lua
+++ b/xmake/platforms/macosx/xmake.lua
@@ -47,6 +47,7 @@ platform("macosx")
                 ,   {nil, "cuda",                    "kv", "auto",       "The Cuda SDK Directory"            }
                 ,   {category = "Qt SDK Configuration"                                                       }
                 ,   {nil, "qt",                      "kv", "auto",       "The Qt SDK Directory"              }
+                ,   {nil, "qt_host",                 "kv", "auto",       "The Qt Host SDK Directory"         }
                 ,   {nil, "qt_sdkver",               "kv", "auto",       "The Qt SDK Version"                }
                 ,   {category = "Vcpkg Configuration"                                                        }
                 ,   {nil, "vcpkg",                   "kv", "auto",       "The Vcpkg Directory"               }
@@ -63,6 +64,7 @@ platform("macosx")
                 ,   {nil, "cuda",                    "kv", "auto",       "The Cuda SDK Directory"            }
                 ,   {category = "Qt SDK Configuration"                                                       }
                 ,   {nil, "qt",                      "kv", "auto",       "The Qt SDK Directory"              }
+                ,   {nil, "qt_host",                 "kv", "auto",       "The Qt Host SDK Directory"         }
                 ,   {category = "Vcpkg Configuration"                                                        }
                 ,   {nil, "vcpkg",                   "kv", "auto",       "The Vcpkg Directory"               }
                 }

--- a/xmake/platforms/windows/xmake.lua
+++ b/xmake/platforms/windows/xmake.lua
@@ -47,6 +47,7 @@ platform("windows")
                 ,   {nil, "cuda",       "kv", "auto", "The Cuda SDK Directory"                      }
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",         "kv", "auto", "The Qt SDK Directory"                        }
+                ,   {nil, "qt_host",    "kv", "auto", "The Qt Host SDK Directory"                   }
                 ,   {nil, "qt_sdkver",  "kv", "auto", "The Qt SDK Version"                          }
                 ,   {category = "WDK Configuration"                                                 }
                 ,   {nil, "wdk",        "kv", "auto", "The WDK Directory"                           }
@@ -71,6 +72,7 @@ platform("windows")
                 ,   {nil, "cuda",       "kv", "auto", "The Cuda SDK Directory"                      }
                 ,   {category = "Qt SDK Configuration"                                              }
                 ,   {nil, "qt",         "kv", "auto", "The Qt SDK Directory"                        }
+                ,   {nil, "qt_host",    "kv", "auto", "The Qt Host SDK Directory"                   }
                 ,   {category = "WDK Configuration"                                                 }
                 ,   {nil, "wdk",        "kv", "auto", "The WDK Directory"                           }
                 ,   {category = "Vcpkg Configuration"                                               }

--- a/xmake/rules/qt/deploy/android.lua
+++ b/xmake/rules/qt/deploy/android.lua
@@ -71,10 +71,10 @@ function main(target, opt)
     end
 
     -- get androiddeployqt
-    local androiddeployqt = path.join(qt.bindir, "androiddeployqt" .. (is_host("windows") and ".exe" or ""))
-    if not os.isexec(androiddeployqt) and qt.bindir_host then
-        androiddeployqt = path.join(qt.bindir_host, "androiddeployqt" .. (is_host("windows") and ".exe" or ""))
-    end
+    local search_dirs = {}
+    if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+    if qt.bindir then table.insert(search_dirs, qt.bindir) end
+    local androiddeployqt = find_file("androiddeployqt" .. (is_host("windows") and ".exe" or ""), search_dirs)
     assert(os.isexec(androiddeployqt), "androiddeployqt not found!")
 
     -- get working directory
@@ -152,18 +152,18 @@ function main(target, opt)
         settings_file:print('   "target-architecture": "%s",', target_arch)
         settings_file:print('   "qml-root-path": "%s",', _escape_path(os.projectdir()))
         -- for 6.2.x
-        local qmlimportscanner = path.join(qt.libexecdir, "qmlimportscanner")
-        if not os.isexec(qmlimportscanner) and qt.libexecdir_host then
-            qmlimportscanner = path.join(qt.libexecdir_host, "qmlimportscanner")
-        end
+        local search_dirs = {}
+        if qt.libexecdir_host then table.insert(search_dirs, qt.libexecdir_host) end
+        if qt.libexecdir then table.insert(search_dirs, qt.libexecdir) end
+        local qmlimportscanner = find_file("qmlimportscanner" .. (is_host("windows") and ".exe" or ""), search_dirs)
         if os.isexec(qmlimportscanner) then
             settings_file:print('   "qml-importscanner-binary": "%s",', _escape_path(qmlimportscanner))
         end
         -- for 6.3.x
-        local rcc = path.join(qt.bindir, "rcc")
-        if not os.isexec(rcc) and qt.bindir_host then
-            rcc = path.join(qt.bindir_host, "rcc")
-        end
+        local search_dirs = {}
+        if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+        if qt.bindir then table.insert(search_dirs, qt.bindir) end
+        local rcc = find_file("rcc" .. (is_host("windows") and ".exe" or ""), search_dirs)
         if os.isexec(rcc) then
             settings_file:print('   "rcc-binary": "%s",', _escape_path(rcc))
         end

--- a/xmake/rules/qt/deploy/macosx.lua
+++ b/xmake/rules/qt/deploy/macosx.lua
@@ -24,6 +24,7 @@ import("core.base.option")
 import("core.project.config")
 import("core.project.depend")
 import("core.tool.toolchain")
+import("lib.detect.find_file")
 import("lib.detect.find_path")
 import("detect.sdks.find_qt")
 import("utils.progress")
@@ -91,7 +92,10 @@ function main(target, opt)
     local qt = assert(find_qt(), "Qt SDK not found!")
 
     -- get macdeployqt
-    local macdeployqt = path.join(qt.bindir, "macdeployqt")
+    local search_dirs = {}
+    if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+    if qt.bindir then table.insert(search_dirs, qt.bindir) end
+    local macdeployqt = find_file("macdeployqt" .. (is_host("windows") and ".exe" or ""), search_dirs)
     assert(os.isexec(macdeployqt), "macdeployqt not found!")
 
     -- generate target app

--- a/xmake/rules/qt/env/xmake.lua
+++ b/xmake/rules/qt/env/xmake.lua
@@ -33,7 +33,12 @@ rule("qt.env")
 
         local qmlimportpath = target:values("qt.env.qmlimportpath") or {}
         if target:is_plat("windows") or (target:is_plat("mingw") and is_host("windows")) then
-            target:add("runenvs", "PATH", qt.bindir)
+            if qt.bindir_host then
+                target:add("runenvs", "PATH", qt.bindir_host)
+            end
+            if qt.bindir then
+                target:add("runenvs", "PATH", qt.bindir)
+            end
             table.insert(qmlimportpath, qt.qmldir)
             -- add targetdir in QML2_IMPORT_PATH in case of the user have qml plugins
             table.insert(qmlimportpath, target:targetdir())

--- a/xmake/rules/qt/install/mingw.lua
+++ b/xmake/rules/qt/install/mingw.lua
@@ -23,6 +23,7 @@ import("core.base.option")
 import("core.project.config")
 import("core.tool.toolchain")
 import("lib.detect.find_path")
+import("lib.detect.find_file")
 import("detect.sdks.find_qt")
 
 -- get install directory
@@ -42,7 +43,10 @@ function main(target, opt)
     local qt = assert(find_qt(), "Qt SDK not found!")
 
     -- get windeployqt
-    local windeployqt = path.join(qt.bindir, "windeployqt.exe")
+    local search_dirs = {}
+    if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+    if qt.bindir then table.insert(search_dirs, qt.bindir) end
+    local windeployqt = find_file("windeployqt" .. (is_host("windows") and ".exe" or ""), search_dirs)
     assert(os.isexec(windeployqt), "windeployqt.exe not found!")
 
     -- find qml directory

--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -449,7 +449,12 @@ function main(target, opt)
         target:add("linkdirs", qt.libdir)
         target:add("syslinks", "ws2_32", "gdi32", "ole32", "advapi32", "shell32", "user32", "opengl32", "imm32", "winmm", "iphlpapi")
         -- for debugger, https://github.com/xmake-io/xmake-vscode/issues/225
-        target:add("runenvs", "PATH", qt.bindir)
+        if qt.bindir_host then
+            target:add("runenvs", "PATH", qt.bindir_host)
+        end
+        if qt.bindir then
+            target:add("runenvs", "PATH", qt.bindir)
+        end
     elseif target:is_plat("mingw") then
         target:set("frameworks", nil)
         -- we need to fix it, because gcc maybe does not work on latest mingw when `-isystem D:\a\_temp\msys64\mingw64\include` is passed.

--- a/xmake/rules/qt/moc/xmake.lua
+++ b/xmake/rules/qt/moc/xmake.lua
@@ -24,16 +24,16 @@ rule("qt.moc")
     set_extensions(".h", ".hpp")
     before_buildcmd_file(function (target, batchcmds, sourcefile, opt)
         import("core.tool.compiler")
+        import("lib.detect.find_file")
 
         -- get moc
         local qt = assert(target:data("qt"), "Qt not found!")
-        local moc = path.join(qt.bindir, is_host("windows") and "moc.exe" or "moc")
-        if not os.isexec(moc) and qt.libexecdir then
-            moc = path.join(qt.libexecdir, is_host("windows") and "moc.exe" or "moc")
-        end
-        if not os.isexec(moc) and qt.libexecdir_host then
-            moc = path.join(qt.libexecdir_host, is_host("windows") and "moc.exe" or "moc")
-        end
+        local search_dirs = {}
+        if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+        if qt.bindir then table.insert(search_dirs, qt.bindir) end
+        if qt.libexecdir_host then table.insert(search_dirs, qt.libexecdir_host) end
+        if qt.libexecdir then table.insert(search_dirs, qt.libexecdir) end
+        local moc = find_file(is_host("windows") and "moc.exe" or "moc", search_dirs)
         assert(moc and os.isexec(moc), "moc not found!")
 
         -- get c++ source file for moc

--- a/xmake/rules/qt/qmltyperegistrar/xmake.lua
+++ b/xmake/rules/qt/qmltyperegistrar/xmake.lua
@@ -23,17 +23,18 @@ rule("qt.qmltyperegistrar")
     set_extensions(".h", ".hpp")
 
     on_config(function(target)
+        import("lib.detect.find_file")
+
         -- get qt
         local qt = assert(target:data("qt"), "Qt not found!")
 
         -- get qmltyperegistrar
-        local qmltyperegistrar = path.join(qt.bindir, is_host("windows") and "qmltyperegistrar.exe" or "qmltyperegistrar")
-        if not os.isexec(qmltyperegistrar) and qt.libexecdir then
-            qmltyperegistrar = path.join(qt.libexecdir, is_host("windows") and "qmltyperegistrar.exe" or "qmltyperegistrar")
-        end
-        if not os.isexec(qmltyperegistrar) and qt.libexecdir_host then
-            qmltyperegistrar = path.join(qt.libexecdir_host, is_host("windows") and "qmltyperegistrar.exe" or "qmltyperegistrar")
-        end
+        local search_dirs = {}
+        if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+        if qt.bindir then table.insert(search_dirs, qt.bindir) end
+        if qt.libexecdir_host then table.insert(search_dirs, qt.libexecdir_host) end
+        if qt.libexecdir then table.insert(search_dirs, qt.libexecdir) end
+        local qmltyperegistrar = find_file(is_host("windows") and "qmltyperegistrar.exe" or "qmltyperegistrar", search_dirs)
         assert(qmltyperegistrar and os.isexec(qmltyperegistrar), "qmltyperegistrar not found!")
 
         -- set targetdir

--- a/xmake/rules/qt/qrc/xmake.lua
+++ b/xmake/rules/qt/qrc/xmake.lua
@@ -22,16 +22,16 @@ rule("qt.qrc")
     add_deps("qt.env")
     set_extensions(".qrc")
     on_config(function (target)
+        import("lib.detect.find_file")
 
         -- get rcc
         local qt = assert(target:data("qt"), "Qt not found!")
-        local rcc = path.join(qt.bindir, is_host("windows") and "rcc.exe" or "rcc")
-        if not os.isexec(rcc) and qt.libexecdir then
-            rcc = path.join(qt.libexecdir, is_host("windows") and "rcc.exe" or "rcc")
-        end
-        if not os.isexec(rcc) and qt.libexecdir_host then
-            rcc = path.join(qt.libexecdir_host, is_host("windows") and "rcc.exe" or "rcc")
-        end
+        local search_dirs = {}
+        if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+        if qt.bindir then table.insert(search_dirs, qt.bindir) end
+        if qt.libexecdir_host then table.insert(search_dirs, qt.libexecdir_host) end
+        if qt.libexecdir then table.insert(search_dirs, qt.libexecdir) end
+        local rcc = find_file(is_host("windows") and "rcc.exe" or "rcc", search_dirs)
         assert(os.isexec(rcc), "rcc not found!")
 
         -- save rcc

--- a/xmake/rules/qt/ui/xmake.lua
+++ b/xmake/rules/qt/ui/xmake.lua
@@ -22,16 +22,16 @@ rule("qt.ui")
     add_deps("qt.env")
     set_extensions(".ui")
     on_config(function (target)
+        import("lib.detect.find_file")
 
         -- get uic
         local qt = assert(target:data("qt"), "Qt not found!")
-        local uic = path.join(qt.bindir, is_host("windows") and "uic.exe" or "uic")
-        if not os.isexec(uic) and qt.libexecdir then
-            uic = path.join(qt.libexecdir, is_host("windows") and "uic.exe" or "uic")
-        end
-        if not os.isexec(uic) and qt.libexecdir_host then
-            uic = path.join(qt.libexecdir_host, is_host("windows") and "uic.exe" or "uic")
-        end
+        local search_dirs = {}
+        if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
+        if qt.bindir then table.insert(search_dirs, qt.bindir) end
+        if qt.libexecdir_host then table.insert(search_dirs, qt.libexecdir_host) end
+        if qt.libexecdir then table.insert(search_dirs, qt.libexecdir) end
+        local uic = find_file(is_host("windows") and "uic.exe" or "uic", search_dirs)
         assert(uic and os.isexec(uic), "uic not found!")
 
         -- add includedirs, @note we need to create this directory first to suppress warning (file not found).


### PR DESCRIPTION
This update introduces an option, `qt_host`, to facilitate cross-building of Qt desktop applications.

#### Example Usage

1. **Build a Qt Widgets app for MinGW on Linux**  
   Using an SDK downloaded by `aqt`:
   ```bash
   xmake f -c -p mingw --qt=../sdk/6.9.0/llvm-mingw_64 --qt_host=../sdk/6.9.0/gcc_64
   ```

2. **Build a Qt Widgets app for Linux on Windows**  
   Using an SDK downloaded by `aqt` and the Zig toolchain:
   ```bash
   xmake f -c -p linux --toolchain=zig --qt=../sdk/6.9.0/gcc_64 --qt_host=../sdk/6.9.0/llvm-mingw_64
   ```

#### Caution

- Ensure the host Qt version matches the target version.
- The rules `qt.deploy` and `qt.install` might cause cross-platform issues, as `windeployqt` and `macdeployqt` need to run on their native platforms.

#### Tested Configurations

- **Cross-Builds:**
  - Qt 6.9.0 for Linux built on Windows with the Zig toolchain
  - Qt 6.9.0 for MinGW built on Linux
  - Qt 6.8.0 for Android built on Windows 

- **Native Builds (Regression Tests):**
  - Qt 6.8.1 for Linux (system-installed)
  - Qt 5.15.16 for Linux (system-installed)
  - Qt 6.9.0 for Linux (downloaded via `aqt`)
  - Qt 6.9.0 for MinGW