### PR TITLE
Clearer extract errors

### DIFF
--- a/xmake/modules/private/action/require/impl/actions/download_resources.lua
+++ b/xmake/modules/private/action/require/impl/actions/download_resources.lua
@@ -135,14 +135,27 @@ function _download(package, resource_name, resource_url, resource_hash)
     local resourcedir_tmp = resourcedir .. ".tmp"
     os.tryrm(resourcedir_tmp)
     local extension = archive.extension(resource_file)
-    local ok = try {function() archive.extract(resource_file, resourcedir_tmp); return true end}
+    local errors
+    local ok = try {
+        function() 
+            archive.extract(resource_file, resourcedir_tmp)
+            return true 
+        end,
+        catch {
+            function (errs)
+                if errs then
+                    errors = tostring(errs)
+                end
+            end
+        }
+    }
     if ok then
         os.tryrm(resourcedir)
         os.mv(resourcedir_tmp, resourcedir)
     elseif extension and extension ~= "" then
         os.tryrm(resourcedir_tmp)
         os.tryrm(resourcedir)
-        raise("cannot extract %s", resource_file)
+        raise(errors or string.format("cannot extract %s", resource_file))
     else
         -- if it is not archive file, we only need to create empty resource directory and use package:resourcefile(resource_name)
         os.tryrm(resourcedir)

--- a/xmake/modules/private/action/require/impl/actions/patch_sources.lua
+++ b/xmake/modules/private/action/require/impl/actions/patch_sources.lua
@@ -107,14 +107,27 @@ function _patch(package, patchinfo)
         local patchdir = patch_file .. ".dir"
         local patchdir_tmp = patchdir .. ".tmp"
         os.tryrm(patchdir_tmp)
-        local ok = try {function() archive.extract(patch_file, patchdir_tmp); return true end}
+        local errors
+        local ok = try {
+            function() 
+                archive.extract(patch_file, patchdir_tmp)
+                return true 
+            end,
+            catch {
+                function (errs)
+                    if errs then
+                        errors = tostring(errs)
+                    end
+                end
+            }
+        }
         if ok then
             os.tryrm(patchdir)
             os.mv(patchdir_tmp, patchdir)
         else
             os.tryrm(patchdir_tmp)
             os.tryrm(patchdir)
-            raise("cannot extract %s", patch_file)
+            raise(errors or string.format("cannot extract %s", patch_file))
         end
 
         -- apply patch files

--- a/xmake/modules/utils/archive/archive.lua
+++ b/xmake/modules/utils/archive/archive.lua
@@ -306,7 +306,7 @@ function _archive(archivefile, inputfiles, extension, archivers, opt)
             return true
         end
     end
-    raise("cannot archive %s, %s!", path.filename(archivefile), errors or "archivers not found!")
+    raise("cannot archive %s, %s!", path.filename(archivefile), errors or "no archiver found")
 end
 
 -- only archive tar file

--- a/xmake/modules/utils/archive/archive.lua
+++ b/xmake/modules/utils/archive/archive.lua
@@ -306,7 +306,7 @@ function _archive(archivefile, inputfiles, extension, archivers, opt)
             return true
         end
     end
-    raise("cannot archive %s, %s!", path.filename(archivefile), errors or "no archiver found")
+    raise("cannot archive %s, %s!", path.filename(archivefile), errors or "no archiver(like zip, ...) found")
 end
 
 -- only archive tar file

--- a/xmake/modules/utils/archive/extract.lua
+++ b/xmake/modules/utils/archive/extract.lua
@@ -446,7 +446,7 @@ function _extract(archivefile, outputdir, extension, extractors, opt)
             return true
         end
     end
-    raise("cannot extract %s, %s!", path.filename(archivefile), errors or "extractors not found!")
+    raise("cannot extract %s, %s!", path.filename(archivefile), errors or "no extractor found")
 end
 
 -- extract file

--- a/xmake/modules/utils/archive/extract.lua
+++ b/xmake/modules/utils/archive/extract.lua
@@ -446,7 +446,7 @@ function _extract(archivefile, outputdir, extension, extractors, opt)
             return true
         end
     end
-    raise("cannot extract %s, %s!", path.filename(archivefile), errors or "no extractor found")
+    raise("cannot extract %s, %s!", path.filename(archivefile), errors or "no extractor(like unzip, ...) found")
 end
 
 -- extract file


### PR DESCRIPTION
Forwards and rewords errors fom 'archive.extract' to make it clearer what exactly the error is.
