### PR TITLE
fix: rcc search path for qt android

### DIFF
--- a/xmake/rules/qt/deploy/android.lua
+++ b/xmake/rules/qt/deploy/android.lua
@@ -163,6 +163,8 @@ function main(target, opt)
         local search_dirs = {}
         if qt.bindir_host then table.insert(search_dirs, qt.bindir_host) end
         if qt.bindir then table.insert(search_dirs, qt.bindir) end
+        if qt.libexecdir_host then table.insert(search_dirs, qt.libexecdir_host) end
+        if qt.libexecdir then table.insert(search_dirs, qt.libexecdir) end
         local rcc = find_file("rcc" .. (is_host("windows") and ".exe" or ""), search_dirs)
         if os.isexec(rcc) then
             settings_file:print('   "rcc-binary": "%s",', _escape_path(rcc))


### PR DESCRIPTION
Linux 下编译安卓的时候发现的，找不到 rcc 文件，修复方案可以参考：

https://github.com/xmake-io/xmake/blob/dev/xmake/rules/qt/qrc/xmake.lua#L30

加上这两句就可以找到 rcc 文件