### PR TITLE
workflows: use musl to avoid glibc's version issue

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Artifact
         run: |
           cd core
-          xrepo env -b zig xmake f --embed=y --toolchain=zig --cross=x86_64-linux-gnu.2.29 -c
+          xrepo env -b zig xmake f --embed=y --toolchain=zig --cross=x86_64-linux-musl -c
           xmake
           mkdir ../artifacts
           cp build/xmake ../artifacts/xmake-bundle


### PR DESCRIPTION
- #6792

use musl-libc static link xmake-bundle to avoid "version `GLIBC_2.29' not found"

