### PR TITLE
(cmake) fix default flags detection on windows platform

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -819,15 +819,22 @@ end
 function _get_default_flags(package, configs, buildtype, opt)
     -- The default flags are different for different platforms
     -- @see https://github.com/xmake-io/xmake-repo/pull/4038#issuecomment-2116489448
-    local cachekey = buildtype .. package:plat() .. package:arch() .. package:build_getenv("cc") .. package:build_getenv("cxx")
+    local cc = package:build_getenv("cc")
+    local cxx = package:build_getenv("cxx")
+    local cachekey = buildtype .. package:plat() .. package:arch() .. (cc or "") .. (cxx or "")
     local cmake_default_flags = _g.cmake_default_flags and _g.cmake_default_flags[cachekey]
     if not cmake_default_flags then
         local tmpdir = path.join(os.tmpfile() .. ".dir", package:displayname(), package:mode())
         local dummy_cmakelist = path.join(tmpdir, "CMakeLists.txt")
 
-        -- set compiler
-        local cc_flag =  "-DCMAKE_C_COMPILER=" .. _translate_bin_path(package:build_getenv("cc"))
-        local cxx_flag =  "-DCMAKE_CXX_COMPILER=" .. _translate_bin_path(package:build_getenv("cxx"))
+        local cflags
+        if cc then
+            cflags = "-DCMAKE_C_COMPILER=" .. _translate_bin_path(cc)
+        end
+        local cxxflags
+        if cxx then
+            cxxflags = "-DCMAKE_CXX_COMPILER=" .. _translate_bin_path(cxx)
+        end
 
         -- About the minimum cmake version requirement
         -- @see https://github.com/xmake-io/xmake/pull/6032
@@ -853,7 +860,7 @@ function _get_default_flags(package, configs, buildtype, opt)
 
         local runenvs = opt.envs or buildenvs(package)
         local cmake = find_tool("cmake")
-        local _configs = table.join(configs, "-S " .. path.directory(dummy_cmakelist), "-B " .. tmpdir, cc_flag, cxx_flag)
+        local _configs = table.join(configs, "-S " .. path.directory(dummy_cmakelist), "-B " .. tmpdir, cflags or {}, cxxflags)
         local outdata = try{ function() return os.iorunv(cmake.program, _configs, {envs = runenvs}) end}
         if outdata and outdata ~= "" then
             cmake_default_flags = {}


### PR DESCRIPTION
when using llvm or clang  toolchain on windows platform and using --sdk instead of having clang in PATH env var, xmake fail to get correct default c and cxx flags when installing a package using CMake, this patch fix it