### PR TITLE
Improve runjobs to reduce the time spent on coroutine scheduling

### DIFF
--- a/tests/test_utils/test_build.lua
+++ b/tests/test_utils/test_build.lua
@@ -2,7 +2,7 @@ local test_build = {}
 
 function test_build:build(argv)
     os.exec("xmake f -c -D -y")
-    os.exec("xmake")
+    os.exec("xmake -D")
 end
 
 function main()

--- a/xmake/actions/build/build.lua
+++ b/xmake/actions/build/build.lua
@@ -41,6 +41,9 @@ function _build(targets_root, opt)
     opt.progress_factor = 0.95
     if distcc_build_client.is_connected() then
         opt.distcc = distcc_build_client.singleton()
+        if project.policy("build.distcc.remote_only") then
+            opt.remote_only = true
+        end
     end
     target_buildutils.run_targetjobs(targets_root, opt)
 end

--- a/xmake/core/base/scheduler.lua
+++ b/xmake/core/base/scheduler.lua
@@ -31,6 +31,7 @@ local string    = require("base/string")
 local poller    = require("base/poller")
 local timer     = require("base/timer")
 local hashset   = require("base/hashset")
+local queue     = require("base/queue")
 local coroutine = require("base/coroutine")
 local bit       = require("base/bit")
 
@@ -39,7 +40,8 @@ function _semaphore.new(name, value)
     local instance    = table.inherit(_semaphore)
     instance._NAME    = name
     instance._VALUE   = value or 0
-    instance._WAITING = hashset.new()
+    instance._WAITING = queue.new()
+    instance._POSTING = false
     setmetatable(instance, _semaphore)
     return instance
 end
@@ -51,22 +53,25 @@ end
 
 -- post the semaphore value
 function _semaphore:post(value)
+    if self._POSTING then
+        return self._VALUE
+    end
+    self._POSTING = true
     local new_value = self._VALUE + value
     self._VALUE = new_value
     if new_value > 0 then
-        local pending = {}
         local waiting = self._WAITING
-        for item in waiting:items() do
-            if #pending < new_value then
-                table.insert(pending, item)
-            else
+        local post_count = 0
+        while not waiting:empty() do
+            local item = waiting:pop()
+            scheduler:co_resume(item)
+            post_count = post_count + 1
+            if post_count >= new_value then
                 break
             end
         end
-        for _, item in ipairs(pending) do
-            scheduler:co_resume(item)
-        end
     end
+    self._POSTING = false
     return new_value
 end
 
@@ -97,7 +102,7 @@ function _semaphore:wait(timeout)
     end
 
     -- wait semaphore
-    self._WAITING:insert(running)
+    self._WAITING:push(running)
     if timeout > 0 then
         scheduler:_timer():post(function (cancel)
             if running:is_suspended() then
@@ -113,15 +118,16 @@ function _semaphore:wait(timeout)
         local value = self._VALUE
         if value > 0 then
             self._VALUE = value - 1
-            self._WAITING:remove(running)
             return value
         end
 
         if timeout then
             break
         end
+
+        -- continue to wait it
+        self._WAITING:push(running)
     end
-    self._WAITING:remove(running)
     return 0
 end
 

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -115,6 +115,8 @@ function policy.policies()
             ["build.linker.output"]               = {description = "Enable linker output.", type = "boolean"},
             -- Enable build jobgraph
             ["build.jobgraph"]                    = {description = "Enable build jobgraph.", default = true, type = "boolean"},
+            -- Enable build on only remote machines
+            ["build.distcc.remote_only"]          = {description = "Enable build on only remote machines.", default = false, type = "boolean"},
             -- Enable windows UAC and set level, e.g. invoker, admin, highest
             ["windows.manifest.uac"]              = {description = "Enable windows manifest UAC.", type = "string"},
             -- Enable ui access for windows UAC

--- a/xmake/modules/async/runjobs.lua
+++ b/xmake/modules/async/runjobs.lua
@@ -159,7 +159,7 @@ function _comsume_jobs_loop(state)
         {
             function ()
                 -- run job
-                local job_index = state.finished_count
+                local job_index = state.finished_count + 1
                 state.running_jobs_indices[job_index] = job_index
                 if job_func then
                     if curdir then

--- a/xmake/modules/async/runjobs.lua
+++ b/xmake/modules/async/runjobs.lua
@@ -338,9 +338,13 @@ function main(name, jobs, opt)
         if distcc then
             state.distcc_semaphore = scheduler.co_semaphore(state.group_name .. "/distcc", 0)
         end
-        local local_comax = math.min(state.total, state.comax)
-        for id = 1, local_comax do
-            scheduler.co_start_withopt({name = name .. '/' .. tostring(id), isolate = opt.isolate}, _consume_jobs_loop, state, false)
+        -- @note we can set `remote_only = true` to run all jobs in remote only
+        local local_comax = 0
+        if not opt.remote_only then
+            local_comax = math.min(state.total, state.comax)
+            for id = 1, local_comax do
+                scheduler.co_start_withopt({name = name .. '/' .. tostring(id), isolate = opt.isolate}, _consume_jobs_loop, state, false)
+            end
         end
         if distcc then
             local left_comax = state.total - local_comax

--- a/xmake/modules/private/action/build/target.lua
+++ b/xmake/modules/private/action/build/target.lua
@@ -788,7 +788,9 @@ function run_targetjobs(targets_root, opt)
             if errors and progress.showing_without_scroll() then
                 print("")
             end
-        end, comax = opt.jobs or option.get("jobs") or 1, curdir = curdir, distcc = opt.distcc, progress_factor = opt.progress_factor})
+        end,
+        comax = opt.jobs or option.get("jobs") or 1, curdir = curdir,
+        distcc = opt.distcc, remote_only = opt.remote_only, progress_factor = opt.progress_factor})
         os.cd(curdir)
         return true
     end
@@ -806,7 +808,9 @@ function run_filejobs(targets_root, opt)
             if errors and progress.showing_without_scroll() then
                 print("")
             end
-        end, comax = opt.jobs or option.get("jobs") or 1, curdir = curdir, distcc = opt.distcc, progress_factor = opt.progress_factor})
+        end,
+        comax = opt.jobs or option.get("jobs") or 1, curdir = curdir,
+        distcc = opt.distcc, remote_only = opt.remote_only, progress_factor = opt.progress_factor})
         os.cd(curdir)
         return true
     end

--- a/xmake/modules/private/service/distcc_build/client.lua
+++ b/xmake/modules/private/service/distcc_build/client.lua
@@ -25,6 +25,7 @@ import("core.base.socket")
 import("core.base.option")
 import("core.base.scheduler")
 import("core.project.policy")
+import("core.project.project")
 import("core.project.config", {alias = "project_config"})
 import("lib.detect.find_tool")
 import("private.service.client_config", {alias = "config"})
@@ -262,7 +263,7 @@ function distcc_build_client:compile(program, argv, opt)
         -- do distcc compilation
         if not cached then
             -- we just compile the large preprocessed file in remote
-            if os.filesize(cppinfo.cppfile) > 4096 and not session:is_unreachable() then
+            if (self:remote_only() or os.filesize(cppinfo.cppfile) > 4096) and not session:is_unreachable() then
                 local compile_fallback = opt.compile_fallback
                 if compile_fallback then
                     local ok = try
@@ -389,6 +390,11 @@ end
 -- get working directory
 function distcc_build_client:workdir()
     return self._WORKDIR
+end
+
+-- build on only remote machines
+function distcc_build_client:remote_only()
+    return project.policy("build.distcc.remote_only") == true
 end
 
 -- get free host


### PR DESCRIPTION
- [x] Reduce the time spent on coroutine scheduling
- [x] Add `build.distcc.remote_only` policy to enable build on only remote machines

### Before optimization

```console
ruki:xmake ruki$ xmake l tests/benchmarks/async/runjobs.lua
runjobs(10000/1): 1678 ms, plain: 0 ms
runjobs(10000/10): 1853 ms, plain: 0 ms
runjobs(10000/100): 1904 ms, plain: 1 ms
runjobs_proc(1000/10): 63061 ms
```

### After optimization

```console
ruki:xmake ruki$ xmake l tests/benchmarks/async/runjobs.lua
runjobs(10000/1): 50 ms, plain: 0 ms
runjobs(10000/10): 51 ms, plain: 0 ms
runjobs(10000/100): 67 ms, plain: 0 ms
runjobs_proc(1000/10): 52977 ms
```
