### PR TITLE
update: find qt by qt_sdkver option

### DIFF
--- a/xmake/modules/detect/sdks/find_qt.lua
+++ b/xmake/modules/detect/sdks/find_qt.lua
@@ -141,7 +141,13 @@ function _find_sdkdir(sdkdir, sdkver)
         -- @see https://github.com/xmake-io/xmake/issues/4881
         if sdkver then
             local major = sdkver:sub(1, 1)
-            qmake = find_file("qmake" .. major, paths, {suffixes = subdirs})
+            local suffixes = {major, "-" .. major, "-qt" .. major, ""}
+            for _, suffix in ipairs(suffixes) do
+                qmake = find_file("qmake" .. suffix, paths, {suffixes = subdirs})
+                if qmake then
+                    break
+                end
+            end
         end
         if not qmake then
             qmake = find_file("qmake", paths, {suffixes = subdirs})
@@ -167,18 +173,25 @@ function _find_qmake(sdkdir, sdkver)
     if sdkver then
         sdkver = semver.try_parse(sdkver)
         if sdkver then
-            local cachekey = "qmake-" .. sdkver:major()
-            qmake = find_tool("qmake", {program = "qmake" .. sdkver:major(), cachekey = cachekey, paths = sdkdir and path.join(sdkdir, "bin")})
+            local major = sdkver:major()
+            local suffixes = {major, "-" .. major, "-qt" .. major}
+            for _, suffix in ipairs(suffixes) do
+                local cachekey = "qmake" .. suffix
+                qmake = find_tool("qmake", {program = cachekey, cachekey = cachekey, paths = sdkdir and path.join(sdkdir, "bin")})
+                if qmake then
+                    break
+                end
+            end
         end
     end
 
     -- we need to find the default qmake in current system
     -- maybe we only installed qmake6
     if not qmake then
-        local suffixes = {"", "6", "-qt5"}
+        local suffixes = {"", "6", "-6", "-qt6", "5", "-5", "-qt5"}
         for _, suffix in ipairs(suffixes) do
-            local cachekey = "qmake-" .. suffix
-            qmake = find_tool("qmake", {program = "qmake" .. suffix, cachekey = cachekey, paths = sdkdir and path.join(sdkdir, "bin")})
+            local cachekey = "qmake" .. suffix
+            qmake = find_tool("qmake", {program = cachekey, cachekey = cachekey, paths = sdkdir and path.join(sdkdir, "bin")})
             if qmake then
                 break
             end


### PR DESCRIPTION
## 前言

- 系统：AOSC OS

存在的 qmake 文件名如下

```bash
root@aosc-binlep [ bin ] # qmak
qmake       qmake6-qt6  qmake-qt5   qmake-qt6
```

## 原有行为

通过默认的 sdkdir 直接找 qmake 文件，找到后用 qmake 来获取对应 QT 的版本

加了 qt_sdkver 是不能获取同目录路径下其他 QT 主项目的

获取的信息如下所示

```bash
binlep@aosc-binlep [ LepTV@master ] $ xmake f -m debug --qt_sdkver=6.8.2
checking for platform ... linux
checking for architecture ... x86_64
checking for Qt SDK directory ... /usr
checking for Qt SDK version ... 5.15.16
```

## 修改后行为

### 不指定 qt_sdkver

获取 qmake 对应的版本

```bash
$ xmake f -m debug
checking for platform ... linux
checking for architecture ... x86_64
checking for Qt SDK directory ... /usr
checking for Qt SDK version ... 5.15.16
```

### 指定 qt_sdkver

获取 qt_sdkver 指定的主版本，这里写的 6.8.3，获取的是系统的 6.8.2

```bash
xmake f -m debug --qt_sdkver=6.8.3
checking for platform ... linux
checking for architecture ... x86_64
checking for Qt SDK directory ... /usr
checking for Qt SDK version ... 6.8.2
```

### 其他

如果啥都没搜到的话，（通过 qmake）优先获取 qt6 的版本，再获取 qt5 的版本，最后用默认的版本
