### PR TITLE
package(autoconf): Resolve issue with backslash-separated `CXX` path in MSYS

### DIFF
--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -434,6 +434,7 @@ function buildenvs(package, opt)
 
     if is_host("windows") then
         envs.CC       = _translate_windows_bin_path(envs.CC)
+        envs.CXX      = _translate_windows_bin_path(envs.CXX)
         envs.AS       = _translate_windows_bin_path(envs.AS)
         envs.AR       = _translate_windows_bin_path(envs.AR)
         envs.LD       = _translate_windows_bin_path(envs.LD)


### PR DESCRIPTION
While cross-compiling `icu4c` for Android using `Git Bash`, I encountered an error:

```console
/usr/bin/sh: line 1: D:ApplicationsScooppersistandroid-cltndk22.1.7171670toolchainsllvmprebuiltwindows-x86_64binclang++: command not found
```

This suggests that the `CXX` path might be misinterpreted. The dumped environment variables confirmed the issue:

```
{
 CXX = "D:\Applications\Scoop\persist\android-clt\ndk\22.1.7171670\toolchains\llvm\prebuilt\windows-x86_64\bin\clang++",
 CC = "D:/Applications/Scoop/persist/android-clt/ndk/22.1.7171670/toolchains/llvm/prebuilt/windows-x86_64/bin/clang.exe"
}
```

This PR aims to fix this path interpretation issue.