### PR TITLE
do windeployqt for qt.shared

### DIFF
--- a/xmake/rules/qt/xmake.lua
+++ b/xmake/rules/qt/xmake.lua
@@ -62,6 +62,9 @@ rule("qt.shared")
         import("load")(target, {frameworks = {"QtCore"}})
     end)
 
+    after_install("windows", "install.windows")
+    after_install("mingw", "install.mingw")
+
 -- define rule: qt console
 rule("qt.console")
     add_deps("qt.qrc", "qt.ui", "qt.moc", "qt.ts")


### PR DESCRIPTION
目前遇到这样一种情况：

```lua
target("qtsqlshared")
    ...
    add_rules("qt.shared")
    add_files(...)
    add_frameworks("QtCore", "QtGui", "QtWidgets", "QtSql")

target("app")
    ...
    add_rules("qt.widgetapp")
    add_files(...)
    add_deps("qtsqlshared")
    add_frameworks("QtCore", "QtGui", "QtWidgets")
```

对于上述程序xmake run运行正常，但在xmake install后运行会出现运行时异常，但并不是提示缺少dll文件，经排查运行异常原因是缺少qtsql所用到的这些文件：

```
sqldrivers/qsqlited.dll
sqldrivers/qsqlodbcd.dll
sqldrivers/qsqlpsqld.dll
...
```

也就是target("qtsqlshared")所需要的运行dll，在对target("qtsqlshared")执行windeployqt后上述文件正常拷贝，xmake install后运行正常，故提此pr