### PR TITLE
cargo: fix package cross-compilation

### DIFF
--- a/xmake/modules/package/manager/cargo/find_package.lua
+++ b/xmake/modules/package/manager/cargo/find_package.lua
@@ -136,6 +136,12 @@ function main(name, opt)
     local librarydir_host = path.join(opt.installdir, "lib", "host")
     local libfiles = os.files(path.join(librarydir, "*.rlib"))
 
+    local frameworkdirs = {}
+    table.insert(frameworkdirs, librarydir)
+    if os.exists(librarydir_host) then
+        table.insert(frameworkdirs, librarydir_host)
+    end
+
     -- @see https://github.com/xmake-io/xmake/issues/4228
     local libfiles_native
     local plat = opt.plat
@@ -165,7 +171,6 @@ function main(name, opt)
             libraryname = "lib" .. libraryname
         end
         if names:has(libraryname) and not libraries_set[libraryname] then
-            frameworkdirs = frameworkdirs or {}
             frameworks = frameworks or {}
             table.insert(frameworkdirs, path.directory(libraryfile))
             table.insert(frameworks, libraryfile)

--- a/xmake/modules/package/manager/cargo/find_package.lua
+++ b/xmake/modules/package/manager/cargo/find_package.lua
@@ -138,7 +138,7 @@ function main(name, opt)
 
     local frameworkdirs = {}
     table.insert(frameworkdirs, librarydir)
-    if os.exists(librarydir_host) then
+    if os.isdir(librarydir_host) then
         table.insert(frameworkdirs, librarydir_host)
     end
 

--- a/xmake/modules/package/manager/cargo/find_package.lua
+++ b/xmake/modules/package/manager/cargo/find_package.lua
@@ -172,7 +172,6 @@ function main(name, opt)
         end
         if names:has(libraryname) and not libraries_set[libraryname] then
             frameworks = frameworks or {}
-            table.insert(frameworkdirs, path.directory(libraryfile))
             table.insert(frameworks, libraryfile)
             libraries_set[libraryname] = true
         end
@@ -181,7 +180,7 @@ function main(name, opt)
     if frameworks and frameworkdirs then
         result = result or {}
         result.libfiles = libfiles
-        result.frameworkdirs = frameworkdirs and table.unique(frameworkdirs) or nil
+        result.frameworkdirs = frameworkdirs
         result.frameworks = frameworks
         result.version = opt.require_version
     end

--- a/xmake/modules/package/manager/cargo/install_package.lua
+++ b/xmake/modules/package/manager/cargo/install_package.lua
@@ -23,6 +23,7 @@ import("core.base.option")
 import("core.project.config")
 import("lib.detect.find_tool")
 import("private.tools.rust.check_target")
+import("private.tools.rust.target_triple")
 
 -- translate local path in dependencies
 -- @see https://github.com/xmake-io/xmake/issues/4222
@@ -78,7 +79,10 @@ function main(name, opt)
     -- get target
     -- e.g. x86_64-pc-windows-msvc, aarch64-unknown-none
     -- @see https://github.com/xmake-io/xmake/issues/4049
-    local target = check_target(opt.arch, true) and opt.arch or nil
+    local target = #opt.arch:split("%-") >= 2 and check_target(opt.arch, true) and opt.arch
+    if not target then
+        target = target_triple(opt.plat, opt.arch)
+    end
 
     -- generate Cargo.toml
     local sourcedir = path.join(opt.cachedir, "source")

--- a/xmake/modules/private/tools/rust/target_triple.lua
+++ b/xmake/modules/private/tools/rust/target_triple.lua
@@ -1,0 +1,95 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      SirLynix
+-- @file        target_triple.lua
+--
+
+-- get arch part
+function _translate_arch(arch, opt)
+    local maps =
+    {
+        ["aarch64"]     = "aarch64"
+    ,   ["armv5te"]     = "arm"
+    ,   ["armeabi"]     = "arm"
+    ,   ["armeabi-v7a"] = "armv7"
+    ,   ["armv7-a"]     = "armv7"
+    ,   ["arm64"]       = "aarch64"
+    ,   ["arm64-v8a"]   = "aarch64"
+    ,   ["i386"]        = "i686"
+    ,   ["i686"]        = "i686"
+    ,   ["x86"]         = "i686"
+    ,   ["x86_64"]      = "x86_64"
+    ,   ["x64"]         = "x86_64"
+    ,   ["wasm32"]      = "wasm32"
+    ,   ["wasm64"]      = "wasm64"
+    }
+    return maps[arch]
+end
+
+-- get platform part
+function _translate_plat(plat, arch, opt)
+    if plat == "windows" then
+        return "-pc-windows-msvc"
+    elseif plat == "mingw" then
+        return "-pc-windows-gnu"
+    elseif plat == "linux" then
+        return "-unknown-linux-gnu"
+    elseif plat == "macosx" then
+        return "-apple-darwin"
+    elseif plat == "android" then
+        if arch == "armeabi-v7a" or arch == "armeabi" or arch == "armv7-a" or arch == "armv5te" then
+            return "-linux-androideabi"
+        else
+            return "-linux-android"
+        end
+    elseif plat == "iphoneos" or plat == "appletvos" or plat == "watchos" then
+        local suffix = opt and opt.apple_sim and "-sim" or ""
+        if plat == "iphoneos" then
+            return "-apple-ios" .. suffix
+        elseif plat == "appletvos" then
+            return "-apple-tvos" .. suffix
+        elseif plat == "watchos" then
+            return "-apple-watchos" .. suffix
+        end
+    elseif plat == "bsd" then
+        return "-unknown-freebsd"
+    elseif plat == "wasm" then
+        return "-unknown-unknown"
+    end
+end
+
+-- gets the rustc compatible target triple (e.g. x86_64-pc-windows-msvc) for a set plat/arch
+--
+-- @param plat      the target plat, e.g. windows, android, macosx, ...
+-- @param arch      the target name, e.g. arm64, x86_64, wasm64, ...
+-- @param opt       the options, e.g. {apple_sim = true)
+--
+-- @return          a valid rustc triple if plat and arch are recognized, nil otherwise
+function main(plat, arch, opt)
+
+    local target_arch = _translate_arch(arch, opt)
+    if not target_arch then
+        return
+    end
+
+    local target_plat = _translate_plat(plat, arch, opt)
+    if not target_plat then
+        return
+    end
+
+    return target_arch .. target_plat
+end

--- a/xmake/toolchains/rust/xmake.lua
+++ b/xmake/toolchains/rust/xmake.lua
@@ -28,58 +28,14 @@ toolchain("rust")
     set_toolset("rcar", "$(env RC)", "rustc")
 
     on_load(function (toolchain)
-        local target
-        if toolchain:is_arch("x86_64", "x64") then
-            target = "x86_64"
-        elseif toolchain:is_arch("i386", "x86", "i686") then
-            target = "i686"
-        elseif toolchain:is_arch("arm64", "aarch64", "arm64-v8a") then
-            target = "aarch64"
-        elseif toolchain:is_arch("armeabi-v7a", "armv7-a") then
-            target = "armv7"
-        elseif toolchain:is_arch("armeabi", "armv5te") then
-            target = "arm"
-        elseif toolchain:is_arch("wasm32") then
-            target = "wasm32"
-        elseif toolchain:is_arch("wasm64") then
-            target = "wasm64"
+        local opt = {}
+        if toolchain:config("appledev") == "simulator" then
+            opt.apple_sim = true
         end
-
+ 
+        local target = import("private.tools.rust.target_triple")(toolchain:plat(), toolchain:arch(), opt)
         if target then
-            if toolchain:is_plat("windows") then
-                target = target .. "-pc-windows-msvc"
-            elseif toolchain:is_plat("mingw") then
-                target = target .. "-pc-windows-gnu"
-            elseif toolchain:is_plat("linux") then
-                target = target .. "-unknown-linux-gnu"
-            elseif toolchain:is_plat("macosx") then
-                target = target .. "-apple-darwin"
-            elseif toolchain:is_plat("android") then
-                target = target .. "-linux-"
-                if toolchain:is_arch("armeabi-v7a", "armeabi", "armv7-a", "armv5te") then
-                    target = target .. "androideabi"
-                else
-                    target = target .. "android"
-                end
-            elseif toolchain:is_plat("iphoneos", "appletvos", "watchos") then
-                if toolchain:is_plat("iphoneos") then
-                    target = target .. "-apple-ios"
-                elseif toolchain:is_plat("appletvos") then
-                    target = target .. "-apple-tvos"
-                elseif toolchain:is_plat("watchos") then
-                    target = target .. "-apple-watchos"
-                end
-                if toolchain:config("appledev") == "simulator" then
-                    target = target .. "-sim"
-                end
-            elseif toolchain:is_plat("bsd") then
-                target = target .. "-unknown-freebsd"
-            elseif toolchain:is_plat("wasm") then
-                target = target .. "-unknown-unknown"
-            end 
-        end
-
-        if target then
+            toolchain:add("rcflags", "--verbose")
             toolchain:add("rcflags", "--target=" .. target)
         else
             toolchain:set("rcshflags", "")

--- a/xmake/toolchains/rust/xmake.lua
+++ b/xmake/toolchains/rust/xmake.lua
@@ -28,12 +28,14 @@ toolchain("rust")
     set_toolset("rcar", "$(env RC)", "rustc")
 
     on_load(function (toolchain)
+        import("private.tools.rust.target_triple")
+
         local opt = {}
         if toolchain:config("appledev") == "simulator" then
             opt.apple_sim = true
         end
  
-        local target = import("private.tools.rust.target_triple")(toolchain:plat(), toolchain:arch(), opt)
+        local target = target_triple(toolchain:plat(), toolchain:arch(), opt)
         if target then
             toolchain:add("rcflags", "--verbose")
             toolchain:add("rcflags", "--target=" .. target)

--- a/xmake/toolchains/rust/xmake.lua
+++ b/xmake/toolchains/rust/xmake.lua
@@ -37,7 +37,6 @@ toolchain("rust")
  
         local target = target_triple(toolchain:plat(), toolchain:arch(), opt)
         if target then
-            toolchain:add("rcflags", "--verbose")
             toolchain:add("rcflags", "--target=" .. target)
         else
             toolchain:set("rcshflags", "")


### PR DESCRIPTION
Fixes cross-compilation with Cargo by passing the proper triple automatically
Also, the /host folder has to be passed to rustc to find some library (tested with naga)

Fixes https://github.com/xmake-io/xmake-repo/pull/7023