### PR TITLE
fix(raddbg): make rad debugger open as detached

### DIFF
--- a/xmake/modules/devel/debugger/run.lua
+++ b/xmake/modules/devel/debugger/run.lua
@@ -305,7 +305,8 @@ function _run_raddbg(program, argv, opt)
     table.insert(argv, 1, program)
 
     -- run it
-    os.execv(raddbg.program, argv, table.join(opt, {exclusive = true}))
+    opt.detach = true
+    os.execv(raddbg.program, argv, opt)
     return true
 end
 


### PR DESCRIPTION
The Rad debugger should be opened with `opt.detach = true`, as after it's newest update (`v0.9.15-alpha`) it did not open correctly any more with the old `opt`.

It should have likely always used `detach = true`, since its behaviour is similar to `devenv`, but it worked before with the old version, so I didn't notice before #6130.