### PR TITLE
feat(C++ modules support) use a file for requires flags when --verbose or --diagnosis is supplied

### DIFF
--- a/tests/projects/c++/modules/hide_dependency_flags/src/bar.mpp
+++ b/tests/projects/c++/modules/hide_dependency_flags/src/bar.mpp
@@ -1,0 +1,8 @@
+export module bar;
+import zoo;
+
+export namespace bar {
+    int add(int a, int b) {
+        return zoo::add(a, b);
+    }
+}

--- a/tests/projects/c++/modules/hide_dependency_flags/src/cat.mpp
+++ b/tests/projects/c++/modules/hide_dependency_flags/src/cat.mpp
@@ -1,0 +1,8 @@
+export module cat;
+
+export namespace cat {
+    int sub(int a, int b) {
+        return a - b;
+    }
+}
+

--- a/tests/projects/c++/modules/hide_dependency_flags/src/foo.mpp
+++ b/tests/projects/c++/modules/hide_dependency_flags/src/foo.mpp
@@ -1,0 +1,13 @@
+export module foo;
+import bar;
+import cat;
+
+export namespace foo {
+    int add(int a, int b) {
+        return bar::add(a, b);
+    }
+    int sub(int a, int b) {
+        return cat::sub(a, b);
+    }
+}
+

--- a/tests/projects/c++/modules/hide_dependency_flags/src/main.cpp
+++ b/tests/projects/c++/modules/hide_dependency_flags/src/main.cpp
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+import foo;
+
+int main() {
+    printf("add(1, 2): %d\n", foo::add(1, 2));
+    printf("sub(1, 2): %d\n", foo::sub(1, 2));
+    return 0;
+}
+

--- a/tests/projects/c++/modules/hide_dependency_flags/src/main.cpp
+++ b/tests/projects/c++/modules/hide_dependency_flags/src/main.cpp
@@ -2,7 +2,7 @@
 
 import foo;
 
-int main() {
+int main(int argc, char** argv) {
     printf("add(1, 2): %d\n", foo::add(1, 2));
     printf("sub(1, 2): %d\n", foo::sub(1, 2));
     return 0;

--- a/tests/projects/c++/modules/hide_dependency_flags/src/zoo.mpp
+++ b/tests/projects/c++/modules/hide_dependency_flags/src/zoo.mpp
@@ -1,0 +1,8 @@
+export module zoo;
+
+export namespace zoo {
+    int add(int a, int b) {
+        return a + b;
+    }
+}
+

--- a/tests/projects/c++/modules/hide_dependency_flags/test.lua
+++ b/tests/projects/c++/modules/hide_dependency_flags/test.lua
@@ -1,0 +1,1 @@
+inherit(".test_base")

--- a/tests/projects/c++/modules/hide_dependency_flags/xmake.lua
+++ b/tests/projects/c++/modules/hide_dependency_flags/xmake.lua
@@ -1,0 +1,7 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("dependence2")
+    set_kind("binary")
+    add_files("src/*.cpp", "src/*.mpp")
+    set_policy("build.c++.modules.hide_dependencies", true)

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -72,6 +72,8 @@ function policy.policies()
             ["build.rpath"]                       = {description = "Enable build rpath.", default = true, type = "boolean"},
             -- Enable C++ modules for C++ building, even if no .mpp is involved in the compilation
             ["build.c++.modules"]                 = {description = "Enable C++ modules for C++ building.", type = "boolean"},
+            -- Hide C++ required files to reduce noise (may reduce build performance)
+            ["build.c++.modules.hide_dependencies"] = {description = "Hide dependencies from the commandline when build C++ modules.", default = false, type = "boolean"},
             -- Enable two phase compilation for C++ modules if supported by the compiler
             ["build.c++.modules.two_phases"]      = {description = "Enable two phase compilation if supported.", default = true, type = "boolean"},
             -- Enable std module

--- a/xmake/rules/c++/modules/clang/builder.lua
+++ b/xmake/rules/c++/modules/clang/builder.lua
@@ -104,6 +104,24 @@ function _make_headerunitflags(target, headerunit)
     return flags
 end
 
+
+function _get_mapper_str(target, module, opt)
+    local mapper_str
+    if target:policy("build.c++.modules.hide_dependencies") and option.get("diagnosis") then
+        if not opt.headerunit then
+            local requires_flagsfile = target:autogenfile(module.sourcefile .. ".requiresflags.txt")
+            if os.isfile(requires_flagsfile) then
+                if module.name then
+                    mapper_str = format("\n${dim color.warning}mapper file for %s (%s) --------\n%s\n--------", module.name, module.sourcefile, io.readfile(requires_flagsfile):trim())
+                else
+                    mapper_str = format("\n${dim color.warning}mapper file for %s --------\n%s\n--------", module.sourcefile, io.readfile(requires_flagsfile):trim())
+                end
+            end
+        end
+    end
+    return mapper_str
+end
+
 -- do compile
 function _compile(target, flags, module, opt)
 
@@ -119,7 +137,7 @@ function _compile(target, flags, module, opt)
     if option.get("verbose") then
         cmd = "\n" .. compinst:compcmd(sourcefile, outputfile, {target = target, compflags = flags, sourcekind = "cxx", rawargs = true})
     end
-    show_progress(target, module, table.join(opt, {cmd = cmd}))
+    show_progress(target, module, table.join(opt, {cmd = cmd, suffix = _get_mapper_str(target, module, opt)}))
 
     -- do compile
     if not dryrun then
@@ -142,7 +160,7 @@ function _batchcmds_compile(batchcmds, target, flags, module, opt)
     if option.get("verbose") then
         cmd = "\n" .. compinst:compcmd(sourcefile, outputfile, {target = target, compflags = flags, sourcekind = "cxx", rawargs = true})
     end
-    show_progress(target, module, table.join(opt, {cmd = cmd, batchcmds = batchcmds}))
+    show_progress(target, module, table.join(opt, {cmd = cmd, batchcmds = batchcmds, suffix = _get_mapper_str(target, module, opt)}))
 
     -- do compile
     batchcmds:compilev(flags, {compiler = compinst, sourcekind = "cxx", verbose = false})
@@ -194,15 +212,28 @@ end
 function _append_requires_flags(target, module)
     local cxxflags = {}
     local requiresflags = _get_requiresflags(target, module)
-    for _, flag in ipairs(requiresflags) do
-        -- we need to wrap flag to support flag with space
-        if type(flag) == "string" and flag:find(" ", 1, true) then
-            table.insert(cxxflags, {flag})
+    local hide_dependencies = target:policy("build.c++.modules.hide_dependencies")
+    if #requiresflags> 0 then
+        for _, flag in ipairs(requiresflags) do
+            -- we need to wrap flag to support flag with space
+            if type(flag) == "string" and flag:find(" ", 1, true) and not hide_dependencies then
+                    table.insert(cxxflags, {flag})
+            else
+                if hide_dependencies then
+                    table.insert(cxxflags, '"' .. path.unix(flag) .. '"')
+                else
+                    table.insert(cxxflags, flag)
+                end
+            end
+        end
+        if hide_dependencies then
+            local requires_flagsfile = target:autogenfile(module.sourcefile .. ".requiresflags.txt")
+            io.writefile(requires_flagsfile, path.unix(table.concat(cxxflags, "\n")))
+            target:fileconfig_add(module.sourcefile, {force = {cxxflags = {{"@" .. requires_flagsfile}}}})
         else
-            table.insert(cxxflags, flag)
+            target:fileconfig_add(module.sourcefile, {force = {cxxflags = cxxflags}})
         end
     end
-    target:fileconfig_add(module.sourcefile, {force = {cxxflags = cxxflags}})
 end
 
 function append_requires_flags(target, built_modules)

--- a/xmake/rules/c++/modules/clang/builder.lua
+++ b/xmake/rules/c++/modules/clang/builder.lua
@@ -217,7 +217,7 @@ function _append_requires_flags(target, module)
         for _, flag in ipairs(requiresflags) do
             -- we need to wrap flag to support flag with space
             if type(flag) == "string" and flag:find(" ", 1, true) and not hide_dependencies then
-                    table.insert(cxxflags, {flag})
+                table.insert(cxxflags, {flag})
             else
                 if hide_dependencies then
                     table.insert(cxxflags, '"' .. path.unix(flag) .. '"')

--- a/xmake/rules/c++/modules/msvc/builder.lua
+++ b/xmake/rules/c++/modules/msvc/builder.lua
@@ -102,6 +102,23 @@ function _make_headerunitflags(target, headerunit, headertype)
     return flags
 end
 
+function _get_mapper_str(target, module, opt)
+    local mapper_str
+    if target:policy("build.c++.modules.hide_dependencies") and option.get("diagnosis") then
+        if not opt.headerunit then
+            local requires_flagsfile = target:autogenfile(module.sourcefile .. ".requiresflags.txt")
+            if os.isfile(requires_flagsfile) then
+                if module.name  then
+                    mapper_str = format("\n${dim color.warning}mapper file for %s (%s) --------\n%s\n--------", module.name, module.sourcefile, io.readfile(requires_flagsfile):trim())
+                else
+                    mapper_str = format("\n${dim color.warning}mapper file for %s --------\n%s\n--------", module.sourcefile, io.readfile(requires_flagsfile):trim())
+                end
+            end
+        end
+    end
+    return mapper_str
+end
+
 -- do compile
 function _compile(target, flags, module, opt)
     opt = opt or {}
@@ -121,7 +138,7 @@ function _compile(target, flags, module, opt)
             cmd = "\n" .. compinst:compcmd(sourcefile, outputfile, {target = target, compflags = flags, sourcekind = "cxx", rawargs = true})
         end
     end
-    show_progress(target, module, table.join(opt, {cmd = cmd}))
+    show_progress(target, module, table.join(opt, {cmd = cmd, suffix = _get_mapper_str(target, module, opt)}))
 
     -- do compile
     if not dryrun then
@@ -148,7 +165,7 @@ function _batchcmds_compile(batchcmds, target, flags, module, opt)
             cmd = "\n" .. compinst:compcmd(sourcefile, outputfile, {target = target, compflags = flags, sourcekind = "cxx", rawargs = true})
         end
     end
-    show_progress(target, module, table.join(opt, {cmd = cmd, batchcmds = batchcmds}))
+    show_progress(target, module, table.join(opt, {cmd = cmd, batchcmds = batchcmds, suffit = _get_mapper_str(target, module, opt)}))
 
     -- do compile
     batchcmds:compilev(flags, {compiler = compinst, sourcekind = "cxx", verbose = false})
@@ -215,8 +232,20 @@ function _get_requiresflags(target, module)
 end
 
 function _append_requires_flags(target, module)
-    local requiresflags = _get_requiresflags(target, module)
-    target:fileconfig_add(module.sourcefile, {force = {cxxflags = requiresflags}})
+    local cxxflags = _get_requiresflags(target, module)
+    if #cxxflags > 0 then
+        if target:policy("build.c++.modules.hide_dependencies") then
+            local _cxxflags = {}
+            for _, flag in ipairs(cxxflags) do
+                table.insert(_cxxflags, flag[1] .. ' "' .. path.unix(flag[2]) .. '"')
+            end
+            local requires_flagsfile = target:autogenfile(module.sourcefile .. ".requiresflags.txt")
+            io.writefile(requires_flagsfile, table.concat(_cxxflags, "\n"))
+            target:fileconfig_add(module.sourcefile, {force = {cxxflags = {{"@" .. requires_flagsfile}}}})
+        else
+            target:fileconfig_add(module.sourcefile, {force = {cxxflags = cxxflags}})
+        end
+    end
 end
 
 function append_requires_flags(target, built_modules)

--- a/xmake/rules/c++/modules/support.lua
+++ b/xmake/rules/c++/modules/support.lua
@@ -76,10 +76,14 @@ end
 -- strip flags not relevent for module reuse
 function strip_flags(target, flags, opt)
 
-    local strippeable_flags, splitted_strippeable_flags =  _support(target).strippeable_flags()
-
-    if opt and opt.strip_defines then
-        table.join2(splitted_strippeable_flags, {"D", "U"})
+    local strippeable_flags, splitted_strippeable_flags
+    if not opt.requiresonly then
+        strippeable_flags, splitted_strippeable_flags =  _support(target).strippeable_flags()
+        if opt and opt.strip_defines then
+            table.join2(splitted_strippeable_flags, {"D", "U"})
+        end
+    else
+        strippeable_flags, splitted_strippeable_flags =  _support(target).require_flags()
     end
 
     local splitted_strippeable_flags_set = hashset.new()


### PR DESCRIPTION
this PR add a new policy `build.c++.modules.hide_dependency` (default to false)  that enable passing requires flags as a file to reduce build log noise when compiling with -v (only impact msvc and clang as gcc already use a mapper file that do the same thing)
and make -D print the mapping like for gcc

before ---------
-v:
<img width="1179" height="927" alt="{7174ADBE-76EC-453D-8B99-7F6B88D9F1D1}" src="https://github.com/user-attachments/assets/c9b121a9-3b66-4d0c-96cc-dde429885a53" />

-D
<img width="465" height="139" alt="{C376C195-4DE8-401E-936A-9D5894A84237}" src="https://github.com/user-attachments/assets/b45006b3-3bb3-4e95-a241-e8083f18dbda" />

-vD:
<img width="1176" height="1002" alt="{856C06DC-C87E-429F-B443-238F7340DBE4}" src="https://github.com/user-attachments/assets/00a03fb7-ab39-4d99-ad83-b1e736a529ab" />


after ---------
-v:
<img width="1180" height="807" alt="{D81D94C5-6E18-4F62-B4FD-02C7EF1E4228}" src="https://github.com/user-attachments/assets/bbbf240b-bc0b-4fb8-8aef-a5394646ffa2" />

-D
<img width="1179" height="1020" alt="{0823A46A-FFD7-4400-AA20-4B6DB92B5A2D}" src="https://github.com/user-attachments/assets/3017404a-9e25-49f2-81ea-bbfca81a0527" />

-vD:
<img width="1179" height="1027" alt="{89A60786-6361-48F0-AB9F-B2198AC6808A}" src="https://github.com/user-attachments/assets/e3a1b568-e064-4e60-bcd7-0af3742f4807" />



