### PR TITLE
Make zig-cc inherit from clang

### DIFF
--- a/xmake/modules/core/tools/zig_cc.lua
+++ b/xmake/modules/core/tools/zig_cc.lua
@@ -18,7 +18,7 @@
 -- @file        zig_cc.lua
 --
 
--- inherit gcc
+-- inherit clang
 inherit("clang")
 
 -- make the strip flag


### PR DESCRIPTION
根据zig作者andrewkelley的说法，zig cc使用的编译参数和clang相同（其实就是调LLVM的包）

https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html

所以zig cc的配置inherit from clang或许更合理