### PR TITLE
feat(wdk rules) enable support of incomplete wdk

### DIFF
--- a/xmake/rules/wdk/inf/xmake.lua
+++ b/xmake/rules/wdk/inf/xmake.lua
@@ -41,7 +41,6 @@ rule("wdk.inf")
 
         -- get stampinf
         local stampinf = path.join(wdk.bindir, wdk.sdkver, arch, is_host("windows") and "stampinf.exe" or "stampinf")
-        assert(stampinf and os.isexec(stampinf), "stampinf not found!")
 
         -- save uic
         target:data_set("wdk.stampinf", stampinf)
@@ -93,6 +92,7 @@ rule("wdk.inf")
 
         -- get stampinf
         local stampinf = target:data("wdk.stampinf")
+        assert(stampinf and os.isexec(stampinf), "stampinf not found!")
 
         -- update the timestamp
         os.cp(sourcefile, targetfile)

--- a/xmake/rules/wdk/man/xmake.lua
+++ b/xmake/rules/wdk/man/xmake.lua
@@ -44,7 +44,6 @@ rule("wdk.man")
         if not os.isexec(ctrpp) then
             ctrpp = path.join(wdk.bindir, wdk.sdkver, arch, "ctrpp.exe")
         end
-        assert(os.isexec(ctrpp), "ctrpp not found!")
 
         -- save ctrpp
         target:data_set("wdk.ctrpp", ctrpp)
@@ -61,6 +60,7 @@ rule("wdk.man")
 
         -- get ctrpp
         local ctrpp = target:data("wdk.ctrpp")
+        assert(ctrpp and os.isexec(ctrpp), "ctrpp not found!")
 
         -- get output directory
         local outputdir = path.join(target:autogendir(), "rules", "wdk", "man")

--- a/xmake/rules/wdk/mc/xmake.lua
+++ b/xmake/rules/wdk/mc/xmake.lua
@@ -44,7 +44,6 @@ rule("wdk.mc")
         if not os.isexec(mc) then
             mc = path.join(wdk.bindir, wdk.sdkver, arch, is_host("windows") and "mc.exe" or "mc")
         end
-        assert(os.isexec(mc), "mc not found!")
 
         -- save mc
         target:data_set("wdk.mc", mc)
@@ -61,6 +60,7 @@ rule("wdk.mc")
 
         -- get mc
         local mc = target:data("wdk.mc")
+        assert(mc and os.isexec(mc), "mc not found!")
 
         -- get output directory
         local outputdir = path.join(target:autogendir(), "rules", "wdk", "mc")

--- a/xmake/rules/wdk/mof/xmake.lua
+++ b/xmake/rules/wdk/mof/xmake.lua
@@ -47,7 +47,6 @@ rule("wdk.mof")
             os.run("%s %s", program, tmpmof)
             os.tryrm(tmpmof)
         end})
-        assert(mofcomp, "mofcomp not found!")
 
         -- get wmimofck
         local wmimofck = nil
@@ -59,7 +58,6 @@ rule("wdk.mof")
         else
             wmimofck = path.join(wdk.bindir, wdk.sdkver, "x86", "wmimofck.exe")
         end
-        assert(wmimofck and os.isexec(wmimofck), "wmimofck not found!")
 
         -- save mofcomp and wmimofck
         target:data_set("wdk.mofcomp", mofcomp)
@@ -77,9 +75,11 @@ rule("wdk.mof")
 
         -- get mofcomp
         local mofcomp = target:data("wdk.mofcomp")
+        assert(mofcomp and os.isexec(mofcomp), "mofcomp not found!")
 
         -- get wmimofck
         local wmimofck = target:data("wdk.wmimofck")
+        assert(wmimofck and os.isexec(wmimofck), "wmimofck not found!")
 
         -- get output directory
         local outputdir = path.join(target:autogendir(), "rules", "wdk", "mof")

--- a/xmake/rules/wdk/package/xmake.lua
+++ b/xmake/rules/wdk/package/xmake.lua
@@ -55,7 +55,7 @@ rule("wdk.package.cab")
 
         -- get makecab
         local makecab = find_program("makecab", {check = "/?"})
-        assert(makecab, "makecab not found!")
+        assert(makecab and os.isexec(makecab), "makecab not found!")
 
         -- make .ddf file
         local file = io.open(ddfile, "w")

--- a/xmake/rules/wdk/sign/xmake.lua
+++ b/xmake/rules/wdk/sign/xmake.lua
@@ -54,7 +54,6 @@ rule("wdk.sign")
         if not os.isexec(inf2cat) then
             inf2cat = path.join(wdk.bindir, wdk.sdkver, "x86", "inf2cat.exe")
         end
-        assert(os.isexec(inf2cat), "inf2cat not found!")
         target:data_set("wdk.sign.inf2cat", inf2cat)
 
         -- check
@@ -117,6 +116,7 @@ rule("wdk.sign")
 
         -- get inf2cat
         local inf2cat = target:data("wdk.sign.inf2cat")
+        assert(inf2cat and os.isexec(inf2cat), "inf2cat not found!")
 
         -- sign the target file
         sign(target, target:targetfile(), signmode)

--- a/xmake/rules/wdk/tracewpp/xmake.lua
+++ b/xmake/rules/wdk/tracewpp/xmake.lua
@@ -41,7 +41,6 @@ rule("wdk.tracewpp")
         if not os.isexec(tracewpp) then
             tracewpp = path.join(wdk.bindir, wdk.sdkver, arch, is_host("windows") and "tracewpp.exe" or "tracewpp")
         end
-        assert(os.isexec(tracewpp), "tracewpp not found!")
 
         -- save tracewpp
         target:data_set("wdk.tracewpp", tracewpp)
@@ -61,6 +60,7 @@ rule("wdk.tracewpp")
 
         -- get tracewpp
         local tracewpp = target:data("wdk.tracewpp")
+        assert(tracewpp and os.isexec(tracewpp), "tracewpp not found!")
 
         -- get outputdir
         local outputdir = path.join(target:autogendir(), "rules", "wdk", "wpp")


### PR DESCRIPTION
this PR allow the user setting the path of WDK directory and only assert for the missing binaries when  they are needed (for exemple nuget WDK doesn't ship all of  these binary)
