### PR TITLE
toolchain(cross): use target-specific `objcopy`

### DIFF
--- a/xmake/toolchains/cross/load.lua
+++ b/xmake/toolchains/cross/load.lua
@@ -40,6 +40,7 @@ function main(toolchain)
     toolchain:add("toolset", "ar", cross .. "gcc-ar", cross .. "ar")
     toolchain:add("toolset", "ranlib", cross .. "gcc-ranlib", cross .. "ranlib")
     toolchain:add("toolset", "strip", cross .. "strip")
+    toolchain:add("toolset", "objcopy", cross .. "objcopy")
 
     -- add bin search library for loading some dependent .dll files windows
     local bindir = toolchain:bindir()


### PR DESCRIPTION
The `cross` toolchain currently lacks support for `objcopy`, causing a full file copy to be performed when the build mode is `releasedbg`.

#### Current behavior:
When building with the `cross` toolchain and `releasedbg` mode, the process performs a direct file copy:
```bash
$ xmake f -c -vD -m releasedbg -p cross --cross=aarch64-linux-gnu-
$ xmake -r -vD hello_c
[ 50%]: cache compiling.releasedbg src/hello.c
/usr/bin/aarch64-linux-gnu-gcc -c -g -Wall -Wextra -Wpedantic -O3 -DNDEBUG -o build/.objs/hello_c/cross/arm64/releasedbg/src/hello.c.o src/hello.c
[ 75%]: linking.releasedbg hello_c
/usr/bin/aarch64-linux-gnu-g++ -o build/cross/arm64/releasedbg/hello_c build/.objs/hello_c/cross/arm64/releasedbg/src/hello.c.o
[ 75%]: generating.releasedbg hello_c.sym
> copy build/cross/arm64/releasedbg/hello_c to build/cross/arm64/releasedbg/hello_c.sym
/usr/bin/aarch64-linux-gnu-strip -s build/cross/arm64/releasedbg/hello_c
```

#### Behavior after the change:
With the proposed fix, the `cross` toolchain now uses the target-specific `objcopy` to handle debug symbols:
```bash
$ xmake f -c -vD -m releasedbg -p cross --cross=aarch64-linux-gnu-
$ xmake -r -vD hello_c
[ 50%]: cache compiling.releasedbg src/hello.c
/usr/bin/aarch64-linux-gnu-gcc -c -g -Wall -Wextra -Wpedantic -O3 -DNDEBUG -o build/.objs/hello_c/cross/arm64/releasedbg/src/hello.c.o src/hello.c
[ 75%]: linking.releasedbg hello_c
/usr/bin/aarch64-linux-gnu-g++ -o build/cross/arm64/releasedbg/hello_c build/.objs/hello_c/cross/arm64/releasedbg/src/hello.c.o
[ 75%]: generating.releasedbg hello_c.sym
/usr/bin/aarch64-linux-gnu-objcopy --only-keep-debug build/cross/arm64/releasedbg/hello_c build/cross/arm64/releasedbg/hello_c.sym
/usr/bin/aarch64-linux-gnu-strip -s build/cross/arm64/releasedbg/hello_c
/usr/bin/aarch64-linux-gnu-objcopy --add-gnu-debuglink=build/cross/arm64/releasedbg/hello_c.sym build/cross/arm64/releasedbg/hello_c
```