### PR TITLE
improve(tty): support detect ghostty

### DIFF
--- a/xmake/core/base/tty.lua
+++ b/xmake/core/base/tty.lua
@@ -291,6 +291,7 @@ end
 --  - terminator
 --  - rxvt
 --  - lxterminal
+--  - ghostty
 --  - unknown
 --
 function tty.term()
@@ -305,6 +306,8 @@ function tty.term()
                     term = "vscode"
                 elseif TERM_PROGRAM == "mintty" then
                     term = "mintty" -- git bash
+                elseif TERM_PROGRAM == "ghostty" then
+                    term = "ghostty"
                 end
             end
         end
@@ -313,7 +316,9 @@ function tty.term()
         if term == nil then
             local TERM = os.getenv("TERM")
             if TERM ~= nil then
-                if TERM:find("xterm", 1, true) then
+                if TERM:find("ghostty", 1, true) then
+                    term = "ghostty"
+                elseif TERM:find("xterm", 1, true) then
                     term = "xterm"
                 elseif TERM == "cygwin" then
                     term = "cygwin"


### PR DESCRIPTION
Xmake currently reports ghostty as xterm:

```lua
-- test.lua
import("core.base.tty")

print(tty.term())
```

<img width="272" height="69" alt="image" src="https://github.com/user-attachments/assets/d0c883d5-7554-4a92-852c-924868073521" />

This isn't a big deal, since ghostty is fully compatible with xterm. However, we can do better to detect the ghostty by using environment variables:

<img width="586" height="129" alt="image" src="https://github.com/user-attachments/assets/c77c20c2-e535-43a7-b2df-a80b908e7695" />
<img width="300" height="437" alt="image" src="https://github.com/user-attachments/assets/4fa33a58-5fc4-4289-9342-746c800f6284" />


After this patch:

<img width="248" height="229" alt="image" src="https://github.com/user-attachments/assets/cb8d0389-0260-4aaa-b497-f45355794b52" />





