### PR TITLE
(C++ modules support) improve std module support for gcc and clang

### DIFF
--- a/tests/projects/c++/modules/stdmodules_deps/src/bar.mpp
+++ b/tests/projects/c++/modules/stdmodules_deps/src/bar.mpp
@@ -4,8 +4,11 @@ import std;
 
 export auto my_sum2(std::size_t a, std::size_t b) -> std::size_t;
 
+#if defined(__GNUC__) && !defined(__clang__)
+inline
+#else
 module :private;
-
-auto my_sum2(std::size_t a, std::size_t b) -> std::size_t {
+#endif
+    auto my_sum2(std::size_t a, std::size_t b) -> std::size_t {
   return a + a + b + b;
 }

--- a/tests/projects/c++/modules/stdmodules_deps/src/foo.cpp
+++ b/tests/projects/c++/modules/stdmodules_deps/src/foo.cpp
@@ -1,0 +1,3 @@
+module foo;
+
+auto my_sum(std::size_t a, std::size_t b) -> std::size_t { return a + b; }

--- a/tests/projects/c++/modules/stdmodules_deps/src/foo.mpp
+++ b/tests/projects/c++/modules/stdmodules_deps/src/foo.mpp
@@ -3,9 +3,3 @@ export module foo;
 import std;
 
 export auto my_sum(std::size_t a, std::size_t b) -> std::size_t;
-
-module :private;
-
-auto my_sum(std::size_t a, std::size_t b) -> std::size_t {
-  return a + b;
-}

--- a/tests/projects/c++/modules/stdmodules_deps/xmake.lua
+++ b/tests/projects/c++/modules/stdmodules_deps/xmake.lua
@@ -3,6 +3,7 @@ set_languages("c++latest")
 
 target("foo")
     set_kind("static")
+    add_files("src/foo.cpp")
     add_files("src/foo.mpp", {public = true})
 
 target("bar")

--- a/tests/projects/c++/modules/test_stdmodules.lua
+++ b/tests/projects/c++/modules/test_stdmodules.lua
@@ -38,21 +38,25 @@ function main(t)
             end
         end
     elseif is_subhost("msys") then
-        -- os.exec("xmake f -c -p mingw --yes")
-        -- _build()
+        local gcc = find_tool("gcc", {version = true})
+        if is_host("linux") and gcc and gcc.version and semver.compare(gcc.version, "15.0") >= 0 then
+            os.exec("xmake f -c -p mingw --yes")
+            _build()
+        end
     elseif is_host("linux") then -- or is_host("macosx") then
-        -- gcc don't support std modules atm
-        -- local gcc = find_tool("gcc", {version = true})
-        -- if is_host("linux") and gcc and gcc.version and semver.compare(gcc.version, "11.0") >= 0 then
-            -- os.exec("xmake f -c --yes")
-            -- _build()
-        -- end
+        local gcc = find_tool("gcc", {version = true})
+        if is_host("linux") and gcc and gcc.version and semver.compare(gcc.version, "15.0") >= 0 then
+            os.exec("xmake f -c --yes")
+            _build()
+        end
         local clang = find_tool("clang", {version = true})
         if clang and clang.version and semver.compare(clang.version, "19.0") >= 0 then
-            -- clang don't support libstdc++ std modules atm
-            -- os.exec("xmake clean -a")
-            -- os.exec("xmake f --toolchain=clang -c --yes")
-            -- _build()
+            local gcc = find_tool("clang", {version = true})
+            if gcc and gcc.version and semver.compare(gcc.version, "15.0") >= 0 then
+                os.exec("xmake clean -a")
+                os.exec("xmake f --toolchain=clang -c --yes")
+                _build()
+            end
             os.exec("xmake clean -a")
             os.exec("xmake f --toolchain=clang --runtimes=c++_shared -c --yes")
             _build()

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -101,7 +101,7 @@ function policy.policies()
             -- If in the future, gcc can support it well, we'll turn it on by default
             -- https://github.com/xmake-io/xmake/issues/3855
             ["build.c++.modules.gcc.cxx11abi"]    = {description = "Force to enable new cxx11 abi in C++ modules for gcc.", type = "boolean"},
-            ["build.c++.gcc.modules.cxx11abi"]    = {description = "Force to enable new cxx11 abi in C++ modules for gcc. (deprecated)", type = "boolean", default = false},
+            ["build.c++.gcc.modules.cxx11abi"]    = {description = "Force to enable new cxx11 abi in C++ modules for gcc. (deprecated)", type = "boolean"},
             -- Set the default vs runtime, e.g. MT, MD
             ["build.c++.msvc.runtime"]            = {description = "Set the default vs runtime.", type = "string", values = {"MT", "MD"}},
             -- Enable cuda device link

--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -277,7 +277,11 @@ function get_stdmodules(target)
                     end
                 end
             elseif cpplib == "stdc++" then
-                -- libstdc++ doesn't have a std module file atm
+                -- dont be greedy and don't enable stdc++ std module support for llvm < 19
+                local clang_version = get_clang_version(target)
+                if clang_version and semver.compare(clang_version, "19.0") >= 0 then
+                    return import(".gcc.support").get_stdmodules(target, {warn = false})
+                end
             elseif cpplib == "msstl" then
                 -- msstl std module file is not compatible with llvm < 19
                 local clang_version = get_clang_version(target)

--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -289,19 +289,7 @@ function get_stdmodules(target)
             local clang_version = get_clang_version(target)
             if clang_version and semver.compare(clang_version, "19.0") >= 0 then
                 local toolchain = target:toolchain("llvm") or target:toolchain("clang") or target:toolchain("clang-cl")
-                local msvc = import("core.tool.toolchain", {anonymous = true}).load("msvc", {plat = toolchain:plat(), arch = toolchain:arch()})
-                if msvc and msvc:check({ignore_sdk = true}) then
-                    local vcvars = msvc:config("vcvars")
-                    if vcvars.VCInstallDir and vcvars.VCToolsVersion then
-                        local stdmodulesdir = path.join(vcvars.VCInstallDir, "Tools", "MSVC", vcvars.VCToolsVersion, "modules")
-                        if os.isdir(stdmodulesdir) then
-                            return {path.normalize(path.join(stdmodulesdir, "std.ixx")), path.normalize(path.join(stdmodulesdir, "std.compat.ixx"))}
-                        end
-                    end
-                end
-            else
-                wprint("msstl std module file is not compatible with llvm < 19, please upgrade clang/clang-cl version!")
-                return
+                return import(".msvc.support").get_stdmodules(target, {dont_warn = false, toolchain = toolchain})
             end
         end
     end

--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -71,7 +71,7 @@ function _get_cpplibrary_name(target)
     elseif target:has_runtime("MD", "MT", "MDd", "MTd") then
         return "msstl"
     end
-    if target:is_plat("macosx") then
+    if target:is_plat("macosx") or target:is_plat("ios") or target:is_plat("tvos") then
         return "c++"
     elseif target:is_plat("linux") then
         return "stdc++"

--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -258,7 +258,7 @@ end
 
 function get_stdmodules(target)
 
-    if target:policy("build.c++.modules.std") then
+    if not target:policy("build.c++.modules.std") then
         return
     end
     local cpplib = _get_cpplibrary_name(target)
@@ -282,14 +282,14 @@ function get_stdmodules(target)
             -- dont be greedy and don't enable stdc++ std module support for llvm < 19
             local clang_version = get_clang_version(target)
             if clang_version and semver.compare(clang_version, "19.0") >= 0 then
-                return import(".gcc.support").get_stdmodules(target, {dont_warn = true})
+                return import(".gcc.support").get_stdmodules(target)
             end
         elseif cpplib == "msstl" then
             -- msstl std module file is not compatible with llvm < 19
             local clang_version = get_clang_version(target)
             if clang_version and semver.compare(clang_version, "19.0") >= 0 then
                 local toolchain = target:toolchain("llvm") or target:toolchain("clang") or target:toolchain("clang-cl")
-                return import(".msvc.support").get_stdmodules(target, {dont_warn = false, toolchain = toolchain})
+                return import(".msvc.support").get_stdmodules(target, {toolchain = toolchain})
             end
         end
     end

--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -71,7 +71,7 @@ function _get_cpplibrary_name(target)
     elseif target:has_runtime("MD", "MT", "MDd", "MTd") then
         return "msstl"
     end
-    if target:is_plat("macosx") or target:is_plat("ios") or target:is_plat("tvos") then
+    if target:is_plat("macosx", "iphoneos", "appletvos") then
         return "c++"
     elseif target:is_plat("linux") then
         return "stdc++"

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -147,9 +147,9 @@ function _get_std_module_manifest_path(target)
         end
     end
     local ext = ".so"
-    if target:is_plat("windows") or target:is_plat("mingw") then
+    if target:is_plat("windows", "mingw") then
         ext = ".dll"
-    elseif target:is_plat("macos") or target:is_plat("ios") or target:is_plat("tvos") then
+    elseif target:is_plat("macos", "iphoneos", "tvos") then
         ext = ".dylib"
     end
     local stdcpp_libfile, _ = try {

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -166,26 +166,29 @@ function _get_std_module_manifest_path(target)
     end
 end
 
-function get_stdmodules(target)
+function get_stdmodules(target, opt)
+    opt = opt or {}
     if not target:policy("build.c++.modules.std") then
         return
     end
     local modules_json_path = _get_std_module_manifest_path(target)
-    if not modules_json_path then
-        return
-    end
-    local modules_json = json.loadfile(modules_json_path)
-    if modules_json and modules_json.modules and #modules_json.modules > 0 then
-        local std_module_files = {}
-        local modules_json_dir = path.directory(modules_json_path)
-        for _, module_file in ipairs(modules_json.modules) do
-            local module_file_path = module_file["source-path"]
-            if not path.is_absolute(module_file_path) then
-                module_file_path = path.join(modules_json_dir, module_file_path)
+    if modules_json_path then
+        local modules_json = json.loadfile(modules_json_path)
+        if modules_json and modules_json.modules and #modules_json.modules > 0 then
+            local std_module_files = {}
+            local modules_json_dir = path.directory(modules_json_path)
+            for _, module_file in ipairs(modules_json.modules) do
+                local module_file_path = module_file["source-path"]
+                if not path.is_absolute(module_file_path) then
+                    module_file_path = path.join(modules_json_dir, module_file_path)
+                end
+                table.insert(std_module_files, path.normalize(module_file_path))
             end
-            table.insert(std_module_files, path.normalize(module_file_path))
+            return std_module_files
         end
-        return std_module_files
+    end
+    if not opt.dont_warn then
+        wprint("std and std.compat modules not found! maybe try to add --sdk=<PATH/TO/LLVM> or install libc++")
     end
 end
 

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -166,8 +166,7 @@ function _get_std_module_manifest_path(target)
     end
 end
 
-function get_stdmodules(target, opt)
-    opt = opt or {}
+function get_stdmodules(target)
     if not target:policy("build.c++.modules.std") then
         return
     end
@@ -187,9 +186,7 @@ function get_stdmodules(target, opt)
             return std_module_files
         end
     end
-    if not opt.dont_warn then
-        wprint("std and std.compat modules not found! maybe try to add --sdk=<PATH/TO/LLVM> or install libc++")
-    end
+    wprint("std and std.compat modules not found! maybe try to add --sdk=<PATH/TO/LLVM> or install libc++")
 end
 
 function get_bmi_extension()

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -146,10 +146,24 @@ function _get_std_module_manifest_path(target)
             return modules_json_path
         end
     end
-    -- fallback on custom detection
-    -- manifest can be found alongside libstdc++.so
-
-    -- TODO
+    local ext = ".so"
+    if target:is_plat("windows") or target:is_plat("mingw") then
+        ext = ".dll"
+    elseif target:is_plat("macos") or target:is_plat("ios") or target:is_plat("tvos") then
+        ext = ".dylib"
+    end
+    local stdcpp_libfile, _ = try {
+        function()
+            return os.iorunv(compinst:program(), {"-print-file-name=libstdc++" .. ext}, {envs = compinst:runenvs()})
+        end
+    }
+    if stdcpp_libfile then
+        modules_json_path = path.join(path.directory(stdcpp_libfile), "libstdc++.modules.json")
+        modules_json_path = modules_json_path:trim()
+        if os.isfile(modules_json_path) then
+            return modules_json_path
+        end
+    end
 end
 
 function get_stdmodules(target)

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -149,7 +149,7 @@ function _get_std_module_manifest_path(target)
     local ext = ".so"
     if target:is_plat("windows", "mingw") then
         ext = ".dll"
-    elseif target:is_plat("macos", "iphoneos", "tvos") then
+    elseif target:is_plat("macosx", "iphoneos", "appletvos") then
         ext = ".dylib"
     end
     local stdcpp_libfile, _ = try {

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -183,7 +183,7 @@ function get_stdmodules(target)
             if not path.is_absolute(module_file_path) then
                 module_file_path = path.join(modules_json_dir, module_file_path)
             end
-            table.insert(std_module_files, module_file_path)
+            table.insert(std_module_files, path.normalize(module_file_path))
         end
         return std_module_files
     end

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -61,6 +61,13 @@ function load(target)
     -- https://github.com/xmake-io/xmake/issues/3855
     local cxx11abi = target:policy("build.c++.modules.gcc.cxx11abi") or
                      target:policy("build.c++.gcc.modules.cxx11abi")
+    if cxx11abi == nil then
+        -- enable cxx11abi on GCC >= 15 as it is required for C++23 module
+        local gcc_version = get_gcc_version(target)
+        if gcc_version and semver.compare(gcc_version, "15") > 0 then
+            cxx11abi = true
+        end
+    end
     if cxx11abi then
         target:add("cxxflags", "-D_GLIBCXX_USE_CXX11_ABI=1")
     else

--- a/xmake/rules/c++/modules/msvc/support.lua
+++ b/xmake/rules/c++/modules/msvc/support.lua
@@ -99,7 +99,6 @@ end
 
 -- provide toolchain include dir for stl headerunit when p1689 is not supported
 function toolchain_includedirs(target)
-
     for _, toolchain_inst in ipairs(target:toolchains()) do
         if toolchain_inst:name() == "msvc" then
             local vcvars = toolchain_inst:config("vcvars")
@@ -117,22 +116,27 @@ function has_two_phase_compilation_support(_)
 end
 
 -- build c++23 standard modules if needed
-function get_stdmodules(target)
-
-    if target:policy("build.c++.modules.std") then
-        local msvc = target:toolchain("msvc")
-        if msvc then
-            local vcvars = msvc:config("vcvars")
-            if vcvars.VCInstallDir and vcvars.VCToolsVersion then
-                modules = {}
-
-                local stdmodulesdir = path.join(vcvars.VCInstallDir, "Tools", "MSVC", vcvars.VCToolsVersion, "modules")
-
-                if os.isdir(stdmodulesdir) then
-                    return {path.normalize(path.join(stdmodulesdir, "std.ixx")), path.normalize(path.join(stdmodulesdir, "std.compat.ixx"))}
-                end
+function get_stdmodules(target, opt)
+    opt = opt or {}
+    if not target:policy("build.c++.modules.std") then
+        return
+    end
+    local msvc
+    if opt.toolchain then
+        msvc = import("core.tool.toolchain", {anonymous = true}).load("msvc", {plat = opt.toolchain:plat(), arch = opt.toolchain:arch()})
+    else
+        msvc = target:toolchain("msvc")
+    end
+    if msvc and msvc:check() then
+        local vcvars = msvc:config("vcvars")
+        if vcvars.VCInstallDir and vcvars.VCToolsVersion then
+            local stdmodulesdir = path.join(vcvars.VCInstallDir, "Tools", "MSVC", vcvars.VCToolsVersion, "modules")
+            if os.isdir(stdmodulesdir) then
+                return {path.normalize(path.join(stdmodulesdir, "std.ixx")), path.normalize(path.join(stdmodulesdir, "std.compat.ixx"))}
             end
         end
+    end
+    if not opt.dont_warn then
         wprint("std and std.compat modules not found! disabling them for the build")
     end
 end
@@ -142,7 +146,6 @@ function get_bmi_extension()
 end
 
 function get_ifcoutputflag(target)
-
     local ifcoutputflag = _g.ifcoutputflag
     if ifcoutputflag == nil then
         local compinst = target:compiler("cxx")
@@ -156,7 +159,6 @@ function get_ifcoutputflag(target)
 end
 
 function get_ifconlyflag(target)
-
     local ifconlyflag = _g.ifconlyflag
     if ifconlyflag == nil then
         local compinst = target:compiler("cxx")
@@ -169,7 +171,6 @@ function get_ifconlyflag(target)
 end
 
 function get_interfaceflag(target)
-
     local interfaceflag = _g.interfaceflag
     if interfaceflag == nil then
         local compinst = target:compiler("cxx")
@@ -183,7 +184,6 @@ function get_interfaceflag(target)
 end
 
 function get_referenceflag(target)
-
     local referenceflag = _g.referenceflag
     if referenceflag == nil then
         local compinst = target:compiler("cxx")
@@ -197,7 +197,6 @@ function get_referenceflag(target)
 end
 
 function get_headernameflag(target)
-
     local headernameflag = _g.headernameflag
     if headernameflag == nil then
         local compinst = target:compiler("cxx")
@@ -211,7 +210,6 @@ function get_headernameflag(target)
 end
 
 function get_headerunitflag(target)
-
     local headerunitflag = _g.headerunitflag
     if headerunitflag == nil then
         local compinst = target:compiler("cxx")
@@ -226,7 +224,6 @@ function get_headerunitflag(target)
 end
 
 function get_exportheaderflag(target)
-
     local exportheaderflag = _g.exportheaderflag
     if exportheaderflag == nil then
         if get_headernameflag(target) then
@@ -238,7 +235,6 @@ function get_exportheaderflag(target)
 end
 
 function get_scandependenciesflag(target)
-
     local scandependenciesflag = _g.scandependenciesflag
     if scandependenciesflag == nil then
         local compinst = target:compiler("cxx")
@@ -261,7 +257,6 @@ function get_scandependenciesflag(target)
 end
 
 function get_cppversionflag(target)
-
     local cppversionflag = _g.cppversionflag
     if cppversionflag == nil then
         local compinst = target:compiler("cxx")
@@ -272,7 +267,6 @@ function get_cppversionflag(target)
 end
 
 function get_internalpartitionflag(target)
-
     local internalpartitionflag = _g.internalpartitionflag
     if internalpartitionflag == nil then
         local compinst = target:compiler("cxx")

--- a/xmake/rules/c++/modules/msvc/support.lua
+++ b/xmake/rules/c++/modules/msvc/support.lua
@@ -136,9 +136,7 @@ function get_stdmodules(target, opt)
             end
         end
     end
-    if not opt.dont_warn then
-        wprint("std and std.compat modules not found! disabling them for the build")
-    end
+    wprint("std and std.compat modules not found! disabling them for the build")
 end
 
 function get_bmi_extension()

--- a/xmake/rules/c++/modules/msvc/support.lua
+++ b/xmake/rules/c++/modules/msvc/support.lua
@@ -20,6 +20,7 @@
 
 -- imports
 import("core.base.semver")
+import("core.tool.toolchain")
 import("core.project.config")
 import("lib.detect.find_tool")
 import(".support", {inherit = true})
@@ -123,7 +124,7 @@ function get_stdmodules(target, opt)
     end
     local msvc
     if opt.toolchain then
-        msvc = import("core.tool.toolchain", {anonymous = true}).load("msvc", {plat = opt.toolchain:plat(), arch = opt.toolchain:arch()})
+        msvc = toolchain.load("msvc", {plat = opt.toolchain:plat(), arch = opt.toolchain:arch()})
     else
         msvc = target:toolchain("msvc")
     end


### PR DESCRIPTION
this patch default cxx11abi for gcc >= 15 it should be safe now and is a requirement for libstdc++ module
factorize msstl std module support for clang/llvm
add support for libstdc++ module for clang/llvm
add fallback for finding libstdc++ module manifest for gcc
