### PR TITLE
fix more versions of the same vstudio in the system.

### DIFF
--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -518,7 +518,7 @@ function _find_vstudio(opt)
         end
         
         if vswhere_VCAuxiliaryBuildDir then
-            for i, vc_path in ipairs(vswhere_VCAuxiliaryBuildDir) do
+            for _, vc_path in ipairs(vswhere_VCAuxiliaryBuildDir) do
                 if os.isdir(vc_path) then
                     table.insert(paths, 1, vc_path)
                 end


### PR DESCRIPTION
Fixed the issue where vstudio cannot be found when there are more versions of the same vstudio in the system.

vswhere echo string:
D:\Microsoft Visual Studio\2022\Professional2
D:\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build

xmake thought it was a string, but in fact, it was two.  should split it by "\n":
{
  "D:\Microsoft Visual Studio\2022\Professional2",
  "D:\Microsoft Visual Studio\2022\Professional"
}

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

