### PR TITLE
devel: enable verbose for git clone

### DIFF
--- a/xmake/modules/devel/git/clone.lua
+++ b/xmake/modules/devel/git/clone.lua
@@ -148,5 +148,9 @@ function main(url, opt)
     end
 
     -- clone it
-    os.vrunv(git.program, argv, {envs = envs})
+    if opt.verbose then
+        os.execv(git.program, argv, {envs = envs})
+    else
+        os.vrunv(git.program, argv, {envs = envs})
+    end
 end


### PR DESCRIPTION
**Test**

```lua
function main(url, opt)

    url = "https://github.com/d2learn/xlings.git"
    opt = { verbose = true }

    -- find git
    local git = assert(find_tool("git"), "git not found!")

    -- ...

    -- clone it
    if opt.verbose then
        os.execv(git.program, argv, {envs = envs})
    else
        os.vrunv(git.program, argv, {envs = envs})
    end
end
```

```bash
speak@speak-pc:~/workspace/scode/xmake/xmake/modules/devel/git$ xmake l clone.lua 
Cloning into 'xlings'...
remote: Enumerating objects: 1633, done.
remote: Counting objects: 100% (218/218), done.
remote: Compressing objects: 100% (79/79), done.
remote: Total 1633 (delta 165), reused 150 (delta 139), pack-reused 1415 (from 2)
Receiving objects: 100% (1633/1633), 319.07 KiB | 2.25 MiB/s, done.
Resolving deltas: 100% (953/953), done.
```

**xmake-sourcecode**

https://github.com/xmake-io/xmake/blob/35a469902bfcdf9396feac420eff043578a5f858/xmake/modules/private/action/require/impl/repository.lua#L67