### PR TITLE
Support customizing `implib` path of MinGW/MSVC

### DIFF
--- a/xmake/actions/package/oldpkg/main.lua
+++ b/xmake/actions/package/oldpkg/main.lua
@@ -48,11 +48,19 @@ function _package_library(target)
 
     -- copy *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/787
-    if target:is_shared() and target:is_plat("windows", "mingw") then
-        local targetfile = target:targetfile()
-        local targetfile_lib = path.join(path.directory(targetfile), path.basename(targetfile) .. ".lib")
-        if os.isfile(targetfile_lib) then
-            os.vcp(targetfile_lib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
+    if target:is_shared() then
+        if target:is_plat("windows") then
+            local targetfile = target:targetfile()
+            local targetfile_lib = path.join(target:implibdir(), path.basename(targetfile) .. ".lib")
+            if os.isfile(targetfile_lib) then
+                os.vcp(targetfile_lib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
+            end
+        elseif target:is_plat("mingw") then
+            local targetfile = target:targetfile()
+            local targetfile_lib = path.join(target:implibdir(), path.basename(targetfile) .. ".dll.a")
+            if os.isfile(targetfile_lib) then
+                os.vcp(targetfile_lib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
+            end
         end
     end
 

--- a/xmake/actions/package/oldpkg/main.lua
+++ b/xmake/actions/package/oldpkg/main.lua
@@ -48,11 +48,9 @@ function _package_library(target)
 
     -- copy *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/787
-    if target:has_implib() then
-        local target_implib = target:artifactfile("lib")
-        if os.isfile(target_implib) then
-            os.vcp(target_implib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
-        end
+    local target_implib = target:byproduct("implib")
+    if target_implib and os.isfile(target_implib) then
+        os.vcp(target_implib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
     end
 
     -- copy headers

--- a/xmake/actions/package/oldpkg/main.lua
+++ b/xmake/actions/package/oldpkg/main.lua
@@ -48,7 +48,7 @@ function _package_library(target)
 
     -- copy *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/787
-    local target_implib = target:byproduct("implib")
+    local target_implib = target:artifactfile("implib")
     if target_implib and os.isfile(target_implib) then
         os.vcp(target_implib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
     end

--- a/xmake/actions/package/oldpkg/main.lua
+++ b/xmake/actions/package/oldpkg/main.lua
@@ -48,9 +48,11 @@ function _package_library(target)
 
     -- copy *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/787
-    local target_implib = target:implibfile()
-    if target_implib and os.isfile(target_implib) then
-        os.vcp(target_implib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
+    if target:has_implib() then
+        local target_implib = target:artifactfile("lib")
+        if os.isfile(target_implib) then
+            os.vcp(target_implib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
+        end
     end
 
     -- copy headers

--- a/xmake/actions/package/oldpkg/main.lua
+++ b/xmake/actions/package/oldpkg/main.lua
@@ -48,20 +48,9 @@ function _package_library(target)
 
     -- copy *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/787
-    if target:is_shared() then
-        if target:is_plat("windows") then
-            local targetfile = target:targetfile()
-            local targetfile_lib = path.join(target:implibdir(), path.basename(targetfile) .. ".lib")
-            if os.isfile(targetfile_lib) then
-                os.vcp(targetfile_lib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
-            end
-        elseif target:is_plat("mingw") then
-            local targetfile = target:targetfile()
-            local targetfile_lib = path.join(target:implibdir(), path.basename(targetfile) .. ".dll.a")
-            if os.isfile(targetfile_lib) then
-                os.vcp(targetfile_lib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
-            end
-        end
+    local target_implib = target:implibfile()
+    if target_implib and os.isfile(target_implib) then
+        os.vcp(target_implib, format("%s/%s.pkg/$(plat)/$(arch)/lib/$(mode)/", outputdir, targetname))
     end
 
     -- copy headers

--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -1643,6 +1643,13 @@ function _instance:artifactdir(type)
 end
 
 -- get the build artifact output file
+--
+-- supported artifact types:
+--    1. bin: executable(.exe, Unix Executables), windows shared library(.dll)
+--    2. lib: static library(.lib, .a), windows DLL implib(.lib, .dll.a), non-windows shared library(.so, .dylib)
+--
+-- otherwise returns nil
+--
 function _instance:artifactfile(type)
     if type == "bin" then
         -- executable, windows shared library
@@ -1676,14 +1683,7 @@ function _instance:artifactfile(type)
     end
 
     -- to be added...
-    return nil
-end
 
--- get the implib file (windows shared library only)
-function _instance:implibfile()
-    if self:has_implib() then
-        return self:artifactfile("lib")
-    end
     return nil
 end
 
@@ -2565,7 +2565,8 @@ end
 
 -- has implib artifact file?
 --
--- equivalent to "is_windows_shared_library"
+-- returns true if the target is a windows shared library
+--
 function _instance:has_implib()
     return self:is_shared() and self:is_plat("windows", "mingw")
 end

--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -1644,14 +1644,14 @@ function _instance:_targetdir_extra(kind)
     return targetdir
 end
 
--- get the build byproduct file
+-- get the extra build artifact file
 --
--- supported byproduct kinds:
+-- supported artifact kinds:
 --    1. implib: windows DLL implib(.lib, .dll.a)
 --
 -- otherwise returns nil
 --
-function _instance:byproduct(kind)
+function _instance:artifactfile(kind)
     if kind == "implib" then
         if self:is_shared() and self:is_plat("windows", "mingw") then
             return path.join(self:_targetdir_extra("libdir"), path.basename(self:filename()) .. (self:is_plat("mingw") and ".dll.a" or ".lib"))

--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -1611,18 +1611,20 @@ function _instance:implibdir()
         return nil
     end
 
-    local targetdir = self:extraconf("targetdir") or {}
-    local implibdir = nil
-    for _, v in pairs(targetdir) do
-        if type(v) == "table" then
-            implibdir = v["implibdir"]
-        end
-        break
-    end
+    local implibdir = self:get("implibdir")
     if not implibdir then
-        return self:targetdir()
+        implibdir = self:targetdir()
     end
     return implibdir
+end
+
+-- get the imp-lib file (only on windows)
+function _instance:implibfile()
+    local implibdir = self:implibdir()
+    if not implibdir then
+        return nil
+    end
+    return path.join(implibdir, path.basename(self:targetfile()) .. (self:is_plat("mingw") and ".dll.a" or ".lib"))
 end
 
 -- get the target file name
@@ -2916,6 +2918,7 @@ function target.apis()
             -- target.set_xxx
             "target.set_targetdir"
         ,   "target.set_objectdir"
+        ,   "target.set_implibdir"
         ,   "target.set_dependir"
         ,   "target.set_autogendir"
         ,   "target.set_configdir"

--- a/xmake/core/project/target.lua
+++ b/xmake/core/project/target.lua
@@ -1605,6 +1605,26 @@ function _instance:targetdir()
     return targetdir
 end
 
+-- get the imp-lib directory (only on windows)
+function _instance:implibdir()
+    if not ((self:is_plat("windows", "mingw")) and self:is_shared()) then
+        return nil
+    end
+
+    local targetdir = self:extraconf("targetdir") or {}
+    local implibdir = nil
+    for _, v in pairs(targetdir) do
+        if type(v) == "table" then
+            implibdir = v["implibdir"]
+        end
+        break
+    end
+    if not implibdir then
+        return self:targetdir()
+    end
+    return implibdir
+end
+
 -- get the target file name
 function _instance:filename()
 

--- a/xmake/core/tool/linker.lua
+++ b/xmake/core/tool/linker.lua
@@ -67,21 +67,6 @@ function linker:_add_flags_from_linker(flags)
     end
 end
 
--- add implib-dir to the options
-function linker:_add_implib_to_options(opt)
-    opt = opt or {}
-    if not opt.implib then
-        local target = self:target()
-        if target:type() == "target" then
-            local impblibfile = target:implibfile()
-            if impblibfile then
-                opt.implib = impblibfile
-            end
-        end
-    end
-    return opt
-end
-
 -- load tool
 function linker._load_tool(targetkind, sourcekinds, target)
 
@@ -244,8 +229,6 @@ function linker:link(objectfiles, targetfile, opt)
     opt = table.copy(opt)
     opt.target = self:target()
 
-    opt = self:_add_implib_to_options(opt)
-
     profiler:enter(self:name(), "link", targetfile)
     local ok, errors = sandbox.load(self:_tool().link, self:_tool(), table.wrap(objectfiles), self:_targetkind(), targetfile, linkflags, opt)
     profiler:leave(self:name(), "link", targetfile)
@@ -254,13 +237,11 @@ end
 
 -- get the link arguments list
 function linker:linkargv(objectfiles, targetfile, opt)
-    opt = self:_add_implib_to_options(opt)
     return self:_tool():linkargv(table.wrap(objectfiles), self:_targetkind(), targetfile, opt.linkflags or self:linkflags(opt), opt)
 end
 
 -- get the link command
 function linker:linkcmd(objectfiles, targetfile, opt)
-    opt = self:_add_implib_to_options(opt)
     return os.args(table.join(self:linkargv(objectfiles, targetfile, opt)))
 end
 

--- a/xmake/core/tool/linker.lua
+++ b/xmake/core/tool/linker.lua
@@ -68,14 +68,14 @@ function linker:_add_flags_from_linker(flags)
 end
 
 -- add implib-dir to the options
-function linker:_add_implibdir_to_options(opt)
+function linker:_add_implib_to_options(opt)
     opt = opt or {}
-    if not opt.implibdir then
+    if not opt.implib then
         local target = self:target()
         if target:type() == "target" then
-            local implibdir = target:implibdir()
-            if implibdir then
-                opt.implibdir = implibdir
+            local impblibfile = target:implibfile()
+            if impblibfile then
+                opt.implib = impblibfile
             end
         end
     end
@@ -244,7 +244,7 @@ function linker:link(objectfiles, targetfile, opt)
     opt = table.copy(opt)
     opt.target = self:target()
 
-    opt = self:_add_implibdir_to_options(opt)
+    opt = self:_add_implib_to_options(opt)
 
     profiler:enter(self:name(), "link", targetfile)
     local ok, errors = sandbox.load(self:_tool().link, self:_tool(), table.wrap(objectfiles), self:_targetkind(), targetfile, linkflags, opt)
@@ -254,13 +254,13 @@ end
 
 -- get the link arguments list
 function linker:linkargv(objectfiles, targetfile, opt)
-    opt = self:_add_implibdir_to_options(opt)
+    opt = self:_add_implib_to_options(opt)
     return self:_tool():linkargv(table.wrap(objectfiles), self:_targetkind(), targetfile, opt.linkflags or self:linkflags(opt), opt)
 end
 
 -- get the link command
 function linker:linkcmd(objectfiles, targetfile, opt)
-    opt = self:_add_implibdir_to_options(opt)
+    opt = self:_add_implib_to_options(opt)
     return os.args(table.join(self:linkargv(objectfiles, targetfile, opt)))
 end
 

--- a/xmake/core/tool/linker.lua
+++ b/xmake/core/tool/linker.lua
@@ -228,6 +228,11 @@ function linker:link(objectfiles, targetfile, opt)
     local linkflags = opt.linkflags or self:linkflags(opt)
     opt = table.copy(opt)
     opt.target = self:target()
+
+    if self:_targetkind() == "shared" and self:target():implibdir() then
+        opt.implibdir = self:target():implibdir()
+    end
+
     profiler:enter(self:name(), "link", targetfile)
     local ok, errors = sandbox.load(self:_tool().link, self:_tool(), table.wrap(objectfiles), self:_targetkind(), targetfile, linkflags, opt)
     profiler:leave(self:name(), "link", targetfile)

--- a/xmake/core/tool/linker.lua
+++ b/xmake/core/tool/linker.lua
@@ -229,8 +229,11 @@ function linker:link(objectfiles, targetfile, opt)
     opt = table.copy(opt)
     opt.target = self:target()
 
-    if self:_targetkind() == "shared" and self:target():implibdir() then
-        opt.implibdir = self:target():implibdir()
+    if self:target():type() == "target" then
+        local implibdir = self:target():implibdir()
+        if implibdir then
+            opt.implibdir = implibdir
+        end
     end
 
     profiler:enter(self:name(), "link", targetfile)

--- a/xmake/core/tool/linker.lua
+++ b/xmake/core/tool/linker.lua
@@ -228,7 +228,6 @@ function linker:link(objectfiles, targetfile, opt)
     local linkflags = opt.linkflags or self:linkflags(opt)
     opt = table.copy(opt)
     opt.target = self:target()
-
     profiler:enter(self:name(), "link", targetfile)
     local ok, errors = sandbox.load(self:_tool().link, self:_tool(), table.wrap(objectfiles), self:_targetkind(), targetfile, linkflags, opt)
     profiler:leave(self:name(), "link", targetfile)

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -575,10 +575,7 @@ function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
 
     -- add `-Wl,--out-implib,outputdir/libxxx.a` for xxx.dll on mingw/gcc
     if targetkind == "shared" and self:is_plat("mingw") then
-        local implibdir = path.directory(targetfile)
-        if opt.target then
-            implibdir = opt.target:implibdir()
-        end
+        local implibdir = opt.implibdir or path.directory(targetfile)
         table.insert(flags_extra, "-Wl,--out-implib," .. path.join(implibdir, path.basename(targetfile) .. ".dll.a"))
     end
 
@@ -601,8 +598,8 @@ function link(self, objectfiles, targetkind, targetfile, flags, opt)
     os.mkdir(path.directory(targetfile))
 
     -- ensure the implib directory
-    if opt and opt.target and opt.target:implibdir() then
-        os.mkdir(opt.target:implibdir())
+    if opt.implibdir then
+        os.mkdir(opt.implibdir)
     end
 
     local program, argv = linkargv(self, objectfiles, targetkind, targetfile, flags, opt)

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -575,8 +575,8 @@ function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
 
     -- add `-Wl,--out-implib,outputdir/libxxx.a` for xxx.dll on mingw/gcc
     if targetkind == "shared" and self:is_plat("mingw") then
-        local implibdir = opt.implibdir or path.directory(targetfile)
-        table.insert(flags_extra, "-Wl,--out-implib," .. path.join(implibdir, path.basename(targetfile) .. ".dll.a"))
+        local implib = opt.implib or path.join(path.directory(targetfile), path.basename(targetfile) .. ".dll.a")
+        table.insert(flags_extra, "-Wl,--out-implib," .. implib)
     end
 
     -- init arguments
@@ -595,11 +595,13 @@ end
 --
 function link(self, objectfiles, targetkind, targetfile, flags, opt)
     opt = opt or {}
+
+    -- ensure the target directory
     os.mkdir(path.directory(targetfile))
 
     -- ensure the implib directory
-    if opt.implibdir then
-        os.mkdir(opt.implibdir)
+    if opt.implib then
+        os.mkdir(path.directory(opt.implib))
     end
 
     local program, argv = linkargv(self, objectfiles, targetkind, targetfile, flags, opt)

--- a/xmake/modules/core/tools/link.lua
+++ b/xmake/modules/core/tools/link.lua
@@ -137,8 +137,8 @@ function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
         table.insert(argv, 1, "-lib")
     elseif targetkind == "shared" then
         table.insert(argv, 1, "-dll")
-        if opt.implibdir then
-            table.insert(argv, "/IMPLIB:" .. path.join(opt.implibdir, path.basename(targetfile) .. ".lib"))
+        if opt.implib then
+            table.insert(argv, "/IMPLIB:" .. opt.implib)
         end
     end
     return self:program(), argv
@@ -151,8 +151,8 @@ function link(self, objectfiles, targetkind, targetfile, flags, opt)
     os.mkdir(path.directory(targetfile))
 
     -- ensure the implib directory
-    if opt and opt.implibdir then
-        os.mkdir(opt.implibdir)
+    if opt and opt.implib then
+        os.mkdir(path.directory(opt.implib))
     end
 
     try

--- a/xmake/modules/core/tools/link.lua
+++ b/xmake/modules/core/tools/link.lua
@@ -137,6 +137,9 @@ function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
         table.insert(argv, 1, "-lib")
     elseif targetkind == "shared" then
         table.insert(argv, 1, "-dll")
+        if opt.target then
+            table.insert(argv, "/IMPLIB:" .. path.join(opt.target:implibdir(), path.basename(targetfile) .. ".lib"))
+        end
     end
     return self:program(), argv
 end
@@ -146,6 +149,11 @@ function link(self, objectfiles, targetkind, targetfile, flags, opt)
 
     -- ensure the target directory
     os.mkdir(path.directory(targetfile))
+
+    -- ensure the implib directory
+    if opt and opt.target and opt.target:implibdir() then
+        os.mkdir(opt.target:implibdir())
+    end
 
     try
     {

--- a/xmake/modules/core/tools/link.lua
+++ b/xmake/modules/core/tools/link.lua
@@ -137,8 +137,8 @@ function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
         table.insert(argv, 1, "-lib")
     elseif targetkind == "shared" then
         table.insert(argv, 1, "-dll")
-        if opt.target then
-            table.insert(argv, "/IMPLIB:" .. path.join(opt.target:implibdir(), path.basename(targetfile) .. ".lib"))
+        if opt.implibdir then
+            table.insert(argv, "/IMPLIB:" .. path.join(opt.implibdir, path.basename(targetfile) .. ".lib"))
         end
     end
     return self:program(), argv
@@ -151,8 +151,8 @@ function link(self, objectfiles, targetkind, targetfile, flags, opt)
     os.mkdir(path.directory(targetfile))
 
     -- ensure the implib directory
-    if opt and opt.target and opt.target:implibdir() then
-        os.mkdir(opt.target:implibdir())
+    if opt and opt.implibdir then
+        os.mkdir(opt.implibdir)
     end
 
     try

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -275,6 +275,7 @@ end
 
 -- make the link arguments list
 function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
+    opt = opt or {}
 
     -- add rpath for dylib (macho), e.g. -install_name @rpath/file.dylib
     local flags_extra = {}
@@ -287,10 +288,7 @@ function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
 
     -- add `-Wl,--out-implib,outputdir/libxxx.a` for xxx.dll on mingw/gcc
     if targetkind == "shared" and self:is_plat("mingw") then
-        local implibdir = path.directory(targetfile)
-        if opt.target then
-            implibdir = opt.target:implibdir()
-        end
+        local implibdir = opt.implibdir or path.directory(targetfile)
         table.insert(flags_extra, "-Xlinker")
         table.insert(flags_extra, "-Wl,--out-implib," .. path.join(implibdir, path.basename(targetfile) .. ".dll.a"))
     end
@@ -304,8 +302,8 @@ function link(self, objectfiles, targetkind, targetfile, flags, opt)
     os.mkdir(path.directory(targetfile))
 
     -- ensure the implib directory
-    if opt and opt.target and opt.target:implibdir() then
-        os.mkdir(opt.target:implibdir())
+    if opt and opt.implibdir then
+        os.mkdir(opt.implibdir)
     end
 
     local program, argv = linkargv(self, objectfiles, targetkind, targetfile, flags, opt)

--- a/xmake/modules/core/tools/nvcc.lua
+++ b/xmake/modules/core/tools/nvcc.lua
@@ -288,9 +288,9 @@ function linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
 
     -- add `-Wl,--out-implib,outputdir/libxxx.a` for xxx.dll on mingw/gcc
     if targetkind == "shared" and self:is_plat("mingw") then
-        local implibdir = opt.implibdir or path.directory(targetfile)
+        local implib = opt.implib or path.join(path.directory(targetfile), path.basename(targetfile) .. ".dll.a")
         table.insert(flags_extra, "-Xlinker")
-        table.insert(flags_extra, "-Wl,--out-implib," .. path.join(implibdir, path.basename(targetfile) .. ".dll.a"))
+        table.insert(flags_extra, "-Wl,--out-implib," .. implib)
     end
 
     -- make link args
@@ -299,11 +299,13 @@ end
 
 -- link the target file
 function link(self, objectfiles, targetkind, targetfile, flags, opt)
+    
+    -- ensure the target directory
     os.mkdir(path.directory(targetfile))
 
     -- ensure the implib directory
-    if opt and opt.implibdir then
-        os.mkdir(opt.implibdir)
+    if opt and opt.implib then
+        os.mkdir(path.directory(opt.implib))
     end
 
     local program, argv = linkargv(self, objectfiles, targetkind, targetfile, flags, opt)

--- a/xmake/modules/private/action/build/link_objects.lua
+++ b/xmake/modules/private/action/build/link_objects.lua
@@ -49,11 +49,11 @@ function _do_link_target(target, opt)
 
         if verbose then
             -- show the full link command with raw arguments, it will expand @xxx.args for msvc/link on windows
-            print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, implib = target:byproduct("implib"), rawargs = true}))
+            print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, implib = target:artifactfile("implib"), rawargs = true}))
         end
 
         if not dryrun then
-            assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags, implib = target:byproduct("implib")}))
+            assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags, implib = target:artifactfile("implib")}))
         end
     end, {dependfile = target:dependfile(),
           lastmtime = os.mtime(target:targetfile()),

--- a/xmake/modules/private/action/build/link_objects.lua
+++ b/xmake/modules/private/action/build/link_objects.lua
@@ -48,11 +48,13 @@ function _do_link_target(target, opt)
         local verbose = option.get("verbose")
         if verbose then
             -- show the full link command with raw arguments, it will expand @xxx.args for msvc/link on windows
-            print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, rawargs = true}))
+            print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, implib = target:implibfile(), rawargs = true}))
         end
 
+        print("TO LINK: ", target:name(), target:implibfile(), targetfile)
+
         if not dryrun then
-            assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags}))
+            assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags, implib = target:implibfile()}))
         end
     end, {dependfile = target:dependfile(),
           lastmtime = os.mtime(target:targetfile()),

--- a/xmake/modules/private/action/build/link_objects.lua
+++ b/xmake/modules/private/action/build/link_objects.lua
@@ -46,13 +46,19 @@ function _do_link_target(target, opt)
         local targetfile = target:targetfile()
         local objectfiles = target:objectfiles()
         local verbose = option.get("verbose")
+
+        local target_implib = nil
+        if target:has_implib() then
+            target_implib = target:artifactfile("lib")
+        end
+
         if verbose then
             -- show the full link command with raw arguments, it will expand @xxx.args for msvc/link on windows
-            print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, implib = target:implibfile(), rawargs = true}))
+            print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, implib = target_implib, rawargs = true}))
         end
 
         if not dryrun then
-            assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags, implib = target:implibfile()}))
+            assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags, implib = target_implib}))
         end
     end, {dependfile = target:dependfile(),
           lastmtime = os.mtime(target:targetfile()),

--- a/xmake/modules/private/action/build/link_objects.lua
+++ b/xmake/modules/private/action/build/link_objects.lua
@@ -51,8 +51,6 @@ function _do_link_target(target, opt)
             print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, implib = target:implibfile(), rawargs = true}))
         end
 
-        print("TO LINK: ", target:name(), target:implibfile(), targetfile)
-
         if not dryrun then
             assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags, implib = target:implibfile()}))
         end

--- a/xmake/modules/private/action/build/link_objects.lua
+++ b/xmake/modules/private/action/build/link_objects.lua
@@ -47,18 +47,13 @@ function _do_link_target(target, opt)
         local objectfiles = target:objectfiles()
         local verbose = option.get("verbose")
 
-        local target_implib = nil
-        if target:has_implib() then
-            target_implib = target:artifactfile("lib")
-        end
-
         if verbose then
             -- show the full link command with raw arguments, it will expand @xxx.args for msvc/link on windows
-            print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, implib = target_implib, rawargs = true}))
+            print(linkinst:linkcmd(objectfiles, targetfile, {linkflags = linkflags, implib = target:byproduct("implib"), rawargs = true}))
         end
 
         if not dryrun then
-            assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags, implib = target_implib}))
+            assert(linkinst:link(objectfiles, targetfile, {linkflags = linkflags, implib = target:byproduct("implib")}))
         end
     end, {dependfile = target:dependfile(),
           lastmtime = os.mtime(target:targetfile()),

--- a/xmake/modules/target/action/clean/main.lua
+++ b/xmake/modules/target/action/clean/main.lua
@@ -39,7 +39,7 @@ function main(target)
     -- @see https://github.com/xmake-io/xmake/issues/3052
     if target:is_shared() then
         if target:is_plat("windows") then
-            local libfile = target:byproduct("implib")
+            local libfile = target:artifactfile("implib")
             local expfile = path.join(path.directory(libfile), path.basename(targetfile) .. ".exp")
             if os.isfile(libfile) then
                 remove_files(libfile)
@@ -50,7 +50,7 @@ function main(target)
         end
 
         if target:is_plat("mingw") then
-            local libfile = target:byproduct("implib")
+            local libfile = target:artifactfile("implib")
             if os.isfile(libfile) then
                 remove_files(libfile)
             end

--- a/xmake/modules/target/action/clean/main.lua
+++ b/xmake/modules/target/action/clean/main.lua
@@ -45,9 +45,11 @@ function main(target)
             end
         end
 
-        local implibfile = target:implibfile()
-        if implibfile and os.isfile(implibfile) then
-            remove_files(implibfile)
+        if target:has_implib() then
+            local libfile = target:artifactfile("lib")
+            if os.isfile(libfile) then
+                remove_files(libfile)
+            end
         end
     end
 

--- a/xmake/modules/target/action/clean/main.lua
+++ b/xmake/modules/target/action/clean/main.lua
@@ -39,7 +39,7 @@ function main(target)
     -- @see https://github.com/xmake-io/xmake/issues/3052
     if target:is_shared() then
         if target:is_plat("windows") then
-            local expfile = path.join(target:implibdir(), path.basename(targetfile) .. ".exp")
+            local expfile = path.join(target:artifactdir("lib"), path.basename(targetfile) .. ".exp")
             if os.isfile(expfile) then
                 remove_files(expfile)
             end

--- a/xmake/modules/target/action/clean/main.lua
+++ b/xmake/modules/target/action/clean/main.lua
@@ -37,12 +37,19 @@ function main(target)
 
     -- remove import library of the target file
     -- @see https://github.com/xmake-io/xmake/issues/3052
-    if target:is_plat("windows") and target:is_shared() then
-        local expfile = path.join(path.directory(targetfile), path.basename(targetfile) .. ".exp")
-        local libfile = path.join(path.directory(targetfile), path.basename(targetfile) .. ".lib")
-        if os.isfile(expfile) then
-            remove_files(libfile)
-            remove_files(expfile)
+    if target:is_shared() then
+        if target:is_plat("windows") then
+            local expfile = path.join(target:implibdir(), path.basename(targetfile) .. ".exp")
+            local libfile = path.join(target:implibdir(), path.basename(targetfile) .. ".lib")
+            if os.isfile(expfile) then
+                remove_files(libfile)
+                remove_files(expfile)
+            end
+        elseif target:is_plat("mingw") then
+            local libfile = path.join(target:implibdir(), path.basename(targetfile) .. ".dll.a")
+            if os.isfile(libfile) then
+                remove_files(libfile)
+            end
         end
     end
 

--- a/xmake/modules/target/action/clean/main.lua
+++ b/xmake/modules/target/action/clean/main.lua
@@ -39,14 +39,18 @@ function main(target)
     -- @see https://github.com/xmake-io/xmake/issues/3052
     if target:is_shared() then
         if target:is_plat("windows") then
-            local expfile = path.join(target:artifactdir("lib"), path.basename(targetfile) .. ".exp")
+            local libfile = target:byproduct("implib")
+            local expfile = path.join(path.directory(libfile), path.basename(targetfile) .. ".exp")
+            if os.isfile(libfile) then
+                remove_files(libfile)
+            end
             if os.isfile(expfile) then
                 remove_files(expfile)
             end
         end
 
-        if target:has_implib() then
-            local libfile = target:artifactfile("lib")
+        if target:is_plat("mingw") then
+            local libfile = target:byproduct("implib")
             if os.isfile(libfile) then
                 remove_files(libfile)
             end

--- a/xmake/modules/target/action/clean/main.lua
+++ b/xmake/modules/target/action/clean/main.lua
@@ -40,16 +40,14 @@ function main(target)
     if target:is_shared() then
         if target:is_plat("windows") then
             local expfile = path.join(target:implibdir(), path.basename(targetfile) .. ".exp")
-            local libfile = path.join(target:implibdir(), path.basename(targetfile) .. ".lib")
             if os.isfile(expfile) then
-                remove_files(libfile)
                 remove_files(expfile)
             end
-        elseif target:is_plat("mingw") then
-            local libfile = path.join(target:implibdir(), path.basename(targetfile) .. ".dll.a")
-            if os.isfile(libfile) then
-                remove_files(libfile)
-            end
+        end
+
+        local implibfile = target:implibfile()
+        if implibfile and os.isfile(implibfile) then
+            remove_files(implibfile)
         end
     end
 

--- a/xmake/modules/target/action/install/main.lua
+++ b/xmake/modules/target/action/install/main.lua
@@ -232,7 +232,7 @@ function _install_shared(target, opt)
     os.mkdir(bindir)
     local targetfile = target:targetfile()
 
-    if target:is_plat("windows", "mingw") and target:is_shared() then
+    if target:has_implib() then
         -- install *.lib for shared/windows (*.dll) target
         -- @see https://github.com/xmake-io/xmake/issues/714
         os.vcp(target:targetfile(), bindir)

--- a/xmake/modules/target/action/install/main.lua
+++ b/xmake/modules/target/action/install/main.lua
@@ -237,7 +237,7 @@ function _install_shared(target, opt)
         -- @see https://github.com/xmake-io/xmake/issues/714
         os.vcp(target:targetfile(), bindir)
         local libdir = _get_target_libdir(target, opt)
-        local target_implib = target:byproduct("implib")
+        local target_implib = target:artifactfile("implib")
         if os.isfile(target_implib) then
             os.mkdir(libdir)
             os.vcp(target_implib, libdir)

--- a/xmake/modules/target/action/install/main.lua
+++ b/xmake/modules/target/action/install/main.lua
@@ -237,7 +237,7 @@ function _install_shared(target, opt)
         -- @see https://github.com/xmake-io/xmake/issues/714
         os.vcp(target:targetfile(), bindir)
         local libdir = _get_target_libdir(target, opt)
-        local target_implib = target:implibfile()
+        local target_implib = target:artifact("lib")
         if os.isfile(target_implib) then
             os.mkdir(libdir)
             os.vcp(target_implib, libdir)

--- a/xmake/modules/target/action/install/main.lua
+++ b/xmake/modules/target/action/install/main.lua
@@ -232,12 +232,12 @@ function _install_shared(target, opt)
     os.mkdir(bindir)
     local targetfile = target:targetfile()
 
-    if target:has_implib() then
+    if target:is_plat("windows", "mingw") then
         -- install *.lib for shared/windows (*.dll) target
         -- @see https://github.com/xmake-io/xmake/issues/714
         os.vcp(target:targetfile(), bindir)
         local libdir = _get_target_libdir(target, opt)
-        local target_implib = target:artifact("lib")
+        local target_implib = target:byproduct("implib")
         if os.isfile(target_implib) then
             os.mkdir(libdir)
             os.vcp(target_implib, libdir)

--- a/xmake/modules/target/action/install/main.lua
+++ b/xmake/modules/target/action/install/main.lua
@@ -232,12 +232,12 @@ function _install_shared(target, opt)
     os.mkdir(bindir)
     local targetfile = target:targetfile()
 
-    if target:is_plat("windows", "mingw") then
+    if target:is_plat("windows", "mingw") and target:is_shared() then
         -- install *.lib for shared/windows (*.dll) target
         -- @see https://github.com/xmake-io/xmake/issues/714
         os.vcp(target:targetfile(), bindir)
         local libdir = _get_target_libdir(target, opt)
-        local targetfile_lib = path.join(path.directory(targetfile), path.basename(targetfile) .. (target:is_plat("mingw") and ".dll.a" or ".lib"))
+        local targetfile_lib = path.join(target:implibdir(), path.basename(targetfile) .. (target:is_plat("mingw") and ".dll.a" or ".lib"))
         if os.isfile(targetfile_lib) then
             os.mkdir(libdir)
             os.vcp(targetfile_lib, libdir)

--- a/xmake/modules/target/action/install/main.lua
+++ b/xmake/modules/target/action/install/main.lua
@@ -237,10 +237,10 @@ function _install_shared(target, opt)
         -- @see https://github.com/xmake-io/xmake/issues/714
         os.vcp(target:targetfile(), bindir)
         local libdir = _get_target_libdir(target, opt)
-        local targetfile_lib = path.join(target:implibdir(), path.basename(targetfile) .. (target:is_plat("mingw") and ".dll.a" or ".lib"))
-        if os.isfile(targetfile_lib) then
+        local target_implib = target:implibfile()
+        if os.isfile(target_implib) then
             os.mkdir(libdir)
-            os.vcp(targetfile_lib, libdir)
+            os.vcp(target_implib, libdir)
         end
     else
         -- install target with soname and symlink

--- a/xmake/plugins/pack/batchcmds.lua
+++ b/xmake/plugins/pack/batchcmds.lua
@@ -303,11 +303,13 @@ function _on_target_installcmd_shared(target, batchcmds_, opt)
 
     -- install *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/714
-    local targetfile = target:targetfile()
-    local targetfile_lib = path.join(path.directory(targetfile), path.basename(targetfile) .. (target:is_plat("mingw") and ".dll.a" or ".lib"))
-    if os.isfile(targetfile_lib) then
-        batchcmds_:mkdir(libdir)
-        batchcmds_:cp(targetfile_lib, path.join(libdir, path.filename(targetfile_lib)))
+    if target:is_plat("windows", "mingw") and target:is_shared() then
+        local targetfile = target:targetfile()
+        local targetfile_lib = path.join(target:implibdir(), path.basename(targetfile) .. (target:is_plat("mingw") and ".dll.a" or ".lib"))
+        if os.isfile(targetfile_lib) then
+            batchcmds_:mkdir(libdir)
+            batchcmds_:cp(targetfile_lib, path.join(libdir, path.filename(targetfile_lib)))
+        end
     end
 
     _install_target_headers(target, batchcmds_, opt)

--- a/xmake/plugins/pack/batchcmds.lua
+++ b/xmake/plugins/pack/batchcmds.lua
@@ -303,13 +303,10 @@ function _on_target_installcmd_shared(target, batchcmds_, opt)
 
     -- install *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/714
-    
-    if target:has_implib() then
-        local target_implib = target:artifactfile("lib")
-        if os.isfile(target_implib) then
-            batchcmds_:mkdir(libdir)
-            batchcmds_:cp(target_implib, path.join(libdir, path.filename(target_implib)))
-        end
+    local target_implib = target:byproduct("implib")
+    if target_implib and os.isfile(target_implib) then
+        batchcmds_:mkdir(libdir)
+        batchcmds_:cp(target_implib, path.join(libdir, path.filename(target_implib)))
     end
 
     _install_target_headers(target, batchcmds_, opt)

--- a/xmake/plugins/pack/batchcmds.lua
+++ b/xmake/plugins/pack/batchcmds.lua
@@ -303,13 +303,10 @@ function _on_target_installcmd_shared(target, batchcmds_, opt)
 
     -- install *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/714
-    if target:is_plat("windows", "mingw") and target:is_shared() then
-        local targetfile = target:targetfile()
-        local targetfile_lib = path.join(target:implibdir(), path.basename(targetfile) .. (target:is_plat("mingw") and ".dll.a" or ".lib"))
-        if os.isfile(targetfile_lib) then
-            batchcmds_:mkdir(libdir)
-            batchcmds_:cp(targetfile_lib, path.join(libdir, path.filename(targetfile_lib)))
-        end
+    local target_implib = target:implibfile()
+    if target_implib and os.isfile(target_implib) then
+        batchcmds_:mkdir(libdir)
+        batchcmds_:cp(target_implib, path.join(libdir, path.filename(target_implib)))
     end
 
     _install_target_headers(target, batchcmds_, opt)

--- a/xmake/plugins/pack/batchcmds.lua
+++ b/xmake/plugins/pack/batchcmds.lua
@@ -303,7 +303,7 @@ function _on_target_installcmd_shared(target, batchcmds_, opt)
 
     -- install *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/714
-    local target_implib = target:byproduct("implib")
+    local target_implib = target:artifactfile("implib")
     if target_implib and os.isfile(target_implib) then
         batchcmds_:mkdir(libdir)
         batchcmds_:cp(target_implib, path.join(libdir, path.filename(target_implib)))

--- a/xmake/plugins/pack/batchcmds.lua
+++ b/xmake/plugins/pack/batchcmds.lua
@@ -303,10 +303,13 @@ function _on_target_installcmd_shared(target, batchcmds_, opt)
 
     -- install *.lib for shared/windows (*.dll) target
     -- @see https://github.com/xmake-io/xmake/issues/714
-    local target_implib = target:implibfile()
-    if target_implib and os.isfile(target_implib) then
-        batchcmds_:mkdir(libdir)
-        batchcmds_:cp(target_implib, path.join(libdir, path.filename(target_implib)))
+    
+    if target:has_implib() then
+        local target_implib = target:artifactfile("lib")
+        if os.isfile(target_implib) then
+            batchcmds_:mkdir(libdir)
+            batchcmds_:cp(target_implib, path.join(libdir, path.filename(target_implib)))
+        end
     end
 
     _install_target_headers(target, batchcmds_, opt)

--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -80,8 +80,9 @@ function main(target)
             end
         end
 
-        if target:has_implib() then
-            _add_export_value(target, "linkdirs", target:artifactdir("lib"))
+        local target_implib = target:byproduct("implib")
+        if target_implib then
+            _add_export_value(target, "linkdirs", path.directory(target_implib))
         else
             _add_export_value(target, "linkdirs", path.directory(targetfile))
         end

--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -80,9 +80,8 @@ function main(target)
             end
         end
 
-        local implibdir = target:implibdir()
-        if implibdir then
-            _add_export_value(target, "linkdirs", implibdir)
+        if target:has_implib() then
+            _add_export_value(target, "linkdirs", target:artifactdir("lib"))
         else
             _add_export_value(target, "linkdirs", path.directory(targetfile))
         end

--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -80,7 +80,13 @@ function main(target)
             end
         end
 
-        _add_export_value(target, "linkdirs", path.directory(targetfile))
+        local implibdir = target:implibdir()
+        if implibdir then
+            _add_export_value(target, "linkdirs", implibdir)
+        else
+            _add_export_value(target, "linkdirs", path.directory(targetfile))
+        end
+
         if target:rule("go") then
             -- we need to add includedirs to support import modules for golang
             _add_export_value(target, "includedirs", path.directory(targetfile))

--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -80,7 +80,7 @@ function main(target)
             end
         end
 
-        local target_implib = target:byproduct("implib")
+        local target_implib = target:artifactfile("implib")
         if target_implib then
             _add_export_value(target, "linkdirs", path.directory(target_implib))
         else


### PR DESCRIPTION
#3052 
我很久以前问过关于设置一个动态库目标`dll`和`lib`文件输出目录分离的问题，当时作者给的答复是不希望给 MSVC 特有的功能设置新的 API，当时比较忙就没继续跟进。

这段时间读了很久源码，大致知道了 xmake 工作流程，发现了一些问题。
1. xmake 源码里有超过 10 处位置对`.lib`或者`.dll.a`进行了特殊处理，而且工具链 nvcc (mingw)、link (msvc)、gcc (mingw) 都被涉及，而且有多处特殊处理是我上次提 issue 之后添加的，说明不止我一个人遇到了与之相关的问题；
2. xmake 工程安装可以在`set_prefixdir`里设置`bindir`、`libdir`把`dll`和`lib`的安装目录分离了，这个功能是去年添加的，这就会导致一个更加匪夷所思的问题，为什么安装的时候允许分离但构建的时候不允许？我暂且认为这是 xmake 设计之初没有考虑周全，CMake 的构建和安装就统一对一个目标的潜在输出文件分为了 RUNTIME/LIBRARY/ARCHIVE 三种类型（虽然我觉得 ARCHIVE 纯粹没必要），我认为一个目标的构建和安装目录的配置最好有一致性，让项目的构建目录结构和安装目录结构保持相同，可以减少出问题的概率；
3. 关于`clean`的问题是我上次提的，f40cd6da49ed65067d4c6060fa3605cdbd994499 这个提交只处理了 MSVC 的输出文件，我补充了 MinGW 的；

结论，我还是希望作者能考虑一下直接支持构建期`dll`和`lib`输出分离。
目前我是通过扩展`set_targetdir`实现的，在后面添加一个形如`{ implibdir = "$(buildir)/lib" }`的 option table 就可以完成，对 msvc/gcc 的 build、clean 和 install 都进行了测试。当然这样一个接口看起来不完美，跟 install 时候的 api 名称不一样，之后名称怎么改可以讨论。如果这个 option 不加，那么整个 xmake 的逻辑与以前完全相同。

目前还差一个小问题，就是修改了`implib`的输出目录以后，还要对工程里其他所有依赖这个动态库的目标增加一个`linkdir`，这个暂时还没实现，目测应该加在`inherit_link`这个模块里。

Sample：
```lua
add_rules("mode.debug")
set_prefixdir("", { bindir = "bin", libdir = "lib64" })

target("hello")
    set_kind("shared")
    add_files("hello.cpp")
    set_targetdir("$(buildir)/bin", { implibdir = "$(buildir)/lib" }) -- 设置 implib 的输出路径
    add_linkdirs("$(buildir)/lib", { interface = true }) -- 现在必须设置 linkdir，否则 main 就会链接失败
target_end()

target("main")
    set_kind("binary")
    add_files("main.cpp")
    add_deps("hello")
    set_targetdir("$(buildir)/bin")
target_end()
```