### PR TITLE
fix upper in xmake.lua

### DIFF
--- a/xmake/rules/platform/windows/subsystem/xmake.lua
+++ b/xmake/rules/platform/windows/subsystem/xmake.lua
@@ -41,7 +41,7 @@ rule("platform.windows.subsystem")
             if target:has_tool("ld", "clang", "clangxx", "clang_cl") then
                 target:add("ldflags", "-Wl,-subsystem:" .. subsystem, { force = true })
             elseif target:has_tool("ld", "link", "lld-link") then
-                target:add("ldflags", "/SUBSYSTEM:" .. string.upper(subsystem), { force = true })
+                target:add("ldflags", "/SUBSYSTEM:" .. subsystem:upper(), { force = true })
             elseif target:has_tool("ld", "gcc", "gxx") then
                 target:add("ldflags", "-Wl,-m" .. subsystem, { force = true })
             elseif target:has_tool("ld", "lld") then

--- a/xmake/rules/platform/windows/subsystem/xmake.lua
+++ b/xmake/rules/platform/windows/subsystem/xmake.lua
@@ -41,7 +41,7 @@ rule("platform.windows.subsystem")
             if target:has_tool("ld", "clang", "clangxx", "clang_cl") then
                 target:add("ldflags", "-Wl,-subsystem:" .. subsystem, { force = true })
             elseif target:has_tool("ld", "link", "lld-link") then
-                target:add("ldflags", "/SUBSYSTEM:" .. upper(subsystem), { force = true })
+                target:add("ldflags", "/SUBSYSTEM:" .. string.upper(subsystem), { force = true })
             elseif target:has_tool("ld", "gcc", "gxx") then
                 target:add("ldflags", "-Wl,-m" .. subsystem, { force = true })
             elseif target:has_tool("ld", "lld") then


### PR DESCRIPTION
小写转大写这部分用的 upper 函数在 windows 上执行的时候报错了，加个 string 的命名标识就OK

### 报错输出

```powershell
build cache stats:
cache directory: build\.build_cache
cache hit rate: 0%
cache hit: 0
cache hit total time: 0.000s
cache miss: 0
cache miss total time: 0.000s
new cached files: 0
remote cache hit: 0
remote new cached files: 0
preprocess failed: 0
compile fallback count: 0
compile total time: 0.000s

create ok!
compile_commands.json updated!
error: @programdir\core\main.lua:329: @programdir\rules\platform\windows\subsystem\xmake.lua:44: attempt to call a nil value (global 'upper')
stack traceback:
    [@programdir\rules\platform\windows\subsystem\xmake.lua:44]: in function 'on_config'
    [...dir\core\sandbox\modules\import\core\project\project.lua:145]: in function '_config_target'
    [...dir\core\sandbox\modules\import\core\project\project.lua:180]: in function '_config_targets'
    [...dir\core\sandbox\modules\import\core\project\project.lua:227]: in function 'load_targets'
    [@programdir\actions\run\main.lua:203]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:246]:
    [@programdir\core\base\task.lua:504]: in function 'run'
    [@programdir\core\main.lua:327]: in function 'cotask'
    [@programdir\core\base\scheduler.lua:406]:

stack traceback:
        [C]: in function 'error'
        @programdir\core\base\os.lua:1075: in function 'base/os.raiselevel'
        (...tail calls...)
        @programdir\core\main.lua:329: in upvalue 'cotask'
        @programdir\core\base\scheduler.lua:406: in function <@programdir\core\base\scheduler.lua:399>
warning: If cmake build failure, set package config cmake = false fallback to b2 for the build
```