### PR TITLE
package(autoconf): De-duplicate `LDFLAGS`

### DIFF
--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -362,7 +362,7 @@ function buildenvs(package, opt)
     end
     if ldflags or shflags then
         -- autoconf does not use SHFLAGS
-        envs.LDFLAGS   = table.concat(_translate_paths(table.join(ldflags or {}, shflags)), ' ')
+        envs.LDFLAGS   = table.concat(table.reverse_unique(_translate_paths(table.join(ldflags or {}, shflags))), ' ')
     end
 
     -- cross-compilation? pass the full build environments


### PR DESCRIPTION
This PR aims to eliminate duplicate linker flags that appear after merging `ldflags` and `shflags`. This adjustment resolves the issue where `icu4c` fails to build for Android in `Git Bash` on Windows due to redundant flags.