### PR TITLE
Improve show target

### DIFF
--- a/xmake/plugins/show/info/target.lua
+++ b/xmake/plugins/show/info/target.lua
@@ -227,7 +227,7 @@ function _show_target(target)
             cprint("      ${color.dump.reference}->${clear} %s", os.args(compinst:compflags()))
         end
     end
-    local linker = target:linker()
+    local linker = targetfile and target:linker()
     if linker then
         cprint("    ${color.dump.string}linker (%s)${clear}: %s", linker:kind(), linker:program())
         cprint("      ${color.dump.reference}->${clear} %s", os.args(linker:linkflags()))
@@ -239,7 +239,6 @@ function _show_target(target)
             cprint("      ${color.dump.reference}->${clear} %s", os.args(compinst:compflags({target = target})))
         end
     end
-    local linker = target:linker()
     if linker then
         cprint("    ${color.dump.string}linkflags (%s)${clear}:", linker:kind())
         cprint("      ${color.dump.reference}->${clear} %s", os.args(linker:linkflags({target = target})))

--- a/xmake/plugins/show/info/target.lua
+++ b/xmake/plugins/show/info/target.lua
@@ -136,7 +136,10 @@ function _show_target(target)
     print("The information of target(%s):", target:name())
     cprint("    ${color.dump.string}at${clear}: %s", path.join(target:scriptdir(), "xmake.lua"))
     cprint("    ${color.dump.string}kind${clear}: %s", target:kind())
-    cprint("    ${color.dump.string}targetfile${clear}: %s", target:targetfile())
+    local targetfile = target:targetfile()
+    if targetfile then
+        cprint("    ${color.dump.string}targetfile${clear}: %s", targetfile)
+    end
     local deps = target:get("deps")
     if deps then
         cprint("    ${color.dump.string}deps${clear}:")


### PR DESCRIPTION
Fixes `xmake show -t` for targets without linker (`error: no suitable linker for moduleonly.{cxx}`) and avoids printing `%s` if the target has no targetfile.