### PR TITLE
python.module: Feature of arg python

### DIFF
--- a/xmake/rules/python/module/xmake.lua
+++ b/xmake/rules/python/module/xmake.lua
@@ -27,7 +27,10 @@ rule("python.module")
         local soabi = target:extraconf("rules", "python.module", "soabi")
         if soabi == nil or soabi then
             import("lib.detect.find_tool")
-            local python = assert(find_tool("python3"), "python not found!")
+            local python = target:extraconf("rules", "python.module", "python")
+            if not python then
+                python = assert(find_tool("python3"), "python not found!")
+            end
             local result = try { function() return os.iorunv(python.program, {"-c", "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"}) end}
             if result then
                 result = result:trim()


### PR DESCRIPTION
    python.module: Feature of arg python

    * Support passing python path by user
      Imagine a situation where user has installed multi python
      versions of python on their computer, find_tool function
      might identify a python version that dismatch the user's
      specified requirement.

---

some important messages in QQ group are listed as follow:

![2ae4599285225b7cc3542eb0662af363](https://github.com/user-attachments/assets/2339abc1-1971-4433-839e-70a87d7cbe68)

I have installed python3.13 and python3.8 (not saying venv). Cause xmake before this patch always use find_tool to detect python, xmake generated soabi not properly.

Therefore, a mechanism that allows user to specify python path is needed.