### PR TITLE
add scriptdir to project packages

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -929,9 +929,13 @@ end
 function _instance:rulesdir()
     local rulesdir = self._RULESDIR
     if rulesdir == nil then
-        rulesdir = path.join(self:scriptdir(), "rules")
-        if not os.isdir(rulesdir) and self:base() then
+        if self:repo() == nil and self:base() then
             rulesdir = self:base():rulesdir()
+        else
+            rulesdir = path.join(self:scriptdir(), "rules")
+            if not os.isdir(rulesdir) and self:base() then
+                rulesdir = self:base():rulesdir()
+            end
         end
         if rulesdir == nil or not os.isdir(rulesdir) then
             rulesdir = false
@@ -3063,7 +3067,7 @@ function package.load_from_project(packagename, project)
     end
 
     -- new an instance
-    instance = _instance.new(packagename, packageinfo)
+    instance = _instance.new(packagename, packageinfo, {scriptdir = os.projectdir()})
     package._memcache():set2("packages", instance)
     return instance
 end

--- a/xmake/modules/package/tools/xmake.lua
+++ b/xmake/modules/package/tools/xmake.lua
@@ -485,7 +485,7 @@ function install(package, configs, opt)
 
     -- copy the ported xmake.lua in the default position if it's missing
     local xmakefile = path.join(opt.curdir or os.curdir(), "xmake.lua")
-    if not os.isfile(xmakefile) then
+    if not os.isfile(xmakefile) and package:repo() ~= nil then
         local xmakefile_port = path.join(package:scriptdir(), "port", "xmake.lua")
         if os.isfile(xmakefile_port) then
             os.cp(xmakefile_port, xmakefile)


### PR DESCRIPTION
Allows project local packages to properly use `add_versionfiles` and `add_patches`. Added explicit checks to `rulesdir` and `port` since these are implicit and may conflict with project setups. Using `os.projectdir()` here works correctly with the `--project` parameter, whereas using the packages actual scriptdir does not.

Previously they would try to look into `os.curdir()/nil/`.