### PR TITLE
meson: Force to use vs env on Windows

### DIFF
--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -346,6 +346,7 @@ function _get_configs(package, configs, opt)
 
     -- add vs runtimes flags
     if package:is_plat("windows") then
+        table.insert(configs, "--vsenv")
         if package:has_runtime("MT") then
             table.insert(configs, "-Db_vscrt=mt")
         elseif package:has_runtime("MTd") then


### PR DESCRIPTION
to not detect MinGW if both are available

should fix https://github.com/xmake-io/xmake-repo/pull/6590