### PR TITLE
Pass more options from `package:find_tool` to `lib.detect.find_tool`

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1966,6 +1966,9 @@ function _instance:find_tool(name, opt)
                                   bindirs = self:get("bindirs"),
                                   version = true, -- we alway check version
                                   require_version = opt.require_version,
+                                  check = opt.check,
+                                  command = opt.command,
+                                  parse = opt.parse,
                                   norun = opt.norun,
                                   system = opt.system,
                                   force = opt.force})


### PR DESCRIPTION
This update ensures that ~~all options~~ options `check`, `command` and `parse` are passed from `package:find_tool` to `lib.detect.find_tool`, allowing for customizable check methods in packages.