### PR TITLE
add sdk path to build hash for different toolchains.

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1749,6 +1749,10 @@ function _instance:buildhash()
                 table.sort(toolchains)
                 str = str .. "_" .. table.concat(toolchains, "_")
             end
+            local sdk_path = config.get("sdk")
+            if sdk_path then
+                str = str .. "_" .. tostring(sdk_path)
+            end
             return hash.strhash128(str)
         end
         local function _get_installdir(...)


### PR DESCRIPTION
通过sdk指定工具链由于工具链名字一样，路径不同，通过修改sdk切换不同的工具链时安装库还是用的原来的
