### PR TITLE
Rewrite of Nix Package Manager Support

### DIFF
--- a/xmake/modules/package/manager/nix/find_package.lua
+++ b/xmake/modules/package/manager/nix/find_package.lua
@@ -920,13 +920,7 @@ local function find_with_pkgconfig(package_name, store_paths, opt)
     end
     
     -- Add dependencies of matching packages
-    local all_deps = follow_propagated_inputs(filtered_paths, opt)
-    for _, dep_path in ipairs(all_deps) do
-        if not seen[dep_path] then
-            seen[dep_path] = true
-            table.insert(filtered_paths, dep_path)
-        end
-    end
+    filtered_paths = follow_propagated_inputs(filtered_paths, opt)
 
     -- Search filtered paths
     for _, store_path in ipairs(filtered_paths) do


### PR DESCRIPTION
This PR completely rewrites the Nix package manager integration for xmake as the original version was too naive and unreliable. The rewrite introduces caching, derivation parsing, and multi-environment support.

Improvements:

1. Environment Detection

Before: Only checked basic environment variables and nix-shell state
After: Discovers packages from all the standard Nix environments:

Nix shells (nix-shell, nix develop)
User profiles (nix profile, nix-env)
Home Manager (both tool and NixOS module)
NixOS system packages
NixOS user packages
Current system closure (as fallback for NixOS when nixos-option is not configured)

2. Multi-Level Caching

Session cache: Fast in-memory cache for repeated operations within the same build
Persistent cache: Disk-based cache that survives across xmake invocations
Environment-aware: Cache keys include environment state to detect changes
Selective invalidation: Only re-scans when the Nix environment actually changes

3. Derivation Analysis

Before: Simple string matching against store path names
After: Uses nix derivation show to extract accurate package metadata:

Real package names (pname) instead of guessing from paths (unreliable)
Version information from derivation metadata
Multiple output support (dev, lib, bin, etc.)
Structured attribute handling

4. Propagated Dependencies Support

Automatically follows nix-support/propagated-build-inputs
Ensures transitive dependencies are available for linking
Cached traversal prevents redundant filesystem operations

5. Enhanced Package Information Extraction

pkg-config integration: Leverages existing .pc files when available
Multiple output awareness: Handles packages with separate dev/lib/bin outputs

Apologies for any deviations from xmake's coding conventions or API patterns. I'm still new to xmake source code and lua. I realize this packs a lot of functionality into one file, maybe I could move parts of the implementation to other dirs?