### PR TITLE
Fix Nimble find_package to use latest package list format

### DIFF
--- a/xmake/modules/package/manager/nimble/find_package.lua
+++ b/xmake/modules/package/manager/nimble/find_package.lua
@@ -26,7 +26,26 @@ import("core.project.target")
 import("lib.detect.find_tool")
 import("lib.detect.find_file")
 
--- parse package name and version
+-- parse package name and version (with old version)
+--
+-- e.g.
+-- zip  [0.3.1]
+-- zip  [(version: 0.3.1, checksum: 747aab3c43ecb7b50671cdd0ec3b2edc2c83494c)]
+--
+function _parse_packageinfo_v1(line)
+    local splitinfo = line:split("%s+", {limit = 2})
+    local package_name = splitinfo[1]
+    local version_str = splitinfo[2]
+    if version_str then
+        local version = semver.match(version_str)
+        if version then
+            package_version = version:rawstr()
+        end
+    end
+    return package_name, package_version
+end
+
+-- parse package name and version (with new version)
 --
 -- e.g.
 -- bearssl
@@ -35,7 +54,7 @@ import("lib.detect.find_file")
 -- ├── @1.92.3.0 (9b1400a393d47e0b7a7301115abd04b11a735b06) (C:\Users\V\.nimble\pkgs2\imguin-1.92.3.0-9b1400a393d47e0b7a7301115abd04b11a735b06)
 -- └── @1.92.4.0 (fe2a7f25cfc17144dfb4f34c80655827bbe80fcb) (C:\Users\V\.nimble\pkgs2\imguin-1.92.4.0-fe2a7f25cfc17144dfb4f34c80655827bbe80fcb)
 --
-function _parse_packageinfo(line)
+function _parse_packageinfo_v2(line)
     -- match package name (top-level entries only, not indented)
     local package_name = line:match("^(%S+)$")
     if package_name then
@@ -54,24 +73,12 @@ function _parse_packageinfo(line)
     return nil, nil
 end
 
--- find package using the nimble package manager
---
--- @param name  the package name
--- @param opt   the options, e.g. {verbose = true, require_version = "1.12.x")
---
-function main(name, opt)
-    -- find nimble
-    local nimble = find_tool("nimble")
-    if not nimble then
-        raise("nimble not found!")
-    end
-
-    -- find it from all installed package list
+-- find package with new format
+function _find_package_v2(name, list, opt)
     local result
     local current_package
-    local list = os.iorunv(nimble.program, { "list", "-i", "--ver" })
     for _, line in ipairs(list:split("\n", { plain = true })) do
-        local package_name, package_version = _parse_packageinfo(line)
+        local package_name, package_version = _parse_packageinfo_v2(line)
         if package_name then
             current_package = package_name
         elseif package_version and current_package == name then
@@ -86,6 +93,56 @@ function main(name, opt)
             end
         end
     end
+    return result
+end
+
+-- find package with old format
+function _find_package_v1(name, list, opt)
+    local result
+    for _, line in ipairs(list:split("\n", {plain = true})) do
+        local package_name, package_version = _parse_packageinfo_v1(line)
+        if package_name == name then
+            if opt.require_version then
+                if package_version and (opt.require_version == "latest" or semver.satisfies(package_version, opt.require_version)) then
+                    result = {version = package_version}
+                    break
+                end
+            else
+                result = {}
+                break
+            end
+        end
+    end
+    return result
+end
+
+-- find package using the nimble package manager
+--
+-- @param name  the package name
+-- @param opt   the options, e.g. {verbose = true, require_version = "1.12.x")
+--
+function main(name, opt)
+
+    -- find nimble
+    local nimble = find_tool("nimble")
+    if not nimble then
+        raise("nimble not found!")
+    end
+
+    -- find it from all installed package list
+    local list = os.iorunv(nimble.program, {"list", "-i", "--ver"})
+    if not list then
+        return
+    end
+
+    -- new format?
+    local result
+    if list:find("Package list format:", 1, true) then
+        result = _find_package_v2(name, list, opt)
+    else
+        result = _find_package_v1(name, list, opt)
+    end
+
     -- @note we don't need return links and includedirs information,
     -- because it's nim source code package and nim will find them automatically
     return result


### PR DESCRIPTION
Hi!

`nimble list -i` has changed their CLI output in recent versions. It is now just a list of packages, no version number.
<img width="474" height="291" alt="image" src="https://github.com/user-attachments/assets/fe7863eb-2514-45e2-b9fd-7acc1277b416" />

The new way to call it is `nimble list -i --ver`:
<img width="612" height="251" alt="image" src="https://github.com/user-attachments/assets/74e163e4-12c7-4021-8477-fb5e2bb2e3c8" />

This PR tries to parse find_package.lua so that it can parse the new package list format. Apologies if this PR is poorly written. I don't know Lua and had Kimi K2 help with most of it. I've given it a quick look over and it looks to be sound, and I tested the output with a valid version number I have installed and an invalid version number that does not exist yet and it seems to work well.

<img width="827" height="513" alt="image" src="https://github.com/user-attachments/assets/4e0986ca-05a2-4962-b791-8792ad6cbc90" />
<img width="585" height="329" alt="image" src="https://github.com/user-attachments/assets/7d726001-c5fa-452e-83ec-f7cf9b3af4d1" />

Hopefully you can give it a quick review to see if anything is obviously messed up. I apologize if so.