### PR TITLE
更新了package依赖在安装时找不到so文件的问题

### DIFF
--- a/xmake/modules/target/action/install/main.lua
+++ b/xmake/modules/target/action/install/main.lua
@@ -79,7 +79,7 @@ function _get_target_package_libfiles(target, opt)
         if pkg:enabled() and pkg:get("libfiles") then
             for _, libfile in ipairs(table.wrap(pkg:get("libfiles"))) do
                 local filename = path.filename(libfile)
-                if filename:endswith(".dll") or filename:endswith(".so") or filename:find("%.so%.%d+$") or filename:endswith(".dylib") then
+                if filename:endswith(".dll") or filename:endswith(".so") or filename:find("%.so[%.%d+]+$") or filename:endswith(".dylib") then
                     table.insert(libfiles, libfile)
                 end
             end

--- a/xmake/modules/target/action/uninstall/main.lua
+++ b/xmake/modules/target/action/uninstall/main.lua
@@ -79,7 +79,7 @@ function _get_target_package_libfiles(target, opt)
         if pkg:enabled() and pkg:get("libfiles") then
             for _, libfile in ipairs(table.wrap(pkg:get("libfiles"))) do
                 local filename = path.filename(libfile)
-                if filename:endswith(".dll") or filename:endswith(".so") or filename:find("%.so%.%d+$") or filename:endswith(".dylib") then
+                if filename:endswith(".dll") or filename:endswith(".so") or filename:find("%.so[%.%d+]+$") or filename:endswith(".dylib") then
                     table.insert(libfiles, libfile)
                 end
             end

--- a/xmake/modules/utils/binary/deplibs.lua
+++ b/xmake/modules/utils/binary/deplibs.lua
@@ -81,7 +81,7 @@ function _get_all_depends_by_objdump(binaryfile, opt)
                 else
                     if line:startswith("NEEDED") then
                         local filename = line:split("%s+")[2]
-                        if filename and filename:endswith(".so") or filename:find("%.so%.%d+$") then
+                        if filename and filename:endswith(".so") or filename:find("%.so[%.%d+]+$") then
                             depends = depends or {}
                             table.insert(depends, filename)
                         end
@@ -122,7 +122,7 @@ function _get_all_depends_by_ldd(binaryfile, opt)
                     line = splitinfo[1]
                 end
                 line = line:gsub("%(.+%)", ""):trim()
-                local filename = line:match(".-%.so$") or line:match(".-%.so%.%d+")
+                local filename = line:match(".-%.so$") or line:match(".-%.so[%.%d+]+$")
                 if filename then
                     depends = depends or {}
                     table.insert(depends, filename:trim())

--- a/xmake/plugins/pack/batchcmds.lua
+++ b/xmake/plugins/pack/batchcmds.lua
@@ -92,7 +92,7 @@ function _get_target_package_libfiles(target, opt)
         if pkg:enabled() and pkg:get("libfiles") then
             for _, libfile in ipairs(table.wrap(pkg:get("libfiles"))) do
                 local filename = path.filename(libfile)
-                if filename:endswith(".dll") or filename:endswith(".so") or filename:find("%.so%.%d+$") or filename:endswith(".dylib") then
+                if filename:endswith(".dll") or filename:endswith(".so") or filename:find("%.so[%.%d+]+$") or filename:endswith(".dylib") then
                     table.insert(libfiles, libfile)
                 end
             end


### PR DESCRIPTION
### 前言

原先代码中对于so文件的正则匹配，是如下两种方式

- 匹配以 `.so` 结尾的文件
- 匹配以 `.so.` 加上数字的文件，譬如 `.so.3`

### 遇到的问题

我在自建库中编译 open62541 v1.4.11.1（仓库见：https://github.com/open62541/open62541 ）时

发现 open62541 编译后得到的文件名有如下三个

- libopen62541.so
- libopen62541.so.1.4
- libopen62541.so.1.4.11

安装 target 工程的时候，没有将写在 package 里的 open62541 项目的动态链接库复制到安装目录下

### 进行的调试

下面是我对 xmake 加的 print 调试，可以看到最后没有匹配到 `libopen62541.so.1`，所以没有安装该文件

```plaintext
/home/binlep/.xmake/packages/o/open62541/1.4.11.1/1eaf35dd2b1b4193b001d4e326c75559/lib/libopen62541.so
insert: libopen62541.so
/home/binlep/.xmake/packages/o/open62541/1.4.11.1/1eaf35dd2b1b4193b001d4e326c75559/lib/libopen62541.so.1.4.11
insert: libopen62541.so.1.4.11
/home/binlep/.xmake/packages/o/open62541/1.4.11.1/1eaf35dd2b1b4193b001d4e326c75559/lib/libopen62541.so.1.4
insert: libopen62541.so.1.4
[before] 1: /home/binlep/.xmake/packages/n/neuron/2.9.3/c0560766883c47e08192c8df493eeaa4/lib/libneuron-base.so
[before] 2: /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so.1
[before] 3: /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so
[before] 4: /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so.1.2.12
[before] 5: /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so.1
[before] 6: /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so
[before] 7: /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so.1.2.12
[before] 8: /home/binlep/.xmake/packages/o/open62541/1.4.11.1/1eaf35dd2b1b4193b001d4e326c75559/lib/libopen62541.so
[before] 9: /home/binlep/.xmake/packages/o/open62541/1.4.11.1/1eaf35dd2b1b4193b001d4e326c75559/lib/libopen62541.so.1.4.11
[before] 10: /home/binlep/.xmake/packages/o/open62541/1.4.11.1/1eaf35dd2b1b4193b001d4e326c75559/lib/libopen62541.so.1.4
[ahas] linux-vdso.so.1
[ahas] /local/opt/edgebox/lib/libneuron-base.so
[ahas] /local/opt/edgebox/lib/libzlog.so.1
[ahas] libopen62541.so.1
[ahas] /usr/lib/libstdc++.so.6
[ahas] /usr/lib/glibc-hwcaps/x86-64-v3/libm.so.6
[ahas] /usr/lib/libgcc_s.so.1
[ahas] /usr/lib/glibc-hwcaps/x86-64-v3/libc.so.6
[ahas] /usr/lib64/ld-linux-x86-64.so.2
[ahas] /usr/lib/libmbedtls.so.12
[ahas] /usr/lib/libmbedx509.so.0
[ahas] /usr/lib/libmbedcrypto.so.3
[ahas] linux-vdso.so.1
[ahas] /local/opt/edgebox/lib/libzlog.so.1
[ahas] /usr/lib/glibc-hwcaps/x86-64-v3/libm.so.6
[ahas] /usr/lib/libmbedtls.so.12
[ahas] /usr/lib/libmbedx509.so.0
[ahas] /usr/lib/libmbedcrypto.so.3
[ahas] /usr/lib/glibc-hwcaps/x86-64-v3/libc.so.6
[ahas] /usr/lib64/ld-linux-x86-64.so.2
[ahas] linux-vdso.so.1
[ahas] /usr/lib/glibc-hwcaps/x86-64-v3/libc.so.6
[ahas] /usr/lib64/ld-linux-x86-64.so.2
[ahas] linux-vdso.so.1
[ahas] /usr/lib/glibc-hwcaps/x86-64-v3/libc.so.6
[ahas] /usr/lib64/ld-linux-x86-64.so.2
[has] libopen62541.so.1
[has] libm.so.6
[has] linux-vdso.so.1
[has] libgcc_s.so.1
[has] libstdc++.so.6
[has] ld-linux-x86-64.so.2
[has] libmbedcrypto.so.3
[has] libc.so.6
[has] libzlog.so.1
[has] libmbedx509.so.0
[has] libmbedtls.so.12
[has] libneuron-base.so
[after] 1: /home/binlep/.xmake/packages/n/neuron/2.9.3/c0560766883c47e08192c8df493eeaa4/lib/libneuron-base.so
[after] 2: /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so.1
[after] 3: /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so.1
> copy /home/binlep/.xmake/packages/n/neuron/2.9.3/c0560766883c47e08192c8df493eeaa4/lib/libneuron-base.so to /local/opt/edgebox/lib/libneuron-base.so
> copy /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so.1.2.12 to /local/opt/edgebox/lib/libzlog.so.1.2.12
> copy /home/binlep/.xmake/packages/z/zlog/1.2.18/cfcfcecae15b428dba4734ce49962298/lib/libzlog.so.1 to /local/opt/edgebox/lib/libzlog.so.1
```
