### PR TITLE
add build.linker.output

### DIFF
--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -106,6 +106,9 @@ function policy.policies()
             ["build.c++.msvc.runtime"]            = {description = "Set the default vs runtime.", type = "string", values = {"MT", "MD"}},
             -- Enable cuda device link
             ["build.cuda.devlink"]                = {description = "Enable Cuda devlink.", type = "boolean"},
+            -- Enable linker output, e.g. show -Wl,--print-memory-usage output for gcc/g++
+            -- @see https://github.com/xmake-io/xmake/discussions/6772
+            ["build.linker.output"]               = {description = "Enable linker output.", type = "boolean"},
             -- Enable build jobgraph
             ["build.jobgraph"]                    = {description = "Enable build jobgraph.", default = true, type = "boolean"},
             -- Enable windows UAC and set level, e.g. invoker, admin, highest

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -937,6 +937,13 @@ end
 function link(self, objectfiles, targetkind, targetfile, flags, opt)
     opt = opt or {}
 
+    -- enable linker output?
+    local target = opt.target
+    local linker_output = option.get("verbose")
+    if linker_output == nil and target and target.policy and target:policy("build.linker.output") then
+        linker_output = true
+    end
+
     os.mkdir(path.directory(targetfile))
     local implibfile = _get_implibfile(self, targetkind, targetfile, opt)
     if implibfile then
@@ -944,7 +951,7 @@ function link(self, objectfiles, targetkind, targetfile, flags, opt)
     end
 
     local program, argv = linkargv(self, objectfiles, targetkind, targetfile, flags, opt)
-    if option.get("verbose") then
+    if linker_output then
         os.execv(program, argv, {envs = self:runenvs(), shell = opt.shell})
     else
         os.vrunv(program, argv, {envs = self:runenvs(), shell = opt.shell})


### PR DESCRIPTION
https://github.com/xmake-io/xmake/discussions/6772
https://github.com/xmake-io/xmake/discussions/2916

```sh
ruki@95d67944153d:/tmp/test$ xmake f --policies=build.linker.output
ruki@95d67944153d:/tmp/test$ xmake -r
[ 23%]: cache compiling.release src/main.cpp
[ 47%]: linking.release test
Memory region         Used Size  Region Size  %age Used
[100%]: build ok, spent 0.502s
```

or 

```lua
set_policy("build.linker.output", true)
```