### PR TITLE
fix: the cmake module cannot get the option `cxxflags` correctly

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -227,7 +227,7 @@ function _get_cxxflags(package, opt)
     table.join2(result, package:config("cxxflags"))
     table.join2(result, package:config("cxflags"))
     if opt.cxxflags then
-        table.join2(result, opt.cflags)
+        table.join2(result, opt.cxxflags)
     end
     if opt.cxflags then
         table.join2(result, opt.cxflags)


### PR DESCRIPTION
Though `cxxflags` option is not in the documentation of xmake cmake module, the code here is still an obvious mistake
