### PR TITLE
rule(c++.modules): fix `get_gcc_version` for MinGW GCC 15 when toolname is 'gxx'

### DIFF
--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -64,7 +64,7 @@ function load(target)
     if cxx11abi == nil then
         -- enable cxx11abi on GCC >= 15 as it is required for C++23 module
         local gcc_version = get_gcc_version(target)
-        if gcc_version and semver.compare(gcc_version, "15") > 0 then
+        if gcc_version and semver.compare(gcc_version, "15") >= 0 then
             cxx11abi = true
         end
     end
@@ -323,7 +323,7 @@ function get_gcc_version(target)
     local gcc_version = _g.gcc_version
     if not gcc_version then
         local program, toolname = target:tool("cxx")
-        if program and toolname:startswith("gcc") then
+        if program and (toolname:startswith("gcc") or toolname:startswith("gxx")) then
             local gcc = find_tool(toolname, {program = program, version = true,
                 envs = os.getenvs(), cachekey = "modules_support_gcc_" .. toolname})
             if gcc then


### PR DESCRIPTION
This PR fixes a compilation failure for C++ standard library module projects using MinGW GCC 15. The failure occurred because `_GLIBCXX_USE_CXX11_ABI=1` was not defined, due to `get_gcc_version` returning `nil` when the CXX toolname (`target:tool("cxx")`) was `gxx` instead of `gcc`.

The fix updates `get_gcc_version` to recognize `gxx` as a valid GCC toolname, ensuring the correct ABI define is applied.

### Reproduction

1.  **Toolchain:** MinGW GCC 15 (e.g., [niXman/mingw-builds-binaries](https://github.com/niXman/mingw-builds-binaries), version 15.1.0).
2.  **Project:** A simple C++ project using `std` modules.
    *   `xmake.lua`:
        ```lua
          add_rules("mode.debug", "mode.release")
          set_languages("c++latest")
          
          target("main")
              set_kind("binary")
              add_files("src/main.cpp")
              add_deps("mod")
          
          target("mod")
              set_kind("static")
              add_files("src/mod.cpp")
              add_files("src/mod.mpp", {public = true})
        ```
    *   Source files (importing `std` and a custom module).
        *  `src/main.cpp`:

        ```cpp
            import std;
            
            import my_module;
            
            using namespace std;
            
            int main(int argc, char** argv) {
                cout << my_sum(1, 1) << endl;
            }
        ```
        *   `src/mod.cpp`:
        ```cpp
        module my_module;
        import std;

        auto my_sum(std::size_t a, std::size_t b) -> std::size_t { return a + b; }
        ```
        *   `src/mod.mpp`:
        ```cpp
            export module my_module;
            
            import std;
            
            export auto my_sum(std::size_t a, std::size_t b) -> std::size_t;
        ```

### Before Fix

Compilation fails when processing `std.cc` with errors indicating missing `std` symbols, due to `-D_GLIBCXX_USE_CXX11_ABI=0` being passed:
```console
[  1%]: <main> scanning.module.deps src\main.cpp
D:\Applications\Scoop\apps\mingw\current\bin\x86_64-w64-mingw32-g++ -E -x c++ -m64 -g -O0 -std=c++26 -fmodules-ts -D_GLIBCXX_USE_CXX11_ABI=0 src\main.cpp -MT build\.gens\main\mingw\x86_64\debug\rules\bmi\cache\scans\319122ae\main.cpp.json -MD -MF build\.gens\main\mingw\x86_64\debug\rules\bmi\cache\scans\319122ae\main.cpp.d -fdeps-format=p1689r5 -fdeps-file=build\.gens\main\mingw\x86_64\debug\rules\bmi\cache\scans\319122ae\main.cpp.json -fdeps-target=build\.objs\main\mingw\x86_64\debug\src\main.cpp.obj -o build\.gens\main\mingw\x86_64\debug\rules\bmi\cache\scans\319122ae\main.cpp.i        
[  1%]: <mod> scanning.module.deps src\mod.cpp
D:\Applications\Scoop\apps\mingw\current\bin\x86_64-w64-mingw32-g++ -E -x c++ -m64 -g -O0 -std=c++26 -fmodules-ts -D_GLIBCXX_USE_CXX11_ABI=0 src\mod.cpp -MT build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\eefc838d\mod.cpp.json -MD -MF build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\eefc838d\mod.cpp.d -fdeps-format=p1689r5 -fdeps-file=build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\eefc838d\mod.cpp.json -fdeps-target=build\.objs\mod\mingw\x86_64\debug\src\mod.cpp.obj -o build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\eefc838d\mod.cpp.i
[  1%]: <mod> scanning.module.deps D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.compat.cc
D:\Applications\Scoop\apps\mingw\current\bin\x86_64-w64-mingw32-g++ -E -x c++ -m64 -g -O0 -std=c++26 -fmodules-ts -D_GLIBCXX_USE_CXX11_ABI=0 D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.compat.cc -MT build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\511069ae\std.compat.cc.json -MD -MF build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\511069ae\std.compat.cc.d -fdeps-format=p1689r5 -fdeps-file=build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\511069ae\std.compat.cc.json -fdeps-target=build\.objs\mod\mingw\x86_64\debug\df7d59a08caf441a9a6c54869ff6d10d\std.compat.cc.obj -o build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\511069ae\std.compat.cc.i
[  1%]: <mod> scanning.module.deps D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc
D:\Applications\Scoop\apps\mingw\current\bin\x86_64-w64-mingw32-g++ -E -x c++ -m64 -g -O0 -std=c++26 -fmodules-ts -D_GLIBCXX_USE_CXX11_ABI=0 D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc -MT build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\9864a9ac\std.cc.json -MD -MF build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\9864a9ac\std.cc.d -fdeps-format=p1689r5 -fdeps-file=build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\9864a9ac\std.cc.json -fdeps-target=build\.objs\mod\mingw\x86_64\debug\df7d59a08caf441a9a6c54869ff6d10d\std.cc.obj -o build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\9864a9ac\std.cc.i
[  1%]: <mod> scanning.module.deps src\mod.mpp
D:\Applications\Scoop\apps\mingw\current\bin\x86_64-w64-mingw32-g++ -E -x c++ -m64 -g -O0 -std=c++26 -fmodules-ts -D_GLIBCXX_USE_CXX11_ABI=0 src\mod.mpp -MT build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\ffcefac1\mod.mpp.json -MD -MF build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\ffcefac1\mod.mpp.d -fdeps-format=p1689r5 -fdeps-file=build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\ffcefac1\mod.mpp.json -fdeps-target=build\.objs\mod\mingw\x86_64\debug\src\mod.mpp.obj -o build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\scans\ffcefac1\mod.mpp.i
checking for flags (gcc_module_mapper) ... ok
> x86_64-w64-mingw32-g++ "-fmodule-mapper=C:\Users\leemu\AppData\Local\Temp\.xmake\250612\_B1BC83EA5E5649308F1DB20E824D3A90" "-m64"
checking for flags (gcc_module_only) ... ok
> x86_64-w64-mingw32-g++ "-fmodule-only" "-m64"
[ 14%]: <mod> compiling.module.debug std
D:\Applications\Scoop\apps\mingw\current\bin\x86_64-w64-mingw32-g++ -c -m64 -g -O0 -std=c++26 -fmodules-ts -D_GLIBCXX_USE_CXX11_ABI=0 -fmodule-mapper=C:\Users\leemu\AppData\Local\Temp\.xmake\250612\ae858f41d8b82f2fc94fcfb063c54938\std.cc.mapper.txt -x c++ -fmodules-ts -o build\.objs\mod\mingw\x86_64\debug\df7d59a08caf441a9a6c54869ff6d10d\std.cc.obj D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc
mapper file for std (D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc) --------
root D:/projects/cpp-playground/module
std D:\projects\cpp-playground\module\build\.gens\mod\mingw\x86_64\debug\rules\bmi\cache\interfaces\9864a9ac\std.gcm   
--------
checking for flags (-fdiagnostics-color=always) ... ok
> x86_64-w64-mingw32-g++ "-fdiagnostics-color=always" "-m64"
error: @programdir\core\main.lua:329: @programdir\actions\build\main.lua:146: @programdir\modules\async\runjobs.lua:331: @programdir\rules\c++\modules\gcc\..\gcc\builder.lua:79: @programdir\modules\core\tools\gcc.lua:1035: D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:1571:14: error: 'basic_osyncstream' has not been declared in 'std'
 1571 |   using std::basic_osyncstream;
      |              ^~~~~~~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:1572:14: error: 'basic_syncbuf' has not been declared in 'std'
 1572 |   using std::basic_syncbuf;
      |              ^~~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:1575:14: error: 'osyncstream' has not been declared in 'std'
 1575 |   using std::osyncstream;
      |              ^~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:1576:14: error: 'syncbuf' has not been declared in 'std'
 1576 |   using std::syncbuf;
      |              ^~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:1577:14: error: 'wosyncstream' has not been declared in 'std'
 1577 |   using std::wosyncstream;
      |              ^~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:1578:14: error: 'wsyncbuf' has not been declared in 'std'
 1578 |   using std::wsyncbuf;
      |              ^~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2103:14: error: 'emit_on_flush' has not been declared in 'std'
 2103 |   using std::emit_on_flush;
      |              ^~~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2104:14: error: 'noemit_on_flush' has not been declared in 'std'
 2104 |   using std::noemit_on_flush;
      |              ^~~~~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2105:14: error: 'flush_emit' has not been declared in 'std'
 2105 |   using std::flush_emit;
      |              ^~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2509:21: error: 'cmatch' has not been declared in 'std::pmr'
 2509 |     using std::pmr::cmatch;
      |                     ^~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2510:21: error: 'match_results' has not been declared in 'std::pmr'
 2510 |     using std::pmr::match_results;
      |                     ^~~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2511:21: error: 'smatch' has not been declared in 'std::pmr'
 2511 |     using std::pmr::smatch;
      |                     ^~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2512:21: error: 'wcmatch' has not been declared in 'std::pmr'
 2512 |     using std::pmr::wcmatch;
      |                     ^~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2513:21: error: 'wsmatch' has not been declared in 'std::pmr'
 2513 |     using std::pmr::wsmatch;
      |                     ^~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2739:21: error: 'basic_string' has not been declared in 'std::pmr'
 2739 |     using std::pmr::basic_string;
      |                     ^~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2740:21: error: 'string' has not been declared in 'std::pmr'
 2740 |     using std::pmr::string;
      |                     ^~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2741:21: error: 'u16string' has not been declared in 'std::pmr'
 2741 |     using std::pmr::u16string;
      |                     ^~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2742:21: error: 'u32string' has not been declared in 'std::pmr'
 2742 |     using std::pmr::u32string;
      |                     ^~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2743:21: error: 'u8string' has not been declared in 'std::pmr'
 2743 |     using std::pmr::u8string;
      |                     ^~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2744:21: error: 'wstring' has not been declared in 'std::pmr'
 2744 |     using std::pmr::wstring;
      |                     ^~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2789:14: error: 'basic_syncbuf' has not been declared in 'std'
 2789 |   using std::basic_syncbuf;
      |              ^~~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2791:14: error: 'basic_osyncstream' has not been declared in 'std'
 2791 |   using std::basic_osyncstream;
      |              ^~~~~~~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2792:14: error: 'osyncstream' has not been declared in 'std'
 2792 |   using std::osyncstream;
      |              ^~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2793:14: error: 'syncbuf' has not been declared in 'std'
 2793 |   using std::syncbuf;
      |              ^~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2794:14: error: 'wosyncstream' has not been declared in 'std'
 2794 |   using std::wosyncstream;
      |              ^~~~~~~~~~~~
D:\Applications\Scoop\apps\mingw\current\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits\std.cc:2795:14: error: 'wsyncbuf' has not been declared in 'std'
 2795 |   using std::wsyncbuf;
      |              ^~~~~~~~
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:1075]:
    [@programdir\modules\core\tools\gcc.lua:1035]: in function 'catch'
    [@programdir\core\sandbox\modules\try.lua:123]: in function 'try'
    [@programdir\modules\core\tools\gcc.lua:976]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:246]:
    [@programdir\core\tool\compiler.lua:288]: in function 'compile'
    [@programdir\rules\c++\modules\gcc\..\gcc\builder.lua:79]: in function '_compile'
    [@programdir\rules\c++\modules\gcc\..\gcc\builder.lua:235]: in function 'make_module_job'
    [@programdir\rules\c++\modules\gcc\..\gcc\..\builder.lua:234]: in function 'jobfunc'
    [@programdir\modules\async\runjobs.lua:247]:
    [C]: in function 'xpcall'
    [@programdir\core\base\utils.lua:246]: in function 'trycall'
    [@programdir\core\sandbox\modules\try.lua:117]: in function 'try'
    [@programdir\modules\async\runjobs.lua:230]: in function 'cotask'
    [@programdir\core\base\scheduler.lua:406]:
```

### After Fix

`get_gcc_version` identifies GCC version for `gxx` toolnames. `_GLIBCXX_USE_CXX11_ABI=1` is defined, allowing standard library modules to compile successfully.