### PR TITLE
package download: don't get submodules if disabled

### DIFF
--- a/xmake/modules/private/action/require/impl/actions/download.lua
+++ b/xmake/modules/private/action/require/impl/actions/download.lua
@@ -130,7 +130,8 @@ function _checkout(package, url, sourcedir, opt)
         -- only shallow clone this tag
         -- @see https://github.com/xmake-io/xmake/issues/4151
         if tag and git.clone.can_clone_tag() then
-            git.clone(url, {depth = 1, recursive = true, shallow_submodules = true, longpaths = longpaths, branch = tag, outputdir = packagedir})
+            local clone_submodules = opt.url_submodules ~= false
+            git.clone(url, {depth = 1, recursive = clone_submodules, shallow_submodules = clone_submodules, longpaths = longpaths, branch = tag, outputdir = packagedir})
         else
 
             -- clone whole history and tags


### PR DESCRIPTION
should fix https://github.com/xmake-io/xmake-repo/actions/runs/18327237141/job/52194556351?pr=8344 where submodules were disabled
```lua
    add_urls("https://github.com/libsdl-org/SDL_ttf.git", {alias = "github", submodules = false})
```
but were still cloned