### PR TITLE
fix: Cache compiler version detection

### DIFF
--- a/xmake/modules/detect/tools/find_gxx.lua
+++ b/xmake/modules/detect/tools/find_gxx.lua
@@ -52,8 +52,7 @@ function main(opt)
                 command = "--version",
                 cachekey = "find_gxx_is_clang",
                 envs = opt.envs,
-                parse = function(output)
-                    return output:find("clang", 1, true)
+                    return output:find("clang", 1, true) ~= nil
                 end
             })
         if versioninfo then

--- a/xmake/modules/detect/tools/find_gxx.lua
+++ b/xmake/modules/detect/tools/find_gxx.lua
@@ -47,8 +47,16 @@ function main(opt)
     -- is clang++ or g++
     local is_clang = false
     if program then
-        local versioninfo = os.iorunv(program, {"--version"}, {envs = opt.envs})
-        if versioninfo and versioninfo:find("clang", 1, true) then
+        local versioninfo = find_programver(program,
+            {
+                command = "--version",
+                cachekey = "find_gxx_is_clang",
+                envs = opt.envs,
+                parse = function(output)
+                    return output:find("clang", 1, true)
+                end
+            })
+        if versioninfo then
             is_clang = true
         end
     end


### PR DESCRIPTION
When detecting the version of clang++ or g++, the running results were not cached, leading to multiple version retrievals. Here, the `find_programver` cache is reused for clang search logic. After modifications and testing, the build time has returned to normal.

fixed #6767 