### PR TITLE
fix: Fix prolonged blocking in _ping_via_wget by setting "--tries=1"

### DIFF
--- a/xmake/modules/net/ping.lua
+++ b/xmake/modules/net/ping.lua
@@ -73,7 +73,7 @@ end
 function _ping_via_wget(wget, host)
     local data = try { function ()
         local t = os.mclock()
-        os.runv(wget.program, {"-O", os.nuldev(), "--timeout=1", host})
+        os.runv(wget.program, {"-O", os.nuldev(), "--tries=1", "--timeout=1", host})
         t = os.mclock() - t
         return t
     end }


### PR DESCRIPTION
wget默认会重试20次，使用_ping_via_wget测速时若host不可达则会重试20次导致在此长时间阻塞。
添加--tries=1限制重试次数解决这个问题

