### PR TITLE
package.tools.cmake: Set CMAKE_SYSTEM_PROCESSOR when cross-compiling

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -676,6 +676,7 @@ function _get_configs_for_cross(package, configs, opt)
             system_name = "Windows"
         end
         envs.CMAKE_SYSTEM_NAME = system_name
+        envs.CMAKE_SYSTEM_PROCESSOR = _get_cmake_system_processor(package)
     end
     if not package:is_plat("windows", "mingw") and package:config("pic") ~= false then
         table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")


### PR DESCRIPTION
This is already done in other places.

It's the cause of https://github.com/xmake-io/xmake-repo/actions/runs/13226915040/job/36918950132?pr=6292 and https://github.com/xmake-io/xmake-repo/actions/runs/13226915027/job/36918946568?pr=6292 failing