### PR TITLE
(C++ modules support) fix _patch_sourcebatch when target and deps is in the same namespace

### DIFF
--- a/tests/projects/c++/modules/namespace/src/hello.mpp
+++ b/tests/projects/c++/modules/namespace/src/hello.mpp
@@ -1,0 +1,14 @@
+export module hello;
+
+export namespace hello {
+    extern int data__;
+    void say_hello();
+
+    class say {
+    public:
+        say(int data);
+        void hello();
+    private:
+        int data_;
+    };
+}

--- a/tests/projects/c++/modules/namespace/src/hello_impl.cpp
+++ b/tests/projects/c++/modules/namespace/src/hello_impl.cpp
@@ -1,0 +1,23 @@
+module;
+#include <iostream>
+
+module hello;
+import mod;
+
+void inner() {
+    std::cout << "hello world! data: "
+              << mod::foo() << std::endl;
+}
+
+namespace hello {
+    int data__;
+    void say_hello() { ::inner(); }
+
+    say::say(int data) : data_{data} {
+    }
+
+    void say::hello() {
+        hello::data__ = data_;
+        ::inner();
+    }
+}

--- a/tests/projects/c++/modules/namespace/src/main.cpp
+++ b/tests/projects/c++/modules/namespace/src/main.cpp
@@ -1,0 +1,9 @@
+import hello;
+
+int main() {
+    hello::data__ = 123;
+    hello::say_hello();
+    hello::say(sizeof(hello::say)).hello();
+    return 0;
+}
+

--- a/tests/projects/c++/modules/namespace/src/mod.mpp
+++ b/tests/projects/c++/modules/namespace/src/mod.mpp
@@ -1,0 +1,5 @@
+export module mod;
+
+export namespace mod {
+    int foo();
+}

--- a/tests/projects/c++/modules/namespace/src/mod_impl.cpp
+++ b/tests/projects/c++/modules/namespace/src/mod_impl.cpp
@@ -1,0 +1,8 @@
+module mod;
+import hello;
+
+namespace mod {
+    int foo() {
+        return hello::data__;
+    }
+}

--- a/tests/projects/c++/modules/namespace/test.lua
+++ b/tests/projects/c++/modules/namespace/test.lua
@@ -1,0 +1,1 @@
+inherit(".test_base")

--- a/tests/projects/c++/modules/namespace/xmake.lua
+++ b/tests/projects/c++/modules/namespace/xmake.lua
@@ -1,0 +1,15 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+namespace("foo", function()
+    target("dep")
+        set_kind("static")
+        add_files("src/hello.mpp", "src/mod.mpp", {public = true})
+        add_files("src/hello_impl.cpp", "src/mod_impl.cpp")
+
+    target("binary")
+        set_kind("binary")
+        add_files("src/main.cpp")
+        add_deps("dep")
+end)
+

--- a/tests/projects/c++/modules/namespace2/src/hello.mpp
+++ b/tests/projects/c++/modules/namespace2/src/hello.mpp
@@ -1,0 +1,14 @@
+export module hello;
+
+export namespace hello {
+    extern int data__;
+    void say_hello();
+
+    class say {
+    public:
+        say(int data);
+        void hello();
+    private:
+        int data_;
+    };
+}

--- a/tests/projects/c++/modules/namespace2/src/hello_impl.cpp
+++ b/tests/projects/c++/modules/namespace2/src/hello_impl.cpp
@@ -1,0 +1,23 @@
+module;
+#include <iostream>
+
+module hello;
+import mod;
+
+void inner() {
+    std::cout << "hello world! data: "
+              << mod::foo() << std::endl;
+}
+
+namespace hello {
+    int data__;
+    void say_hello() { ::inner(); }
+
+    say::say(int data) : data_{data} {
+    }
+
+    void say::hello() {
+        hello::data__ = data_;
+        ::inner();
+    }
+}

--- a/tests/projects/c++/modules/namespace2/src/main.cpp
+++ b/tests/projects/c++/modules/namespace2/src/main.cpp
@@ -1,0 +1,9 @@
+import hello;
+
+int main() {
+    hello::data__ = 123;
+    hello::say_hello();
+    hello::say(sizeof(hello::say)).hello();
+    return 0;
+}
+

--- a/tests/projects/c++/modules/namespace2/src/mod.mpp
+++ b/tests/projects/c++/modules/namespace2/src/mod.mpp
@@ -1,0 +1,5 @@
+export module mod;
+
+export namespace mod {
+    int foo();
+}

--- a/tests/projects/c++/modules/namespace2/src/mod_impl.cpp
+++ b/tests/projects/c++/modules/namespace2/src/mod_impl.cpp
@@ -1,0 +1,8 @@
+module mod;
+import hello;
+
+namespace mod {
+    int foo() {
+        return hello::data__;
+    }
+}

--- a/tests/projects/c++/modules/namespace2/test.lua
+++ b/tests/projects/c++/modules/namespace2/test.lua
@@ -1,0 +1,1 @@
+inherit(".test_base")

--- a/tests/projects/c++/modules/namespace2/xmake.lua
+++ b/tests/projects/c++/modules/namespace2/xmake.lua
@@ -1,0 +1,17 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+namespace("bar", function()
+    target("dep")
+        set_kind("static")
+        add_files("src/hello.mpp", "src/mod.mpp", {public = true})
+        add_files("src/hello_impl.cpp", "src/mod_impl.cpp")
+end)
+
+namespace("foo", function()
+    target("binary")
+        set_kind("binary")
+        add_files("src/main.cpp")
+        add_deps("bar::dep")
+end)
+

--- a/xmake/rules/c++/modules/scanner.lua
+++ b/xmake/rules/c++/modules/scanner.lua
@@ -296,7 +296,11 @@ function _get_targetdeps_modules(target)
                     fileconfig.undefines = table.join(fileconfig.undefines or {}, dep:get("undefines") or {})
                     fileconfig.includedirs = table.join(fileconfig.includedirs or {}, dep:get("includedirs") or {})
                     if not dep:is_phony() then
-                        fileconfig.external = dep:fullname()
+                        if target:namespace() == dep:namespace() then
+                            fileconfig.external = dep:name()
+                        else
+                            fileconfig.external = dep:fullname()
+                        end
                         fileconfig.bmionly = not dep:is_moduleonly()
                     end
                     if not modules[sourcefile] then
@@ -358,6 +362,7 @@ function _patch_sourcebatch(target, sourcebatch)
             local strict = target:policy("build.c++.modules.reuse.strict") or
                            target:policy("build.c++.modules.tryreuse.discriminate_on_defines")
             local dep = target:dep(fileconfig.external)
+            assert(dep, format("dep target <%s> for <%s>", fileconfig.external, target:fullname()))
 
             local can_reuse = nocheck or _are_flags_compatible(target, dep, sourcefile, {strict = strict})
             if can_reuse then

--- a/xmake/rules/c++/modules/scanner.lua
+++ b/xmake/rules/c++/modules/scanner.lua
@@ -362,7 +362,7 @@ function _patch_sourcebatch(target, sourcebatch)
             local strict = target:policy("build.c++.modules.reuse.strict") or
                            target:policy("build.c++.modules.tryreuse.discriminate_on_defines")
             local dep = target:dep(fileconfig.external)
-            assert(dep, format("dep target <%s> for <%s>", fileconfig.external, target:fullname()))
+            assert(dep, "dep target <%s> for <%s>", fileconfig.external, target:fullname())
 
             local can_reuse = nocheck or _are_flags_compatible(target, dep, sourcefile, {strict = strict})
             if can_reuse then


### PR DESCRIPTION
`target:dep("namespace::depname")` seems to not work when dep have the same namespace as target, so this PR get rid of it
