### PR TITLE
Fix python module

### DIFF
--- a/xmake/rules/python/module/xmake.lua
+++ b/xmake/rules/python/module/xmake.lua
@@ -27,7 +27,9 @@ rule("python.module")
         local soabi = target:extraconf("rules", "python.module", "soabi")
         if soabi == nil or soabi then
             import("lib.detect.find_tool")
-            local python = assert(find_tool("python3"), "python not found!")
+
+            local envs = target:pkgenvs()
+            local python = assert(find_tool("python3", {envs = envs}), "python not found!")
             local result = try { function() return os.iorunv(python.program, {"-c", "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))"}) end}
             if result then
                 result = result:trim()


### PR DESCRIPTION
When using xrepo python, it should not find the system python library.

```console
$ xmake
[ 93%]: linking.release xxx.cpython-310-x86_64-linux-gnu.so
[100%]: build ok, spent 4.133s
$ xrepo env python --version
Python 3.11.9
```