### PR TITLE
Fix make ninja gen headeronly target

### DIFF
--- a/xmake/plugins/project/ninja/build_ninja.lua
+++ b/xmake/plugins/project/ninja/build_ninja.lua
@@ -352,7 +352,7 @@ function _add_build_for_target(ninjafile, target, outputdir)
     target:data_set("plugin.project.kind", "ninja")
 
     -- is phony target?
-    if target:is_phony() then
+    if target:is_phony() or target:is_headeronly() then
         return _add_build_for_phony(ninjafile, target)
     end
 
@@ -378,7 +378,10 @@ function _add_build_for_target(ninjafile, target, outputdir)
         ninjafile:print(" || $")
         ninjafile:write("  ")
         for _, dep in ipairs(deps) do
-            ninjafile:write(" " .. _get_relative_unix_path(project.target(dep, {namespace = target:namespace()}):targetfile(), outputdir))
+            local dep_target = project.target(dep, {namespace = target:namespace()});
+            if not dep_target:is_headeronly() then
+                ninjafile:write(" " .. _get_relative_unix_path(dep_target:targetfile(), outputdir))
+            end
         end
     end
     ninjafile:print("")


### PR DESCRIPTION
Fixed https://github.com/xmake-io/xmake/issues/6382

Make and ninja generator don't support headeronly target kind.
Phony target kind couldn't be a replacement because cmake requires it to be headeronly.