### PR TITLE
Make sure generic options are always inserted.

### DIFF
--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -472,8 +472,6 @@ function _get_configs_for_windows(package, configs, opt)
 
     if package:is_cross() then
         _get_configs_for_cross(package, configs, opt)
-    else
-        _get_configs_for_generic(package, configs, opt)
     end
 end
 
@@ -510,7 +508,6 @@ function _get_configs_for_android(package, configs, opt)
         table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH")
         table.insert(configs, "-DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=NEVER")
     end
-    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get configs for appleos
@@ -542,7 +539,6 @@ function _get_configs_for_appleos(package, configs, opt)
     -- avoid install bundle targets
     envs.CMAKE_MACOSX_BUNDLE       = "NO"
     _insert_configs_from_envs(configs, envs, opt)
-    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get configs for mingw
@@ -583,7 +579,6 @@ function _get_configs_for_mingw(package, configs, opt)
     end
     _fix_cxx_compiler_cmake(package, envs)
     _insert_configs_from_envs(configs, envs, opt)
-    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get configs for wasm
@@ -612,7 +607,6 @@ function _get_configs_for_wasm(package, configs, opt)
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"
     _insert_configs_from_envs(configs, envs, opt)
-    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get configs for cross
@@ -673,7 +667,6 @@ function _get_configs_for_cross(package, configs, opt)
     envs.CMAKE_FIND_USE_CMAKE_SYSTEM_PATH = "0"
     envs.CMAKE_FIND_USE_INSTALL_PREFIX = "0"
     _insert_configs_from_envs(configs, envs, opt)
-    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get configs for host toolchain
@@ -704,7 +697,6 @@ function _get_configs_for_host_toolchain(package, configs, opt)
         envs.CMAKE_SYSTEM_NAME     = "Linux"
     end
     _insert_configs_from_envs(configs, envs, opt)
-    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get cmake generator for msvc
@@ -909,6 +901,8 @@ function _get_configs(package, configs, opt)
     opt._configs_str = string.serialize(configs, {indent = false, strip = true})
     _get_configs_for_install(package, configs, opt)
     _get_configs_for_generator(package, configs, opt)
+    _get_configs_for_generic(package, configs, opt)
+
     if package:is_plat("windows") then
         _get_configs_for_windows(package, configs, opt)
     elseif package:is_plat("android") then
@@ -931,8 +925,6 @@ function _get_configs(package, configs, opt)
         else
             _get_configs_for_cross(package, configs, opt)
         end
-    else
-        _get_configs_for_generic(package, configs, opt)
     end
 
     -- fix error for cmake 4.x

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -541,6 +541,7 @@ function _get_configs_for_appleos(package, configs, opt)
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM   = "NEVER"
     -- avoid install bundle targets
     envs.CMAKE_MACOSX_BUNDLE       = "NO"
+    _insert_configs_from_envs(configs, envs, opt)
     _get_configs_for_generic(package, configs, opt)
 end
 
@@ -581,6 +582,7 @@ function _get_configs_for_mingw(package, configs, opt)
         envs.CMAKE_MAKE_PROGRAM = _get_mingw32_make(package)
     end
     _fix_cxx_compiler_cmake(package, envs)
+    _insert_configs_from_envs(configs, envs, opt)
     _get_configs_for_generic(package, configs, opt)
 end
 
@@ -609,6 +611,7 @@ function _get_configs_for_wasm(package, configs, opt)
     envs.CMAKE_FIND_ROOT_PATH_MODE_LIBRARY = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"
+    _insert_configs_from_envs(configs, envs, opt)
     _get_configs_for_generic(package, configs, opt)
 end
 
@@ -669,6 +672,7 @@ function _get_configs_for_cross(package, configs, opt)
     -- avoids finding host include/library path
     envs.CMAKE_FIND_USE_CMAKE_SYSTEM_PATH = "0"
     envs.CMAKE_FIND_USE_INSTALL_PREFIX = "0"
+    _insert_configs_from_envs(configs, envs, opt)
     _get_configs_for_generic(package, configs, opt)
 end
 
@@ -699,6 +703,7 @@ function _get_configs_for_host_toolchain(package, configs, opt)
     if package:is_cross() then
         envs.CMAKE_SYSTEM_NAME     = "Linux"
     end
+    _insert_configs_from_envs(configs, envs, opt)
     _get_configs_for_generic(package, configs, opt)
 end
 

--- a/xmake/modules/package/tools/cmake.lua
+++ b/xmake/modules/package/tools/cmake.lua
@@ -541,7 +541,7 @@ function _get_configs_for_appleos(package, configs, opt)
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM   = "NEVER"
     -- avoid install bundle targets
     envs.CMAKE_MACOSX_BUNDLE       = "NO"
-    _insert_configs_from_envs(configs, envs, opt)
+    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get configs for mingw
@@ -581,7 +581,7 @@ function _get_configs_for_mingw(package, configs, opt)
         envs.CMAKE_MAKE_PROGRAM = _get_mingw32_make(package)
     end
     _fix_cxx_compiler_cmake(package, envs)
-    _insert_configs_from_envs(configs, envs, opt)
+    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get configs for wasm
@@ -610,7 +610,6 @@ function _get_configs_for_wasm(package, configs, opt)
     envs.CMAKE_FIND_ROOT_PATH_MODE_INCLUDE = "BOTH"
     envs.CMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "NEVER"
     _get_configs_for_generic(package, configs, opt)
-    _insert_configs_from_envs(configs, envs, opt)
 end
 
 -- get configs for cross
@@ -618,8 +617,6 @@ function _get_configs_for_cross(package, configs, opt)
     opt = opt or {}
     opt.cross                      = true
     local envs                     = {}
-    envs.CMAKE_BUILD_TYPE          = package:is_debug() and "Debug" or "Release"
-    envs.BUILD_SHARED_LIBS         = package:config("shared") and "ON" or "OFF"
     local sdkdir                   = _translate_paths(package:build_getenv("sdk"))
     envs.CMAKE_C_COMPILER          = _translate_bin_path(package:build_getenv("cc"))
     envs.CMAKE_CXX_COMPILER        = _translate_bin_path(package:build_getenv("cxx"))
@@ -655,9 +652,6 @@ function _get_configs_for_cross(package, configs, opt)
         envs.CMAKE_SYSTEM_NAME = system_name
         envs.CMAKE_SYSTEM_PROCESSOR = _get_cmake_system_processor(package)
     end
-    if not package:is_plat("windows", "mingw") and package:config("pic") ~= false then
-        table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-    end
     -- avoid find and add system include/library path
     -- @see https://github.com/xmake-io/xmake/issues/2037
     -- https://github.com/xmake-io/xmake/issues/6660
@@ -675,7 +669,7 @@ function _get_configs_for_cross(package, configs, opt)
     -- avoids finding host include/library path
     envs.CMAKE_FIND_USE_CMAKE_SYSTEM_PATH = "0"
     envs.CMAKE_FIND_USE_INSTALL_PREFIX = "0"
-    _insert_configs_from_envs(configs, envs, opt)
+    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get configs for host toolchain
@@ -705,10 +699,7 @@ function _get_configs_for_host_toolchain(package, configs, opt)
     if package:is_cross() then
         envs.CMAKE_SYSTEM_NAME     = "Linux"
     end
-    if not package:is_plat("windows", "mingw") and package:config("pic") ~= false then
-        table.insert(configs, "-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-    end
-    _insert_configs_from_envs(configs, envs, opt)
+    _get_configs_for_generic(package, configs, opt)
 end
 
 -- get cmake generator for msvc


### PR DESCRIPTION
Currently, the package.tools.cmake has not yet inserted generic options for appleos/mingw (such as `CMAKE_BUILD_TYPE`, `BUILD_SHARED_LIBS`, etc). I think this may be a bug.

This patch also makes `_get_configs_for_cross` call `_get_configs_for_generic` and removes the duplicate logic.