### PR TITLE
rule(python.module): remove pybind11-specific linking logic now handled by its package

### DIFF
--- a/xmake/rules/python/module/xmake.lua
+++ b/xmake/rules/python/module/xmake.lua
@@ -42,27 +42,4 @@ rule("python.module")
                 target:set("extension", ".so")
             end
         end
-        -- fix segmentation fault for macosx
-        -- @see https://github.com/xmake-io/xmake/issues/2177#issuecomment-1209398292
-        if target:is_plat("macosx", "linux") then
-            if target:is_plat("macosx") then
-                target:add("shflags", "-undefined dynamic_lookup", {force = true})
-            end
-            for _, pkg in pairs(target:pkgs()) do
-                local links = pkg:get("links")
-                if links then
-                    local with_python = false
-                    for _, link in ipairs(links) do
-                        if link:startswith("python") then
-                            with_python = true
-                            break
-                        end
-                    end
-                    if with_python then
-                        pkg:set("links", nil)
-                        pkg:set("linkdirs", nil)
-                    end
-                end
-            end
-        end
     end)


### PR DESCRIPTION
This pull request removes a legacy workaround from the `python.module` rule that was originally introduced to resolve `pybind11` segmentation faults on macOS. The workaround unconditionally removed all links from packages that linked against Python.

This strategy, though functional for `pybind11`, creates conflicts when using other libraries like `nanobind`.

The specific linking requirements for `pybind11` are now managed directly within the `pybind11` package itself. Therefore, this PR removes the generalized (and now problematic) logic from the `python.module` rule, as it's no longer needed at this level and causes incompatibilities.
