### PR TITLE
Added default file filter for `format` task

### DIFF
--- a/xmake/plugins/format/main.lua
+++ b/xmake/plugins/format/main.lua
@@ -190,9 +190,14 @@ function main()
             end
         end
     else
+        -- Default source file filter when not specifying "--files" option
+        -- **.c, **.cc, **.cxx, **.cpp
+        local source_filepatterns = _get_file_patterns("**.c" .. path.envsep() .. "**.cc" .. path.envsep() .. "**.cxx" .. path.envsep() .. "**.cpp")
         for _, target in ipairs(targets) do
             for _, source in ipairs(target:sourcefiles()) do
-                table.insert(argv, path.join(projectdir, source))
+                if _match_sourcefiles(source, source_filepatterns) then
+                    table.insert(argv, path.join(projectdir, source))
+                end
             end
             for _, header in ipairs(target:headerfiles()) do
                 table.insert(argv, path.join(projectdir, header))

--- a/xmake/plugins/format/xmake.lua
+++ b/xmake/plugins/format/xmake.lua
@@ -40,7 +40,7 @@ task("format")
                                                   "e.g.",
                                                   "    - xmake format --files=src/main.c",
                                                   "    - xmake format --files='src/*.c' [target]",
-                                                  "    - xmake format --files='src/**.c|excluded_file.c",
+                                                  "    - xmake format --files='src/**.c|excluded_file.c'",
                                                   "    - xmake format --files='src/main.c" .. path.envsep() .. "src/test.c'" },
                                                   {},
                     {nil, "target",  "v",  nil,   "The target name. It will format all default targets if this parameter is not specified."


### PR DESCRIPTION
## Background

Currently, when using `format` task, `xmake` calls `clang-format` to format all files added through `add_files`. This is fine if the project/target only contains C or C++ files. However, when we have other files added as source files, such as binary assets (for `utils.bin2c`) and assembly files, clang-format will also "format" those and complely corrupt the files. Take a look at this example:

```lua
target("test")
    set_kind("binary")
    set_languages("c++11")
    add_rules("utils.bin2c", {extensions = {".gz"}})
    
    add_files("src/*.cpp")
    add_files("asset/font.ttf.gz")
    add_includedirs("include")
    add_headerfiles("include/*.hpp")
target_end()
```

File tree:
- src/
  - main.cpp
  - a.cpp
- include/
  - a.hpp
- asset/
  - font.ttf.gz
- xmake.lua

In the most recent `xmake` version (`v3.0.3+HEAD.de7aca4`), after executing `xmake format test`, `asset/font.ttf.gz` will be corrupted by `clang-format`, because `xmake` incorrectly added this file into the command line of `clang-format`.

For more info, see related discussions and issues:
- #6247

## How this PR fixes the issue

This PR fixes the issue by adding a default file filter when no `--files` option is specified for `xmake format`. The default file filter is set as `**.c`, `**.cxx`, `**.cpp` and `**.cc`, which covers most file extensions for C/C++ source.

## Q&A

### Why fix this issue?
Convenience. For projects (especially when developing for embedded sys. and computer graphics, where asm. files or art assets need to be added as source files), it is inconvenient to manually specifying `--files=xxx` every time. Adding a default filter can greatly improve the overall experience of using `xmake`, when a simple `xmake format` help you do all the jobs to format cxx files.

### Why add default filter?
`clang-format` is designed for formatting C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code, and `xmake` is primarily designed for building C/C++ code. Adding a default filter matches the overall design goal of `xmake`, avoids passing unwanted files (archives, asm codes, etc.) to `clang-format` which causes unwanted file corruptions, and improves experience. Usage of formatting non-cxx-files as if they were cxx files is extremely rare, and in my point of view, should be done through custom tasks.

## Other Changes
- Fixed typo in `xmake format` task description