### PR TITLE
New native Xcode project generator.

### DIFF
--- a/xmake/plugins/project/main.lua
+++ b/xmake/plugins/project/main.lua
@@ -33,6 +33,7 @@ import("clang.compile_flags")
 import("clang.compile_commands")
 import("private.utils.statistics")
 import("private.service.remote_build.action", {alias = "remote_build_action"})
+import("xcode2.xcodeproj2")
 
 function makers()
     return {
@@ -42,6 +43,7 @@ function makers()
     ,   cmake            = cmakelists.make
     ,   cmakelists       = cmakelists.make
     ,   xcode            = xcodeproj.make
+    ,   xcode2           = xcodeproj2.make
     ,   ninja            = build_ninja.make
     ,   vs2002           = vs.make(2002)
     ,   vs2003           = vs.make(2003)

--- a/xmake/plugins/project/xcode2/get_xcode_info.lua
+++ b/xmake/plugins/project/xcode2/get_xcode_info.lua
@@ -1,0 +1,240 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      JXMaster
+-- @file        get_xcode_info.lua
+--
+
+-- imports
+import("core.base.option")
+import("core.project.config")
+import("core.project.project")
+
+function _get_project_modes()
+    local ret_modes = {}
+    local modes = option.get("modes")
+    if modes then
+        if not modes:find("\"") then
+            modes = modes:gsub(",", path.envsep())
+        end
+        for _, mode in ipairs(path.splitenv(modes)) do
+            table.insert(ret_modes, mode:trim())
+        end
+    else
+        ret_modes = project.modes()
+    end
+    return ret_modes
+end
+
+function _add_PBXFileReference(xcinfo, file_info)
+    local obj = {}
+    obj.explicitFileType = file_info.explicitFileType
+    obj.lastKnownFileType = file_info.lastKnownFileType
+    obj.name = file_info.name
+    obj.path = file_info.path
+    obj.sourceTree = file_info.sourceTree
+    obj.includeInIndex = file_info.includeInIndex
+    local uuid = xcinfo:gen_uuid()
+    xcinfo.sections.PBXFileReference = xcinfo.sections.PBXFileReference or {}
+    xcinfo.sections.PBXFileReference[uuid] = obj
+    return uuid
+end
+
+function _add_PBXGroup(xcinfo, name, sourceTree)
+    local obj = {}
+    obj.name = name
+    obj.sourceTree = sourceTree
+    obj.children = {}
+    local uuid = xcinfo:gen_uuid()
+    xcinfo.sections.PBXGroup = xcinfo.sections.PBXGroup or {}
+    xcinfo.sections.PBXGroup[uuid] = obj
+    return uuid
+end
+
+function _add_XCBuildConfiguration(xcinfo, mode)
+    local obj = {}
+    obj.name = mode
+    obj.buildSettings = {}
+    -- This allows scripts to read/write files that are not in the Input/Output list of
+    -- the phase.
+    obj.buildSettings.ENABLE_USER_SCRIPT_SANDBOXING = false
+    local uuid = xcinfo:gen_uuid()
+    xcinfo.sections.XCBuildConfiguration = xcinfo.sections.XCBuildConfiguration or {}
+    xcinfo.sections.XCBuildConfiguration[uuid] = obj
+    return uuid
+end
+
+function _add_XCConfigurationList(xcinfo)
+    local obj = {}
+    local modes = _get_project_modes()
+    obj.buildConfigurations = {}
+    for _, mode in ipairs(modes) do
+        table.insert(obj.buildConfigurations, _add_XCBuildConfiguration(xcinfo, mode))
+    end
+    local uuid = xcinfo:gen_uuid()
+    xcinfo.sections.XCConfigurationList = xcinfo.sections.XCConfigurationList or {}
+    xcinfo.sections.XCConfigurationList[uuid] = obj
+    return uuid
+end
+
+function _add_PBXShellScriptBuildPhase(xcinfo, target)
+    local obj = {}
+    obj.shellScript = [[
+cd \"]] .. os.projectdir() .. [[\"
+XMAKE_BIN=\"]] .. os.programfile() .. [[\"
+# Running xmake scripts.
+${XMAKE_BIN} f -y -m ${CONFIGURATION} -p ${PLATFORM_NAME} -a ${NATIVE_ARCH} -o ${BUILD_DIR}
+${XMAKE_BIN} build ${TARGET_NAME}\n# Running xmake install scripts.
+${XMAKE_BIN} install -o ${CONFIGURATION_TEMP_DIR}/Install ${TARGET_NAME}
+# Copy files to build path.
+if test -e ${CONFIGURATION_TEMP_DIR}/Install/bin
+then
+    cp -r ${CONFIGURATION_TEMP_DIR}/Install/bin/* ${CONFIGURATION_BUILD_DIR}
+fi
+if test -e ${CONFIGURATION_TEMP_DIR}/Install/lib
+then
+    cp -r ${CONFIGURATION_TEMP_DIR}/Install/lib/* ${CONFIGURATION_BUILD_DIR}
+fi
+cp -r ${CONFIGURATION_TEMP_DIR}/Install/*.app ${CONFIGURATION_BUILD_DIR}
+# Remove install dir.
+rm -r ${CONFIGURATION_TEMP_DIR}/Install\n\n    
+]]
+    local uuid = xcinfo:gen_uuid()
+    xcinfo.sections.PBXShellScriptBuildPhase = xcinfo.sections.PBXShellScriptBuildPhase or {}
+    xcinfo.sections.PBXShellScriptBuildPhase[uuid] = obj
+    return uuid
+end
+
+function _add_target_files(xcinfo, group, files)
+    for _, v in table.orderpairs(files) do
+        local file_info = {}
+        file_info.name = path.filename(v)
+        file_info.path = path.join(project.directory(), v)
+        file_info.sourceTree = "\"<absolute>\""
+        local ext = path.extension(v)
+        if ext == ".h" then
+            file_info.lastKnownFileType = "sourcecode.c.h"
+        elseif ext == ".c" then
+            file_info.lastKnownFileType = "sourcecode.c.c"
+        elseif ext == ".m" then
+            file_info.lastKnownFileType = "sourcecode.c.objc"
+        elseif ext == ".hpp" then
+            file_info.lastKnownFileType = "sourcecode.cpp.h"
+        elseif ext == ".cpp" then
+            file_info.lastKnownFileType = "sourcecode.cpp.cpp"
+        elseif ext == ".mm" then
+            file_info.lastKnownFileType = "sourcecode.cpp.objcpp"
+        end
+        table.insert(group.children, _add_PBXFileReference(xcinfo, file_info))
+    end
+end
+
+function _add_PBXNativeTarget(xcinfo, target_name, target)
+    local obj = {}
+    obj.name = target_name
+    obj.productName = target_name
+    -- Add product file.
+    local product_file = {}
+    if target:kind() == "static" then
+        product_file.explicitFileType = "com.apple.product-type.library.static"
+    elseif target:kind() == "shared" then
+        product_file.explicitFileType = "com.apple.product-type.library.dynamic"
+    elseif target:kind() == "binary" then
+        product_file.explicitFileType = "com.apple.product-type.tool"
+    end
+    product_file.path = target:filename()
+    product_file.sourceTree = "BUILT_PRODUCTS_DIR"
+    product_file.includeInIndex = 0
+    obj.productReference = _add_PBXFileReference(xcinfo, product_file)
+    obj.productType = product_file.explicitFileType
+    -- Add product file to product group.
+    local project_obj = xcinfo.sections.PBXProject[xcinfo.root_object]
+    local product_group = xcinfo.sections.PBXGroup[project_obj.productRefGroup]
+    table.insert(product_group.children, obj.productReference)
+
+    -- Add files.
+    local headerfiles = target:headerfiles()
+    local sourcefiles = target:sourcefiles()
+    obj.headerFileGroup = _add_PBXGroup(xcinfo, "Header Files", "<group>")
+    obj.sourceFileGroup = _add_PBXGroup(xcinfo, "Source Files", "<group>")
+    local header_group = xcinfo.sections.PBXGroup[obj.headerFileGroup]
+    local source_group = xcinfo.sections.PBXGroup[obj.sourceFileGroup]
+    _add_target_files(xcinfo, header_group, headerfiles)
+    _add_target_files(xcinfo, source_group, sourcefiles)
+    obj.mainGroup = _add_PBXGroup(xcinfo, obj.productName, "<group>")
+    local main_group = xcinfo.sections.PBXGroup[obj.mainGroup]
+    table.insert(main_group.children, obj.headerFileGroup)
+    table.insert(main_group.children, obj.sourceFileGroup)
+    -- Add configuration list for target.
+    obj.buildConfigurationList = _add_XCConfigurationList(xcinfo)
+    -- Add build phases.
+    obj.buildPhases = {}
+    table.insert(obj.buildPhases, _add_PBXShellScriptBuildPhase(xcinfo, target))
+    local uuid = xcinfo:gen_uuid()
+    xcinfo.sections.PBXNativeTarget = xcinfo.sections.PBXNativeTarget or {}
+    xcinfo.sections.PBXNativeTarget[uuid] = obj
+    return uuid
+end
+
+function main(outputdir)
+    local xcinfo = {}
+
+    xcinfo.project_dir = outputdir
+    xcinfo.project_bundle = (project.name() or path.filename(project.directory())) .. ".xcodeproj"
+    xcinfo.project_dir_uuid = string.upper(hash.strhash32(xcinfo.project_dir))
+    xcinfo.project_bundle_uuid = string.upper(hash.strhash32(xcinfo.project_bundle))
+    xcinfo.uuid_counter = 0
+    xcinfo.gen_uuid = function(self)
+        local counter = self.uuid_counter
+        self.uuid_counter = self.uuid_counter + 1
+        return self.project_dir_uuid .. self.project_bundle_uuid .. string.format("%08X", counter)
+    end
+
+    -- Used to collect Xcode nodes.
+    -- nodes are grouped by their types. For example, all PBXFileReference
+    -- nodes will be in xcinfo.sections.PBXFileReference, indexed by their UUIDs.
+    xcinfo.sections = {}
+
+    -- Add project node
+    local sections = xcinfo.sections
+    sections.PBXProject = {}
+    local project_uuid = xcinfo:gen_uuid()
+    xcinfo.root_object = project_uuid
+    sections.PBXProject[project_uuid] = {}
+    local project_obj = sections.PBXProject[project_uuid]
+
+    -- collect buildConfigurationList
+    project_obj.buildConfigurationList = _add_XCConfigurationList(xcinfo)
+
+    -- collect main group
+    project_obj.mainGroup = _add_PBXGroup(xcinfo, nil, "<group>")
+    local main_group = xcinfo.sections.PBXGroup[project_obj.mainGroup]
+
+    -- collect product ref group
+    project_obj.productRefGroup = _add_PBXGroup(xcinfo, "Products", "<group>");
+
+    -- collect targets.
+    project_obj.targets = {}
+    for target_name, target in table.orderpairs(project.targets()) do
+        local target = _add_PBXNativeTarget(xcinfo, target_name, target)
+        table.insert(project_obj.targets, target)
+        local target_obj = xcinfo.sections.PBXNativeTarget[target]
+        table.insert(main_group.children, target_obj.mainGroup)
+    end
+    table.insert(main_group.children, project_obj.productRefGroup)
+
+    return xcinfo
+end

--- a/xmake/plugins/project/xcode2/pbxproj.lua
+++ b/xmake/plugins/project/xcode2/pbxproj.lua
@@ -1,0 +1,239 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      JXMaster
+-- @file        pbxproj.lua
+--
+
+-- imports
+import("core.project.config")
+import("core.project.project")
+
+function _write_file_if_needed(file, content)
+    if os.isfile(file) and io.readfile(file) == content then
+        dprint("skipped file %s since the file has the same content", path.relative(file))
+        return
+    end
+    -- we need utf8 with bom encoding for unicode
+    -- @see https://github.com/xmake-io/xmake/issues/1689
+    io.writefile(file, content, {encoding = "utf8"})
+end
+
+function _write_section_PBXFileReference(info, lines)
+    table.insert(lines, "/* Begin PBXFileReference section */")
+    for uuid, obj in table.orderpairs(info.sections.PBXFileReference) do
+        table.insert(lines, "\t\t" .. uuid .. " = {")
+        table.insert(lines, "\t\t\tisa = PBXFileReference;")
+        if obj.explicitFileType then
+            table.insert(lines, "\t\t\texplicitFileType = \"" .. obj.explicitFileType .. "\";")
+        end
+        if obj.lastKnownFileType then
+            table.insert(lines, "\t\t\tlastKnownFileType = \"" .. obj.lastKnownFileType .. "\";")
+        end
+        if obj.includeInIndex then
+            table.insert(lines, "\t\t\tincludeInIndex = " .. obj.includeInIndex .. ";")
+        end
+        if obj.name then
+            table.insert(lines, "\t\t\tname = \"" .. obj.name .. "\";")
+        end
+        if obj.path then
+            table.insert(lines, "\t\t\tpath = \"" .. obj.path .. "\";")
+        end
+        if obj.sourceTree then
+            table.insert(lines, "\t\t\tsourceTree = " .. obj.sourceTree .. ";")
+        end
+        table.insert(lines, "\t\t};")
+    end
+    table.insert(lines, "/* End PBXFileReference section */")
+end
+
+function _write_section_PBXGroup(info, lines)
+    table.insert(lines, "/* Begin PBXGroup section */")
+    for uuid, obj in table.orderpairs(info.sections.PBXGroup) do
+        table.insert(lines, "\t\t" .. uuid .. " = {")
+        table.insert(lines, "\t\t\tisa = PBXGroup;")
+        if obj.name then
+            table.insert(lines, "\t\t\tname = \"" .. obj.name .. "\";")
+        end
+        table.insert(lines, "\t\t\tchildren = (")
+        for _, child in ipairs(obj.children) do
+            table.insert(lines, "\t\t\t\t" .. child .. ",")
+        end
+        table.insert(lines, "\t\t\t);")
+        table.insert(lines, "\t\t\tsourceTree = \"" .. obj.sourceTree .. "\";")
+        table.insert(lines, "\t\t};")
+    end
+    table.insert(lines, "/* End PBXGroup section */")
+end
+
+function _write_section_PBXNativeTarget(info, lines)
+    table.insert(lines, "/* Begin PBXNativeTarget section */")
+    for uuid, obj in table.orderpairs(info.sections.PBXNativeTarget) do
+        table.insert(lines, "\t\t" .. uuid .. " /* " .. obj.name .. " */ = {")
+        table.insert(lines, "\t\t\tisa = PBXNativeTarget;")
+        table.insert(lines, "\t\t\tbuildConfigurationList = " .. obj.buildConfigurationList .. " /* Build configuration list for PBXNativeTarget \"" .. obj.name .. "\" */;")
+        table.insert(lines, "\t\t\tbuildPhases = (")
+        for _, build_phase_uuid in ipairs(obj.buildPhases) do
+            table.insert(lines, "\t\t\t\t" .. build_phase_uuid .. ",")
+        end
+        table.insert(lines, "\t\t\t);")
+        table.insert(lines, "\t\t\tbuildRules = (")
+        table.insert(lines, "\t\t\t);")
+        table.insert(lines, "\t\t\tdependencies = (")
+        table.insert(lines, "\t\t\t);")
+        table.insert(lines, "\t\t\tname = " .. obj.name .. ";")
+        table.insert(lines, "\t\t\tpackageProductDependencies = (")
+        table.insert(lines, "\t\t\t);")
+        table.insert(lines, "\t\t\tproductName = " .. obj.productName .. ";")
+        table.insert(lines, "\t\t\tproductReference = " .. obj.productReference .. ";")
+        table.insert(lines, "\t\t\tproductType = " .. obj.productType .. ";")
+        table.insert(lines, "\t\t};")
+    end
+    table.insert(lines, "/* End PBXNativeTarget section */")
+end
+
+function _write_section_PBXProject(info, lines)
+    table.insert(lines, "/* Begin PBXProject section */")
+    for uuid, obj in table.orderpairs(info.sections.PBXProject) do
+        table.insert(lines, "\t\t" .. uuid .. " /* Project object */ = {")
+        table.insert(lines, "\t\t\tisa = PBXProject;")
+        table.insert(lines, [[
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+			};]])
+        table.insert(lines, "\t\t\tbuildConfigurationList = " .. obj.buildConfigurationList .. " /* Build configuration list for PBXProject */;")
+        table.insert(lines, [[
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);]])
+        table.insert(lines, "mainGroup = " .. obj.mainGroup .. ";")
+        table.insert(lines, [[
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;]])
+        table.insert(lines, "productRefGroup = " .. obj.productRefGroup .. ";")
+        table.insert(lines, [[
+			projectDirPath = "";
+			projectRoot = "";]])
+        table.insert(lines, "\t\t\ttargets = (")
+        for _, target_uuid in ipairs(obj.targets) do
+            table.insert(lines, "\t\t\t\t" .. target_uuid .. " /* " .. info.sections.PBXNativeTarget[target_uuid].name .. " */,")
+        end
+        table.insert(lines, "\t\t\t);")
+        table.insert(lines, "\t\t};")
+    end
+    table.insert(lines, "/* End PBXProject section */")
+end
+
+function _write_section_PBXShellScriptBuildPhase(info, lines)
+    table.insert(lines, "/* Begin PBXShellScriptBuildPhase section */")
+    for uuid, obj in table.orderpairs(info.sections.PBXShellScriptBuildPhase) do
+        table.insert(lines, "\t\t" .. uuid .. " /* Run xmake Build Command */ = {")
+        table.insert(lines, [[
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "xmake build";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "]] .. obj.shellScript .. "\";")
+        table.insert(lines, "\t\t};")
+    end
+    table.insert(lines, "/* End PBXShellScriptBuildPhase section */")
+end
+
+function _write_section_XCBuildConfiguration(info, lines)
+    table.insert(lines, "/* Begin XCBuildConfiguration section */")
+    for uuid, obj in table.orderpairs(info.sections.XCBuildConfiguration) do
+        table.insert(lines, "\t\t" .. uuid .. " /* " .. obj.name .. " */ = {")
+        table.insert(lines, [[
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+			};
+			name = ]] .. obj.name .. ";")
+        table.insert(lines, "\t\t};")
+    end
+    table.insert(lines, "/* End XCBuildConfiguration section */")
+end
+
+function _write_section_XCConfigurationList(info, lines)
+    table.insert(lines, "/* Begin XCConfigurationList section */")
+    for uuid, obj in table.orderpairs(info.sections.XCConfigurationList) do
+        table.insert(lines, "\t\t" .. uuid .. " = {")
+        table.insert(lines, [[
+			isa = XCConfigurationList;
+			buildConfigurations = (]])
+        for _, build_config in ipairs(obj.buildConfigurations) do
+            table.insert(lines, "\t\t\t\t" .. build_config .. " /* " .. info.sections.XCBuildConfiguration[build_config].name .. " */,")
+        end
+        table.insert(lines, [[
+			);
+			defaultConfigurationIsVisible = 0;]])
+        table.insert(lines, "\t\t};")
+    end
+    table.insert(lines, "/* End XCConfigurationList section */")
+end
+
+local write_section_funcs = {
+    _write_section_PBXFileReference,
+    _write_section_PBXGroup,
+    _write_section_PBXNativeTarget,
+    _write_section_PBXProject,
+    _write_section_PBXShellScriptBuildPhase,
+    _write_section_XCBuildConfiguration,
+    _write_section_XCConfigurationList
+}
+
+function _write_pbxproj(info)
+    local lines = {}
+    table.insert(lines, [[// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+]])
+    -- write sections.
+    for _, write_section in ipairs(write_section_funcs) do
+        write_section(info, lines)
+    end
+
+    table.insert(lines, 
+[[	};
+	rootObject = ]] .. info.root_object .. [[ /* Project object */;
+}]])
+    return table.concat(lines, "\n") .. "\n"
+end
+
+function main(info)
+    local content = _write_pbxproj(info)
+    local file_name = path.join(info.project_dir, info.project_bundle, "project.pbxproj")
+    _write_file_if_needed(file_name, content)
+end

--- a/xmake/plugins/project/xcode2/xcodeproj2.lua
+++ b/xmake/plugins/project/xcode2/xcodeproj2.lua
@@ -1,0 +1,39 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, TBOOX Open Source Group.
+--
+-- @author      JXMaster
+-- @file        xcodeproj2.lua
+--
+
+-- imports
+import("get_xcode_info")
+import("pbxproj")
+
+function make(outputdir)
+    
+    -- collect xcode info.
+    -- see get_xcode_info.lua file for detailed description 
+    -- of the returned info table.
+    local info = get_xcode_info(outputdir)
+
+    -- create xcode dir.
+    local project_bundle = path.join(info.project_dir, info.project_bundle)
+    os.mkdir(project_bundle)
+
+    -- create .pbxproj file.
+    pbxproj(info)
+
+end

--- a/xmake/plugins/project/xmake.lua
+++ b/xmake/plugins/project/xmake.lua
@@ -44,6 +44,7 @@ task("project")
                                                         ,   "    - cmake"
                                                         ,   "    - ninja"
                                                         ,   "    - xcode (need cmake)"
+                                                        ,   "    - xcode2"
                                                         ,   "    - compile_flags"
                                                         ,   "    - compile_commands (clang compilation database with json format)"
                                                         ,   "    - vs (auto detect), vs2002 - vs2022"


### PR DESCRIPTION
This pull request implements a native Xcode project generator for macOS development. The new project generator is temporary named as `Xcode2` to distinguish with the old generator, and has the following features:

1. Generate Xcode projects from `xmake.lua` directly, without the need to install and use CMake.
2. Map files, builds rules and targets to corresponding Xcode concepts (files, groups, configurations, targets, etc).
3. Triggering build in Xcode invokes xmake to build targets by using custom building phases of Xcode. xmake callbacks like `before_build`, `after_build`, `before_install`, `after_install`, etc will be called as expected.
4. Redirect xmake build directory to Xcode `BUILD_DIR`, so that invoking Clean build folder in Xcode will remove all xmake intermediate and output files as expected.
5. Running & debugging in Xcode is supported, with additional graphics debugging support if the application uses Metal.
6. Application bundle (`.app`) is supported if `xcode.application` rule is specified (currently only works for macOS applications. iOS applications will be supported later).

Note that this is still a very early version and needs further improvements and bug-fixes. I tested this generator on my own project and it worked fine, but more projects should be used to test this generator before it can be released.

