### PR TITLE
[toolchains(armclang)] fix target and cpu flags for MDK

### DIFF
--- a/xmake/toolchains/armclang/xmake.lua
+++ b/xmake/toolchains/armclang/xmake.lua
@@ -53,27 +53,18 @@ toolchain("armclang")
         local arch = toolchain:arch()
         if arch then
             local arch_cpu     = arch:lower()
-            local arch_cpu_ld  = ""
-            local arch_target  = ""
-            if arch_cpu:startswith("cortex-m") then
-                arch_cpu_ld = arch_cpu:replace("cortex-m", "Cortex-M", {plain = true})
-                arch_target  = "arm-arm-none-eabi"
-            end
-            if arch_cpu:startswith("cortex-a") then
-                arch_cpu_ld = arch_cpu:replace("cortex-a", "Cortex-A", {plain = true})
-                arch_target  = "aarch64-arm-none-eabi"
-            end
             local as = toolchain:config("toolset_as")
             toolchain:set("toolset", "as", as)
-            toolchain:add("cxflags", "--target=" .. arch_target)
+            toolchain:add("cxflags", "--target=arm-arm-none-eabi")
             toolchain:add("cxflags", "-mcpu="   .. arch_cpu)
             if as == "armclang" then
-                toolchain:add("asflags", "--target=" .. arch_target)
+                toolchain:add("asflags", "--target=arm-arm-none-eabi")
                 toolchain:add("asflags", "-mcpu=" .. arch_cpu)
+                toolchain:add("asflags", "-masm=auto")
             else
                 toolchain:add("asflags", "--cpu=" .. arch_cpu)
             end
-            toolchain:add("ldflags", "--cpu "   .. arch_cpu_ld)
+            toolchain:add("ldflags", "--cpu="   .. arch_cpu)
         end
     end)
 


### PR DESCRIPTION
- Always set `--target=arm-arm-none-eabi` for compiler and assembler to match MDK's armclang requirements
- Add `-masm=auto` to asflags when using armclang assembler for better compatibility
- Unify ldflags cpu format: change from space separator to `--cpu=<arch>` format (note: the `--cpu` parameter is case insensitive)
- Fix incorrect architecture target handling reported in #6283