### PR TITLE
(generators) cmake : fix compiler detection if (Gcc) with a more stan…

### DIFF
--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -721,15 +721,15 @@ function _add_target_compile_options(cmakelists, target, outputdir)
     local compilernames = {
         clang = "Clang",
         clangxx = "Clang",
-        gcc = "Gcc",
-        gxx = "Gcc",
+        gcc = "GNU",
+        gxx = "GNU",
         cl = "MSVC",
         link = "MSVC"
     }
     for _, toolname in toolnames:keys() do
         local name = compilernames[toolname]
         if name then
-            cmakelists:print("if(%s)", name)
+            cmakelists:print("if(CMAKE_COMPILER_ID STREQUAL \"%s\")", name)
             _add_target_compile_options_for_compiler(toolname)
             cmakelists:print("endif()")
         end
@@ -756,17 +756,17 @@ function _add_target_values(cmakelists, target, name)
         if name:endswith("s") then
             name = name:sub(1, #name - 1)
         end
-        cmakelists:print("if(MSVC)")
+        cmakelists:print("if(CMAKE_COMPILER_ID STREQUAL \"MSVC\")")
         local flags_cl = _map_compflags("cl", "c", name, values)
         for _, flag in ipairs(flags_cl) do
             cmakelists:print("    target_compile_options(%s PRIVATE %s)", target:name(), flag)
         end
-        cmakelists:print("elseif(Clang)")
+        cmakelists:print("elseif(CMAKE_COMPILER_ID STREQUAL \"Clang\")")
         local flags_clang = _map_compflags("clang", "c", name, values)
         for _, flag in ipairs(flags_clang) do
             cmakelists:print("    target_compile_options(%s PRIVATE %s)", target:name(), flag)
         end
-        cmakelists:print("elseif(Gcc)")
+        cmakelists:print("elseif(CMAKE_COMPILER_ID STREQUAL \"GNU\")")
         local flags_gcc = _map_compflags("gcc", "c", name, values)
         for _, flag in ipairs(flags_gcc) do
             cmakelists:print("    target_compile_options(%s PRIVATE %s)", target:name(), flag)
@@ -833,7 +833,7 @@ function _add_target_languages(cmakelists, target)
                     if flag:endswith('++') then
                         cmakelists:print('foreach(standard 26 23 20 17 14 11 98)')
                         cmakelists:print('    include(CheckCXXCompilerFlag)')
-                        cmakelists:print('    if(MSVC)')
+                        cmakelists:print('    if(CMAKE_COMPILER_ID STREQUAL \"MSVC\")')
                         cmakelists:print('        check_cxx_compiler_flag("/std:%s${standard}" %s_support_%s_standard_${standard})', flag, target:name(), flag)
                         cmakelists:print('    else()')
                         cmakelists:print('        check_cxx_compiler_flag("-std=%s${standard}" %s_support_%s_standard_${standard})', flag, target:name(), flag)
@@ -846,7 +846,7 @@ function _add_target_languages(cmakelists, target)
                     else
                         cmakelists:print('foreach(standard 23 17 11 99 90)')
                         cmakelists:print('    include(CheckCCompilerFlag)')
-                        cmakelists:print('    if(MSVC)')
+                        cmakelists:print('    if(CMAKE_COMPILER_ID STREQUAL \"MSVC\")')
                         cmakelists:print('        check_c_compiler_flag("/std:%s${standard}" %s_support_%s_standard_${standard})', flag, target:name(), flag)
                         cmakelists:print('    else()')
                         cmakelists:print('        check_c_compiler_flag("-std=%s${standard}" %s_support_%s_standard_${standard})', flag, target:name(), flag)
@@ -886,7 +886,7 @@ function _add_target_optimization(cmakelists, target)
     }
     local optimization = target:get("optimize")
     if optimization then
-        cmakelists:print("if(MSVC)")
+        cmakelists:print("if(CMAKE_COMPILER_ID STREQUAL \"MSVC\")")
         cmakelists:print("    target_compile_options(%s PRIVATE %s)", target:name(), flags_msvc[optimization])
         cmakelists:print("else()")
         cmakelists:print("    target_compile_options(%s PRIVATE %s)", target:name(), flags_gcc[optimization])
@@ -914,7 +914,7 @@ function _add_target_symbols(cmakelists, target)
         if levels:has("hidden") then
             table.insert(flags_gcc, "-fvisibility=hidden")
         end
-        cmakelists:print("if(MSVC)")
+        cmakelists:print("if(CMAKE_COMPILER_ID STREQUAL \"MSVC\")")
         if #flags_msvc > 0 then
             cmakelists:print("    target_compile_options(%s PRIVATE %s)", target:name(), table.concat(flags_msvc, " "))
         end
@@ -935,7 +935,7 @@ function _add_target_runtimes(cmakelists, target)
     local cmake_minver = _get_cmake_minver()
     if cmake_minver:ge("3.15.0") then
         local runtimes = target:get("runtimes")
-        cmakelists:print("if(MSVC)")
+        cmakelists:print("if(CMAKE_COMPILER_ID STREQUAL \"MSVC\")")
         if runtimes then
             if runtimes == "MT" then
                 runtimes = "MultiThreaded"
@@ -1045,7 +1045,7 @@ function _add_target_link_directories(cmakelists, target, outputdir)
             end
             cmakelists:print(")")
         else
-            cmakelists:print("if(MSVC)")
+            cmakelists:print("if(CMAKE_COMPILER_ID STREQUAL \"MSVC\")")
             cmakelists:print("    target_link_libraries(%s PRIVATE", target:name())
             for _, linkdir in ipairs(linkdirs) do
                 cmakelists:print("        -libpath:" .. _get_relative_unix_path(linkdir, outputdir))
@@ -1104,15 +1104,15 @@ function _add_target_link_options(cmakelists, target, outputdir)
     local linkernames = {
         clang = "Clang",
         clangxx = "Clang",
-        gcc = "Gcc",
-        gxx = "Gcc",
+        gcc = "GNU",
+        gxx = "GNU",
         cl = "MSVC",
         link = "MSVC"
     }
     for _, toolname in toolnames:keys() do
         local name = linkernames[toolname]
         if name then
-            cmakelists:print("if(%s)", name)
+            cmakelists:print("if(CMAKE_COMPILER_ID STREQUAL \"%s\")", name)
             _add_target_link_options_for_linker(toolname)
             cmakelists:print("endif()")
         end


### PR DESCRIPTION
The cmake generator was not using the standard syntax to detect compiler
```
if (Gcc)
if (MSVC)
if (Clang)
```
to
```
if (CMAKE_COMPILER_ID STREQUAL "GNU")
if (CMAKE_COMPILER_ID STREQUAL "MSVC")
if (CMAKE_COMPILER_ID STREQUAL "Clang")
```