### PR TITLE
package(cmake): fix incorrect flag handling caused by substring matching

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -390,7 +390,7 @@ function _insert_configs_from_envs(configs, envs, opt)
     opt = opt or {}
     local configs_str = opt._configs_str
     for k, v in pairs(envs) do
-        if configs_str and configs_str:find(k, 1, true) then
+        if configs_str and configs_str:find("-D" .. k .. "=", 1, true) then
             -- use user custom configuration
         else
             table.insert(configs, "-D" .. k .. "=" .. v)


### PR DESCRIPTION
Resolved an issue where flags were mistakenly considered added due to substring matching (e.g., `CMAKE_CXX_FLAGS` being a part of `CMAKE_CXX_FLAGS_RELWITHDEBINFO`). This prevented certain flags from being properly included in the cmake command line. Improved the logic to ensure accurate flag detection and inclusion.

closes #6234

