### PR TITLE
package(install): refine relative path generation in .pc files

### DIFF
--- a/xmake/modules/private/action/require/impl/actions/install.lua
+++ b/xmake/modules/private/action/require/impl/actions/install.lua
@@ -78,10 +78,10 @@ function _patch_pkgconfig(package)
 
     -- get libs
     local libs = ""
-    local base_libdir = path.join(installdir, "lib")
     for _, linkdir in ipairs(fetchinfo.linkdirs) do
-        if linkdir ~= base_libdir then
-            libs = libs .. " -L" .. "${libdir}/" .. path.unix(path.relative(linkdir, base_libdir))
+        linkdir = path.unix(path.normalize(linkdir)):replace(installdir, "${exec_prefix}", {plain = true})
+        if linkdir ~= "${exec_prefix}/lib" then
+            libs = libs .. " -L" .. linkdir
         end
     end
     libs = libs .. " -L${libdir}"
@@ -94,10 +94,10 @@ function _patch_pkgconfig(package)
 
     -- cflags
     local cflags = ""
-    local base_includedir = path.join(installdir, "include")
     for _, includedir in ipairs(fetchinfo.includedirs or fetchinfo.sysincludedirs) do
-        if includedir ~= base_includedir then
-            cflags = cflags .. " -I" .. "${includedir}/" .. path.unix(path.relative(includedir, base_includedir))
+        includedir = path.unix(path.normalize(includedir)):replace(installdir, "${prefix}", {plain = true})
+        if includedir ~= "${prefix}/include" then
+            cflags = cflags .. " -I" .. includedir
         end
     end
     cflags = cflags .. " -I${includedir}"

--- a/xmake/modules/target/action/install/pkgconfig_importfiles.lua
+++ b/xmake/modules/target/action/install/pkgconfig_importfiles.lua
@@ -41,10 +41,10 @@ function main(target, opt)
 
     -- get libs
     local libs = ""
-    local base_libdir = path.join(installdir, "lib")
     for _, linkdir in ipairs(linkdirs) do
-        if linkdir ~= base_libdir then
-            libs = libs .. " -L" .. "${libdir}/" .. path.unix(path.relative(linkdir, base_libdir))
+        linkdir = path.unix(path.normalize(linkdir)):replace(installdir, "${exec_prefix}", {plain = true})
+        if linkdir ~= "${exec_prefix}/lib" then
+            libs = libs .. " -L" .. linkdir
         end
     end
     libs = libs .. " -L${libdir}"
@@ -57,10 +57,10 @@ function main(target, opt)
 
     -- get cflags
     local cflags = ""
-    local base_includedir = path.join(installdir, "include")
     for _, includedir in ipairs(includedirs) do
-        if includedir ~= base_includedir then
-            cflags = cflags .. " -I" .. "${includedir}/" .. path.unix(path.relative(includedir, base_includedir))
+        includedir = path.unix(path.normalize(includedir)):replace(installdir, "${prefix}", {plain = true})
+        if includedir ~= "${prefix}/include" then
+            cflags = cflags .. " -I" .. includedir
         end
     end
     cflags = cflags .. " -I${includedir}"


### PR DESCRIPTION
A previous change (#6445) was introduced to improve the relocatability of packages by using relative paths in the generated `.pc` files. However, this had an undesirable side effect when handling paths to external dependencies.

**The Problem**

For a package like `libpng` that depends on `zlib`, the paths to `zlib` were converted into deeply nested and fragile relative paths, which is not ideal.

For example, the `Libs` field was changed as follows:
```diff
- Libs:  -LC:/package/z/zlib/v1.3.1/95786712bac941e795afa187a68143a4/lib -L${libdir} -lpng -lzlib
+ Libs:  -L${libdir}/../../../../../z/zlib/v1.3.1/95786712bac941e795afa187a68143a4/lib -L${libdir} -lpng -lzlib
```

This path `(${libdir}/../../...)` is confusing and defeats the purpose of improving relocatability.

**The Solution**

This PR fixes the issue by applying a more precise rule for path conversion:

Paths **within** the package's own installation directory (`installdir`) are converted to be relative to `${prefix}` or `${exec_prefix}`.
Paths **outside** of the package's `installdir `(i.e., pointing to external dependencies) are kept as absolute paths.