### PR TITLE
fix: rust static and shared library failing to find extern crate in windows-msvc

### DIFF
--- a/xmake/rules/rust/xmake.lua
+++ b/xmake/rules/rust/xmake.lua
@@ -105,10 +105,17 @@ rule("rust.build")
         assert(rc, "rustc not found. Failed to add libstd in env")
         local outdata, errdata = os.iorunv(rc.program, {"--print=sysroot"})
         assert(not errdata or errdata == "", "failed to find rust sysroot:\n" .. errdata)
-        local libstd = path.join(outdata:trim(), "bin")
-        target:add("runenvs", "PATH", libstd)
-        target:add("runenvs", "LD_LIBRARY_PATH", libstd)
-        target:add("runenvs", "DYLD_LIBRARY_PATH", libstd)
+        local rustc_sysroot = outdata:trim()
+        if target:is_plat("windows") then
+            local libstd = path.join(rustc_sysroot, "bin")
+            target:add("runenvs", "PATH", libstd)
+        elseif target:is_plat("macosx") then
+            local libstd = path.join(rustc_sysroot, "lib")
+            target:add("runenvs", "DYLD_LIBRARY_PATH", libstd)
+        else
+            local libstd = path.join(rustc_sysroot, "lib")
+            target:add("runenvs", "LD_LIBRARY_PATH", libstd)
+        end
     end)
 
 rule("rust")

--- a/xmake/rules/rust/xmake.lua
+++ b/xmake/rules/rust/xmake.lua
@@ -97,16 +97,18 @@ rule("rust.build")
     end)
     on_build("build.target")
 
-    before_run(function (target)
+    on_config(function (target)
         import("lib.detect.find_tool")
 
-        -- Make sure libstd shared library is available
+        -- Ensure libstd shared library is available when running
         local rc = find_tool("rustc")
         assert(rc, "rustc not found. Failed to add libstd in env")
         local outdata, errdata = os.iorunv(rc.program, {"--print=sysroot"})
         assert(not errdata or errdata == "", "failed to find rust sysroot:\n" .. errdata)
         local libstd = path.join(outdata:trim(), "bin")
-        os.addenvs({PATH = libstd, LD_LIBRARY_PATH = libstd, DYLD_LIBRARY_PATH = libstd})
+        target:add("runenvs", "PATH", libstd)
+        target:add("runenvs", "LD_LIBRARY_PATH", libstd)
+        target:add("runenvs", "DYLD_LIBRARY_PATH", libstd)
     end)
 
 rule("rust")

--- a/xmake/rules/rust/xmake.lua
+++ b/xmake/rules/rust/xmake.lua
@@ -32,6 +32,9 @@ rule("rust.cxxbridge")
 rule("rust.build")
     set_sourcekinds("rc")
     on_load(function (target)
+        -- set cratename
+        local cratename = target:values("rust.cratename") or target:name()
+        target:set("basename", cratename)
         -- set cratetype
         local cratetype = target:values("rust.cratetype")
         if cratetype == "staticlib" then
@@ -43,19 +46,32 @@ rule("rust.build")
             target:add("shflags", "--crate-type=cdylib", {force = true})
             target:add("shflags", "-C prefer-dynamic", {force = true})
         elseif target:is_static() then
+            cratetype = "lib"
+            target:set("values", "rust.cratetype", cratetype)
+            if is_plat("windows") then
+                target:set("prefixname", "lib")
+            end
             target:set("extension", ".rlib")
-            target:add("arflags", "--crate-type=lib", {force = true})
+            target:add("arflags", "--crate-type=" .. cratetype, {force = true})
             target:data_set("inherit.links.deplink", false)
         elseif target:is_shared() then
-            target:add("shflags", "--crate-type=dylib", {force = true})
+            cratetype = "dylib"
+            target:set("values", "rust.cratetype", cratetype)
+            target:add("shflags", "--crate-type=" .. cratetype, {force = true})
             -- fix cannot satisfy dependencies so `std` only shows up once
             -- https://github.com/rust-lang/rust/issues/19680
             --
             -- but it will link dynamic @rpath/libstd-xxx.dylib,
             -- so we can no longer modify and set other rpath paths
             target:add("shflags", "-C prefer-dynamic", {force = true})
+            -- don't add links and instead use --extern CRATE[=PATH]
+            -- also, it'll automatically link from linkdirs (-L) even if no --extern
+            -- https://github.com/xmake-io/xmake/issues/6604
+            target:data_set("inherit.links.deplink", false)
         elseif target:is_binary() then
-            target:add("ldflags", "--crate-type=bin", {force = true})
+            cratetype = "bin"
+            target:set("values", "rust.cratetype", cratetype)
+            target:add("ldflags", "--crate-type=" .. cratetype, {force = true})
         end
 
         -- set edition

--- a/xmake/rules/rust/xmake.lua
+++ b/xmake/rules/rust/xmake.lua
@@ -97,6 +97,18 @@ rule("rust.build")
     end)
     on_build("build.target")
 
+    before_run(function (target)
+        import("lib.detect.find_tool")
+
+        -- Make sure libstd shared library is available
+        local rc = find_tool("rustc")
+        assert(rc, "rustc not found. Failed to add libstd in env")
+        local outdata, errdata = os.iorunv(rc.program, {"--print=sysroot"})
+        assert(not errdata or errdata == "", "failed to find rust sysroot:\n" .. errdata)
+        local libstd = path.join(outdata:trim(), "bin")
+        os.addenvs({PATH = libstd, LD_LIBRARY_PATH = libstd, DYLD_LIBRARY_PATH = libstd})
+    end)
+
 rule("rust")
     add_deps("rust.build")
     add_deps("utils.inherit.links")

--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -96,9 +96,9 @@ function main(target)
             local cratetype = target:values("rust.cratetype")
             -- only bin, lib, rlib, dylib can make use of --extern CRATE[=PATH]
             if cratetype ~= "staticlib" and cratetype ~= "cdylib" then
-                local cratename = target:values("rust.cratename") or target:name()
-                local extern_crate_opt = string.format('--extern %s=%s', cratename, target:targetfile())
-                _add_export_value(target, "rcldflags", extern_crate_opt)
+                local extern_crate_opt = rustc:nf_framework(target:targetfile())
+                local extern_crate = table.concat(extern_crate_opt, " ")
+                _add_export_value(target, "rcflags", extern_crate)
             end
         end
     end

--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -91,6 +91,16 @@ function main(target)
             -- we need to add includedirs to support import modules for golang
             _add_export_value(target, "includedirs", path.directory(targetfile))
         end
+
+        if target:rule("rust") then
+            local cratetype = target:values("rust.cratetype")
+            -- only bin, lib, rlib, dylib can make use of --extern CRATE[=PATH]
+            if cratetype ~= "staticlib" and cratetype ~= "cdylib" then
+                local cratename = target:values("rust.cratename") or target:name()
+                local extern_crate_opt = string.format('--extern %s=%s', cratename, target:targetfile())
+                _add_export_value(target, "rcldflags", extern_crate_opt)
+            end
+        end
     end
 
     -- we export all links and linkdirs in self/packages/options to the parent target by default

--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -96,9 +96,7 @@ function main(target)
             local cratetype = target:values("rust.cratetype")
             -- only bin, lib, rlib, dylib can make use of --extern CRATE[=PATH]
             if cratetype ~= "staticlib" and cratetype ~= "cdylib" then
-                local extern_crate_opt = rustc:nf_framework(target:targetfile())
-                local extern_crate = table.concat(extern_crate_opt, " ")
-                _add_export_value(target, "rcflags", extern_crate)
+                _add_export_value(target, "frameworks", target:targetfile())
             end
         end
     end

--- a/xmake/templates/rust/shared/project/src/foo.rs
+++ b/xmake/templates/rust/shared/project/src/foo.rs
@@ -1,0 +1,4 @@
+pub fn add(a: i32, b: i32) -> i32 {
+    return a + b;
+}
+

--- a/xmake/templates/rust/shared/project/src/main.rs
+++ b/xmake/templates/rust/shared/project/src/main.rs
@@ -1,0 +1,6 @@
+extern crate foo;
+
+fn main() {
+    println!("hello xmake!");
+    println!("add: {}", foo::add(1, 1));
+}

--- a/xmake/templates/rust/shared/project/xmake.lua
+++ b/xmake/templates/rust/shared/project/xmake.lua
@@ -7,12 +7,4 @@ target("${TARGETNAME}_demo")
     add_deps("foo")
     add_files("src/main.rs")
 
-    --- Make sure libstd shared library is available
-    before_run(function (target)
-        local outdata, errdata = os.iorun("rustc --print=sysroot")
-        assert(not errdata or errdata == "", "failed to find rust sysroot:\n" .. errdata)
-        local libstd = path.join(outdata:trim(), "bin")
-        os.addenvs({PATH = libstd, LD_LIBRARY_PATH = libstd, DYLD_LIBRARY_PATH = libstd})
-    end)
-
 ${FAQ}

--- a/xmake/templates/rust/shared/project/xmake.lua
+++ b/xmake/templates/rust/shared/project/xmake.lua
@@ -1,0 +1,18 @@
+target("foo")
+    set_kind("shared")
+    add_files("src/foo.rs")
+
+target("${TARGETNAME}_demo")
+    set_kind("binary")
+    add_deps("foo")
+    add_files("src/main.rs")
+
+    --- Make sure libstd shared library is available
+    before_run(function (target)
+        local outdata, errdata = os.iorun("rustc --print=sysroot")
+        assert(not errdata or errdata == "", "failed to find rust sysroot:\n" .. errdata)
+        local libstd = path.join(outdata:trim(), "bin")
+        os.addenvs({PATH = libstd, LD_LIBRARY_PATH = libstd, DYLD_LIBRARY_PATH = libstd})
+    end)
+
+${FAQ}

--- a/xmake/templates/rust/shared/template.lua
+++ b/xmake/templates/rust/shared/template.lua
@@ -1,0 +1,2 @@
+template("shared")
+    add_configfiles("xmake.lua")


### PR DESCRIPTION
* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

------

- Aims to fix #6604 
- Also, added shared library template for rust.

```lua
target("foo")
    set_kind("static")
    add_files("src/foo.rs")
    -- set_values("rust.cratetype", "staticlib")
    -- set_values("rust.cratetype", "cdylib")

target("test1_demo")
    set_kind("binary")
    add_deps("foo")
    add_files("src/main.rs")
```

```lua
target("foo")
    set_kind("shared")
    add_files("src/foo.rs")
    set_values("rust.cratename", "bar")

target("test2_demo")
    set_kind("binary")
    add_deps("foo")
    add_files("src/main.rs") -- extern crate bar as foo;

    -- Incase of dylib, rule("rust") on_config ensures libstd shared library is available when running
```