### PR TITLE
feat: improve GN tool to support extra arguments

### DIFF
--- a/xmake/modules/package/tools/gn.lua
+++ b/xmake/modules/package/tools/gn.lua
@@ -124,8 +124,8 @@ function build(package, configs, opt)
 
     -- do build
     local buildir = _get_buildir(opt)
-    local argv = opt.argv or {}
-    ninja.build(package, argv, {buildir = buildir, envs = opt.envs or buildenvs(package, opt)})
+    local targets = table.wrap(opt.target)
+    ninja.build(package, targets, {buildir = buildir, envs = opt.envs or buildenvs(package, opt)})
 end
 
 -- install package
@@ -137,5 +137,6 @@ function install(package, configs, opt)
 
     -- do build and install
     local buildir = _get_buildir(opt)
-    ninja.install(package, {}, {buildir = buildir, envs = opt.envs or buildenvs(package, opt)})
+    local targets = table.wrap(opt.target)
+    ninja.install(package, targets, {buildir = buildir, envs = opt.envs or buildenvs(package, opt)})
 end

--- a/xmake/modules/package/tools/gn.lua
+++ b/xmake/modules/package/tools/gn.lua
@@ -124,7 +124,8 @@ function build(package, configs, opt)
 
     -- do build
     local buildir = _get_buildir(opt)
-    ninja.build(package, {}, {buildir = buildir, envs = opt.envs or buildenvs(package, opt)})
+    local argv = opt.argv or {}
+    ninja.build(package, argv, {buildir = buildir, envs = opt.envs or buildenvs(package, opt)})
 end
 
 -- install package


### PR DESCRIPTION
`package.tools.gn`

Allows to pass extra arguments to ninja command. It defaults to an empty table (no arguments).

Example of usage:
```lua
local gn = import("package.tools.gn")

gn.build(package, configs, {buildir = "out.gn", argv = {"v8_monolith"}})
--                                              ^
--                                              | optional key of strings
```

This is a solution to discussion: https://github.com/xmake-io/xmake/discussions/6148#discussion-7947552
I've been able to test with my local installation of xmake. fyi, it allows to reduce time to build V8 in half.

Let me know if something is wrong or need changes.