### PR TITLE
(autotools) fix ld override when ld binary is not in the same directo…

### DIFF
--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -449,7 +449,14 @@ function buildenvs(package, opt)
             name = name:gsub("gcc-%d+", "ld")
             name = name:gsub("g%+%+$", "ld")
             name = name:gsub("g%+%+%-%d+", "ld")
-            envs.LD = dir and path.join(dir, name) or name
+            if os.isfile(path.join(dir, name)) then
+                envs.LD = path.join(dir, name)
+            else
+                local ld = find_tool("ld")
+                if ld and path.filename(ld.program) == name then
+                    envs.LD = ld.program
+                end
+            end
         end
         -- we need use clang++ as cxx, autoconf will use it as linker
         -- https://github.com/xmake-io/xmake/issues/2170

--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -449,7 +449,7 @@ function buildenvs(package, opt)
             name = name:gsub("gcc-%d+", "ld")
             name = name:gsub("g%+%+$", "ld")
             name = name:gsub("g%+%+%-%d+", "ld")
-            if os.isfile(path.join(dir, name)) then
+            if dir and os.isfile(path.join(dir, name)) then
                 envs.LD = path.join(dir, name)
             else
                 local ld = find_tool("ld")


### PR DESCRIPTION
shared  packages installation are broken when --sdk is set with a bin directory without ld binary
e.g when using llvm toolchain with --sdk, ld binary may not exists in the bin directory and result with a non-existent path which make autotools use clang++ as linker wich prevent .so to be generated

