### PR TITLE
Fix rc compiler with cmake in cross-compilation

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -625,8 +625,11 @@ function _get_configs_for_cross(package, configs, opt)
     envs.CMAKE_CXX_COMPILER        = _translate_bin_path(package:build_getenv("cxx"))
     envs.CMAKE_ASM_COMPILER        = _translate_bin_path(package:build_getenv("as"))
     envs.CMAKE_AR                  = _translate_bin_path(package:build_getenv("ar"))
-    if package:is_plat("windows") and package:has_tool("cxx", "cl") then
-        envs.CMAKE_AR = path.join(path.directory(envs.CMAKE_CXX_COMPILER), "lib.exe")
+    if package:is_plat("windows") then
+        envs.CMAKE_RC_COMPILER = _translate_bin_path(package:build_getenv("mrc"))
+        if package:has_tool("cxx", "cl") then
+            envs.CMAKE_AR = path.join(path.directory(envs.CMAKE_CXX_COMPILER), "lib.exe")
+        end
     end
     _fix_cxx_compiler_cmake(package, envs)
     -- @note The link command line is set in Modules/CMake{C,CXX,Fortran}Information.cmake and defaults to using the compiler, not CMAKE_LINKER,


### PR DESCRIPTION
clang-xx toolchain
```console
/bin/sh: 1: llvm-rc: not found
```