### PR TITLE
Fix attempt to index a nil value

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -851,7 +851,7 @@ function _get_default_flags(package, configs, buildtype, opt)
         local cmake = find_tool("cmake")
         local _configs = table.join(configs, "-S " .. path.directory(dummy_cmakelist), "-B " .. tmpdir)
         local outdata = try{ function() return os.iorunv(cmake.program, _configs, {envs = runenvs}) end}
-        if outdata then
+        if outdata and outdata ~= "" then
             cmake_default_flags = {}
             cmake_default_flags.cflags = outdata:match("CMAKE_C_FLAGS is (.-)\n") or " "
             cmake_default_flags.cflags = cmake_default_flags.cflags .. " " .. outdata:match(format("CMAKE_C_FLAGS_%s is (.-)\n", buildtype)):replace("/MDd", ""):replace("/MD", "")


### PR DESCRIPTION
```console
error: @programdir/modules/package/tools/cmake.lua:858: attempt to index a nil value
stack traceback:
    [@programdir/modules/package/tools/cmake.lua:858]: in function '_get_default_flags'
    [@programdir/modules/package/tools/cmake.lua:889]: in function '_get_envs_for_default_flags'
    [@programdir/modules/package/tools/cmake.lua:962]: in function '_get_configs'
    [@programdir/modules/package/tools/cmake.lua:1322]: in function 'configure'
    [@programdir/modules/package/tools/cmake.lua:1381]: in function 'install'
    [...e/repositories/xmake-repo/packages/r/robin-map/xmake.lua:18]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:114]: in function 'call'
    [.../modules/private/action/require/impl/actions/install.lua:470]:

  => install robin-map v1.4.0 .. failed
```