### PR TITLE
Add support for automatically using windows system proxy

### DIFF
--- a/xmake/modules/net/proxy.lua
+++ b/xmake/modules/net/proxy.lua
@@ -109,7 +109,7 @@ function _system_proxy()
         return proxy
     end
 
-    if os.host() == "windows" then
+    if is_host("windows") then
         -- Check whether system proxy is enabled
         local proxy_enable = winos.registry_query('HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings;ProxyEnable')
         --  Verify that the proxy is enabled (0x1 means enabled)
@@ -136,7 +136,7 @@ end
 -- translate global proxy
 function _global_proxy()
     local proxy = global.get("proxy")
-    if proxy and string.lower(proxy) == "system" then
+    if proxy and proxy:lower() == "system" then
         return _system_proxy()
     end
     return proxy

--- a/xmake/modules/net/proxy.lua
+++ b/xmake/modules/net/proxy.lua
@@ -102,6 +102,46 @@ function mirror(url)
     return url
 end
 
+-- get system proxy
+function _system_proxy()
+    local proxy = os.getenv("ALL_PROXY") or os.getenv("HTTP_PROXY") or os.getenv("HTTPS_PROXY")
+    if proxy then
+        return proxy
+    end
+
+    if os.host() == "windows" then
+        -- Check whether system proxy is enabled
+        local proxy_enable = winos.registry_query('HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings;ProxyEnable')
+        --  Verify that the proxy is enabled (0x1 means enabled)
+        if not proxy_enable or proxy_enable ~= "1" then
+            return nil
+        end
+
+        -- Extract the proxy server address
+        local proxy_server = winos.registry_query("HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings;ProxyServer")
+        if not proxy_server then
+            return nil
+        end
+
+        -- Prepend the protocol if not present
+        if not proxy_server:match("://(.-)") then
+            proxy_server = "http://" .. proxy_server
+        end
+        return proxy_server
+    end
+
+    return nil
+end
+
+-- translate global proxy
+function _global_proxy()
+    local proxy = global.get("proxy")
+    if proxy and string.lower(proxy) == "system" then
+        return _system_proxy()
+    end
+    return proxy
+end
+
 -- get proxy configuration from the given url, [protocol://]host[:port]
 --
 -- @see https://github.com/xmake-io/xmake/issues/854
@@ -119,7 +159,7 @@ function config(url)
             for _, proxy_host in ipairs(proxy_hosts) do
                 proxy_host = proxy_host:lower()
                 if host == proxy_hosts or host:match(_host_pattern(proxy_host)) then
-                    return global.get("proxy")
+                    return _global_proxy()
                 end
             end
         end
@@ -127,16 +167,16 @@ function config(url)
         -- filter proxy host from the pac file
         local proxy_pac = _proxy_pac()
         if proxy_pac and host and _is_callable(proxy_pac) and proxy_pac(url, host) then
-            return global.get("proxy")
+            return _global_proxy()
         end
 
         -- use global proxy
         if not proxy_pac and not proxy_hosts then
-            return global.get("proxy")
+            return _global_proxy()
         end
         return
     end
 
     -- enable global proxy
-    return global.get("proxy")
+    return _global_proxy()
 end


### PR DESCRIPTION
在 Windows 上即使开启了系统代理，打开终端后终端也不会继承（Ubuntu 是继承的），暂时不知道 Mac 如何。如果打开终端以后什么都不做，xmake install 或者 xmake update 从 github 执行下载就会出错。

新增功能：如果先全局设置`xmake g --proxy=system`，就会自动使用 Windows 系统代理。默认不开。

这个功能是参考 vcpkg 的。