### PR TITLE
feat(test): Support expected-failure tests via should_fail option

### DIFF
--- a/xmake/actions/test/main.lua
+++ b/xmake/actions/test/main.lua
@@ -398,18 +398,8 @@ function _run_tests(tests)
     end
 
     -- Print the summary
-    local summary = string.format("\n${color.success}%d%%%%${clear} tests passed, ${color.failure}%d${clear} test(s) failed", passed_rate, #failed_tests)
-    if #unexpected_passes > 0 then
-        summary = summary .. string.format(", ${color.failure}%d unexpected pass(es)${clear}", #unexpected_passes)
-    end
-    if #expected_failures > 0 then
-        summary = summary .. string.format(", ${color.warning}%d${clear} expected failure(s)", #expected_failures)
-    end
-
-    summary = summary .. string.format(" out of ${bright}%d${clear}, spent ${bright}%0.3fs", report.total, spent / 1000)
-    cprint(summary)
     if #failed_tests > 0 or #expected_failures > 0 or #unexpected_passes > 0 then
-        cprint("Detailed summary:")
+        cprint("\nDetailed summary:")
     end
     if #failed_tests > 0 then
         cprint("${color.failure}Failed tests:${clear}")
@@ -431,6 +421,17 @@ function _run_tests(tests)
             print(" - " .. name)
         end
     end
+
+    local summary = string.format("\n${color.success}%d%%%%${clear} tests passed, ${color.failure}%d${clear} test(s) failed", passed_rate, #failed_tests)
+    if #unexpected_passes > 0 then
+        summary = summary .. string.format(", ${color.failure}%d${clear} unexpected pass(es)", #unexpected_passes)
+    end
+    if #expected_failures > 0 then
+        summary = summary .. string.format(", ${color.warning}%d${clear} expected failure(s)", #expected_failures)
+    end
+
+    summary = summary .. string.format(" out of ${bright}%d${clear}, spent ${bright}%0.3fs", report.total, spent / 1000)
+    cprint(summary)
 
     local return_zero = project.policy("test.return_zero_on_failure")
     if not return_zero and report.passed < report.total then

--- a/xmake/actions/test/main.lua
+++ b/xmake/actions/test/main.lua
@@ -168,23 +168,23 @@ function _do_test_target(target, opt)
         end
     end
 
-    if errors and #errors > 0 then
-        opt.errors = errors
-    end
-
     if should_fail then
         if not passed then
             passed = true
-            opt.errors = nil -- clear errors, since failure was expected
+            errors = nil -- clear errors, since failure was expected
         else
             passed = false
             local extra_info = string.format("Test %s unexpectedly passed (should fail)", opt.name)
-            if opt.errors and #opt.errors > 0 then
-                opt.errors = opt.errors .. "\n" .. extra_info
+            if errors and #errors > 0 then
+                errors = errors .. "\n" .. extra_info
             else
-                opt.errors = extra_info
+                errors = extra_info
             end
         end
+    end
+
+    if errors and #errors > 0 then
+        opt.errors = errors
     end
 
     return passed


### PR DESCRIPTION
This patch adds support for marking test cases as expected to fail using the should_fail option in add_tests(). This is useful for validating crash handling, incomplete features, or contract-breaking behavior in a controlled manner.

The test report has also been slightly modified to:
- Distinguish expected failures and unexpected passes.
- Print a detailed summary of failed tests, unexpected passes, and expected failures at the end.

Documentation PR: https://github.com/xmake-io/xmake-docs/pull/230

