### PR TITLE
Fix clang flag

### DIFF
--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -69,7 +69,7 @@ function _translate_flags(package, flags)
     if package:is_plat("android") then
         local flags_new = {}
         for _, flag in ipairs(flags) do
-            if flag:startswith("-gcc-toolchain ") or flag:startswith("--target=") or flag:startswith("-isystem ") then
+            if flag:startswith("--gcc-toolchain=") or flag:startswith("--target=") or flag:startswith("-isystem ") then
                 table.join2(flags_new, flag:split(" ", {limit = 2}))
             else
                 table.insert(flags_new, flag)

--- a/xmake/toolchains/ndk/load.lua
+++ b/xmake/toolchains/ndk/load.lua
@@ -131,10 +131,10 @@ function main(toolchain)
         -- add gcc toolchain
         local gcc_toolchain = toolchain:config("gcc_toolchain")
         if gcc_toolchain then
-            toolchain:add("cxflags", "-gcc-toolchain " .. gcc_toolchain)
-            toolchain:add("asflags", "-gcc-toolchain " .. gcc_toolchain)
-            toolchain:add("ldflags", "-gcc-toolchain " .. gcc_toolchain)
-            toolchain:add("shflags", "-gcc-toolchain " .. gcc_toolchain)
+            toolchain:add("cxflags", "--gcc-toolchain=" .. gcc_toolchain)
+            toolchain:add("asflags", "--gcc-toolchain=" .. gcc_toolchain)
+            toolchain:add("ldflags", "--gcc-toolchain=" .. gcc_toolchain)
+            toolchain:add("shflags", "--gcc-toolchain=" .. gcc_toolchain)
         end
     else
         local march = arch


### PR DESCRIPTION
https://github.com/xmake-io/xmake-repo/pull/6229
```console
meson.build:1:0: ERROR: Unable to detect linker for compiler `/home/runner/work/xmake-repo/xmake-repo/android-ndk-r22/toolchains/llvm/prebuilt/linux-x86_64/bin/clang -Wl,--version -llog --target=aarch64-none-linux-android30 '-gcc-toolchain /home/runner/work/xmake-repo/xmake-repo/android-ndk-r22/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64' -fPIE -pie -nostdlib++ -llog --target=aarch64-none-linux-android30 '-gcc-toolchain /home/runner/work/xmake-repo/xmake-repo/android-ndk-r22/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64' -nostdlib++`
stdout: 
stderr: clang: error: unknown argument: '-gcc-toolchain /home/runner/work/xmake-repo/xmake-repo/android-ndk-r22/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64'
clang: error: unknown argument: '-gcc-toolchain /home/runner/work/xmake-repo/xmake-repo/android-ndk-r22/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64'
```
May related https://github.com/xmake-io/xmake/pull/5912