### PR TITLE
improve finding windbg debugger

### DIFF
--- a/xmake/modules/devel/debugger/run.lua
+++ b/xmake/modules/devel/debugger/run.lua
@@ -85,7 +85,10 @@ end
 function _run_windbg(program, argv, opt)
     local windbg = find_tool("windbg", {program = config.get("debugger")})
     if not windbg then
-        return false
+        windbg = find_tool("windbgx", {program = config.get("debugger")})
+        if not windbg then
+            return false
+        end
     end
 
     -- patch arguments


### PR DESCRIPTION
新版的windbg的控制台指令改为了windbgx，增加一次判断，避免查找调试器时fallback至vsjitdebugger。