### PR TITLE
Fix xmake failing to find PING.EXE

### DIFF
--- a/xmake/core/sandbox/modules/import/lib/detect/find_program.lua
+++ b/xmake/core/sandbox/modules/import/lib/detect/find_program.lua
@@ -77,14 +77,15 @@ function sandbox_lib_detect_find_program._check(program, opt)
     opt = opt or {}
     local findname = program
     if os.subhost() == "windows" then
-        if not opt.shell and not program:endswith(".exe") and not program:endswith(".cmd") and not program:endswith(".bat") then
+        local ext = path.extension(program):lower()
+        if not opt.shell and ext ~= ".exe" and ext ~= ".cmd" and ext ~= ".bat" then
             findname = program .. ".exe"
         end
     elseif os.subhost() == "msys" and os.isfile(program) and os.filesize(program) < 256 then
         -- only a sh script on msys2? e.g. c:/msys64/usr/bin/7z
         -- we need to use sh to wrap it, otherwise os.exec cannot run it
-        local program_lower = program:lower()
-        if not program_lower:endswith(".exe") and not program_lower:endswith(".cmd") and not program_lower:endswith(".bat") then
+        local ext = path.extension(program):lower()
+        if ext ~= ".exe" and ext ~= ".cmd" and ext ~= ".bat" then
             program = "sh " .. program
         end
         findname = program


### PR DESCRIPTION
Fixes
```
checkinfo: @programdir\core\sandbox\modules\os.lua:264: cannot runv(C:\Windows\System32\PING.EXE.exe -n 1 -w 500 127.0.0.1), No such file or directory
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:1075]:
    [@programdir\core\sandbox\modules\os.lua:264]: in function 'run'
    [@programdir\modules\detect\tools\find_ping.lua:37]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:246]:
    [...\core\sandbox\modules\import\lib\detect\find_program.lua:65]: in function '_do_check'
    [...\core\sandbox\modules\import\lib\detect\find_program.lua:92]: in function '_check'
    [...\core\sandbox\modules\import\lib\detect\find_program.lua:258]: in function '_find'
    [...\core\sandbox\modules\import\lib\detect\find_program.lua:335]:
    [@programdir\modules\lib\detect\find_tool.lua:32]: in function '_find_from_modules'
    [@programdir\modules\lib\detect\find_tool.lua:43]: in function '_find_tool'
    [@programdir\modules\lib\detect\find_tool.lua:89]:
    [@programdir\modules\net\ping.lua:60]:
    [@programdir\modules\net\fasturl.lua:48]: in function 'sort'
    [...\core\sandbox\modules\import\core\package\repository.lua:129]: in function 'repositories'
    [...amdir\modules\private\action\require\impl\repository.lua:120]: in function 'repositories'
    [...amdir\modules\private\action\require\impl\repository.lua:134]: in function 'pulled'
    [@programdir\modules\private\action\require\install.lua:79]:
    [@programdir\actions\config\main.lua:393]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:246]:
    [@programdir\core\base\task.lua:504]: in function 'run'
    [@programdir\core\main.lua:327]: in function 'cotask'
    [@programdir\core\base\scheduler.lua:406]:
```