### PR TITLE
Fix finding clang-scan-deps

### DIFF
--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -241,7 +241,7 @@ function get_clang_scan_deps(target)
                 basename = "clang"
             end
             local extension = path.extension(program)
-            program = (basename:rtrim("+"):gsub("clang", "clang-scan-deps")) .. extension
+            program = (basename:gsub("%+%+", ""):gsub("clang", "clang-scan-deps")) .. extension
             if dir and dir ~= "." and os.isdir(dir) then
                 program = path.join(dir, program)
             end


### PR DESCRIPTION
Finding clang-scan-deps is broken after 3.0.3, probably due to this commit e65101c6c6a4a26f2c6188816008ee4993062dea, where `target:tool("cxx")` now returns `clang++-<version>` and `clangxx` when using versioned clang. Before it returned `clang-<version>` and `clang`. Since `program` may end with a version number, `rtrim("+")` will not work, changing it to `gsub("%+%+", "")` fixes this.

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

