### PR TITLE
Fix clang-cl toolchain with lto

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2389,6 +2389,8 @@ function _instance:_generate_lto_configs(sourcekind)
         local cflag = sourcekind == "cxx" and "cxxflags" or "cflags"
         if cc == "cl" then
             configs[cflag] = "-GL"
+        elseif cc == "clang_cl" then
+            configs[cflag] = "/clang:-flto=thin"
         elseif cc == "clang" or cc == "clangxx" then
             configs[cflag] = "-flto=thin"
         elseif cc == "gcc" or cc == "gxx" then

--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2389,9 +2389,7 @@ function _instance:_generate_lto_configs(sourcekind)
         local cflag = sourcekind == "cxx" and "cxxflags" or "cflags"
         if cc == "cl" then
             configs[cflag] = "-GL"
-        elseif cc == "clang_cl" then
-            configs[cflag] = "/clang:-flto=thin"
-        elseif cc == "clang" or cc == "clangxx" then
+        elseif cc == "clang" or cc == "clangxx" or cc == "clang_cl" then
             configs[cflag] = "-flto=thin"
         elseif cc == "gcc" or cc == "gxx" then
             configs[cflag] = "-flto"

--- a/xmake/rules/c++/build_optimization/config.lua
+++ b/xmake/rules/c++/build_optimization/config.lua
@@ -30,9 +30,7 @@ function _add_lto_optimization(target, sourcekind)
     local cflag = sourcekind == "cxx" and "cxxflags" or "cflags"
     if cc == "cl" then
         target:add(cflag, "-GL")
-    elseif cc == "clang_cl" then
-        target:add(cflag, "/clang:-flto=thin")
-    elseif cc == "clang" or cc == "clangxx" then
+    elseif cc == "clang" or cc == "clangxx" or cc == "clang_cl" then
         target:add(cflag, "-flto=thin")
     elseif cc == "gcc" or cc == "gxx" then
         target:add(cflag, "-flto")

--- a/xmake/rules/c++/build_optimization/config.lua
+++ b/xmake/rules/c++/build_optimization/config.lua
@@ -30,6 +30,8 @@ function _add_lto_optimization(target, sourcekind)
     local cflag = sourcekind == "cxx" and "cxxflags" or "cflags"
     if cc == "cl" then
         target:add(cflag, "-GL")
+    elseif cc == "clang_cl" then
+        target:add(cflag, "/clang:-flto=thin")
     elseif cc == "clang" or cc == "clangxx" then
         target:add(cflag, "-flto=thin")
     elseif cc == "gcc" or cc == "gxx" then
@@ -56,6 +58,11 @@ function _add_lto_optimization(target, sourcekind)
             target:add("ldflags", optimize_flags)
             target:add("shflags", optimize_flags)
         end
+    end
+
+    if cc == "clang_cl" and ld == "link" then
+        wprint([[clang-cl + msvc link unsupported lto, please use `set_toolset("ld", "lld-link")`]])
+        target:set("toolset", "ld", "lld-link")
     end
 end
 


### PR DESCRIPTION
https://clang.llvm.org/docs/ThinLTO.html
> When using lld-link, the -flto option need only be added to the compile step