### PR TITLE
#5426 after_load for capnproto

### DIFF
--- a/xmake/rules/capnproto/xmake.lua
+++ b/xmake/rules/capnproto/xmake.lua
@@ -20,7 +20,11 @@
 
 -- define rule: capnproto.cpp
 rule("capnproto.cpp")
+    add_deps("c++")
     set_extensions(".capnp")
+    after_load(function (target)
+        return import("capnp").load(target)
+    end)
     before_buildcmd_file(function (target, batchcmds, sourcefile_capnp, opt)
         return import("capnp").buildcmd(target, batchcmds, sourcefile_capnp, opt)
     end)


### PR DESCRIPTION
after_load objectfiles for capnproto as described in #5426 and implemented like #5437

As mentioned in https://github.com/xmake-io/xmake/issues/5426#issuecomment-2270205061, the issue affectes most code genrator rules like that. This capnproto implementation has now been in use in my project for some time without exhibiting this bug or any noteworthy new bugs