### PR TITLE
Do not add -fsanitize flags to msvc linker

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2431,7 +2431,8 @@ function _instance:_generate_sanitizer_configs(checkmode, sourcekind)
     end
 
     -- add ldflags and shflags
-    if self:has_tool("ld", "link", "clang", "clangxx", "gcc", "gxx") then
+    -- msvc does not have an fsanitize linker flag, so the 'link' tool is excluded
+    if self:has_tool("ld", "clang", "clangxx", "gcc", "gxx") then
         configs.ldflags = "-fsanitize=" .. checkmode
         configs.shflags = "-fsanitize=" .. checkmode
     end

--- a/xmake/rules/c++/build_sanitizer/config.lua
+++ b/xmake/rules/c++/build_sanitizer/config.lua
@@ -41,7 +41,8 @@ function _add_build_sanitizer(target, sourcekind, checkmode)
     end
 
     -- add ldflags and shflags
-    if target:has_tool("ld", "link", "clang", "clangxx", "gcc", "gxx") then
+    -- msvc does not have an fsanitize linker flag, so the 'link' tool is excluded
+    if target:has_tool("ld", "clang", "clangxx", "gcc", "gxx") then
         target:add("ldflags", "-fsanitize=" .. checkmode, {force = true})
         target:add("shflags", "-fsanitize=" .. checkmode, {force = true})
     end


### PR DESCRIPTION
msvc's linker does not have an `fsanitize` flag. It was not causing build failures by was creating warning messages like:

```text
LINK : warning LNK4044: unrecognized option '/fsanitize=address'; ignored
```

