### PR TITLE
Add xml module

### DIFF
--- a/tests/modules/xml/test.lua
+++ b/tests/modules/xml/test.lua
@@ -80,8 +80,8 @@ function test_load_save(t)
         attrs = {id = "1"},
         children = {xml.text("hello")}
     })
-    assert(xml.save(filepath, doc, {pretty = true}))
-    local reloaded = xml.load(filepath)
+    assert(xml.savefile(filepath, doc, {pretty = true}))
+    local reloaded = xml.loadfile(filepath)
     t:are_equal(reloaded.name, "root")
     t:are_equal(xml.text_of(reloaded), "hello")
     os.tryrm(filepath)

--- a/xmake/core/base/xml.lua
+++ b/xmake/core/base/xml.lua
@@ -781,13 +781,13 @@ function xml.encode(node, opt)
 end
 
 -- load xml file
--- e.g. `local doc, err = xml.load("foo.xml")`
+-- e.g. `local doc, err = xml.loadfile("foo.xml")`
 --
 -- @param filepath  file path
 -- @param opt       read/decode options
 -- @return          node or nil + error
 --
-function xml.load(filepath, opt)
+function xml.loadfile(filepath, opt)
     local data, err = io.readfile(filepath, opt)
     if not data then
         return nil, err
@@ -796,14 +796,14 @@ function xml.load(filepath, opt)
 end
 
 -- save xml node to file
--- e.g. `assert(xml.save("foo.xml", node, {pretty = true}))`
+-- e.g. `assert(xml.savefile("foo.xml", node, {pretty = true}))`
 --
 -- @param filepath  destination file
 -- @param node      xml node
 -- @param opt       encode/write options
 -- @return          true on success or nil + error message
 --
-function xml.save(filepath, node, opt)
+function xml.savefile(filepath, node, opt)
     local data = xml.encode(node, opt)
     if not data then
         return nil, "failed to encode xml"

--- a/xmake/core/sandbox/modules/import/core/base/xml.lua
+++ b/xmake/core/sandbox/modules/import/core/base/xml.lua
@@ -55,8 +55,8 @@ function sandbox_core_base_xml.scan(data, callback, opt)
 end
 
 -- load xml file to the lua table
-function sandbox_core_base_xml.load(filepath, opt)
-    local node, errors = xml.load(filepath, opt)
+function sandbox_core_base_xml.loadfile(filepath, opt)
+    local node, errors = xml.loadfile(filepath, opt)
     if not node then
         raise(errors)
     end
@@ -64,8 +64,8 @@ function sandbox_core_base_xml.load(filepath, opt)
 end
 
 -- save xml node to the file
-function sandbox_core_base_xml.save(filepath, node, opt)
-    local ok, errors = xml.save(filepath, node, opt)
+function sandbox_core_base_xml.savefile(filepath, node, opt)
+    local ok, errors = xml.savefile(filepath, node, opt)
     if not ok then
         raise(errors)
     end


### PR DESCRIPTION
# core.base.xml

The `core.base.xml` module provides a tiny DOM-style XML toolkit that works inside Xmake’s sandbox. It focuses on predictable data structures, JSON-like usability, and optional streaming so you can parse large XML documents without building the entire tree.

## Node Structure

XML nodes are plain Lua tables. All constructors (`xml.new`, `xml.text`, `xml.comment`, etc.) return values shaped like:

```lua
{
    name     = "element-name" | nil, -- only for element nodes
    kind     = "element" | "text" | "comment" | "cdata" | "doctype" | "document",
    attrs    = { key = value, ... } or nil,
    text     = string or nil,
    children = { child1, child2, ... } or nil,
    prolog   = { comment/doctype nodes before root } or nil
}
```

Because these are regular tables, mutating them updates the DOM in place and the changes show up automatically when you call `xml.encode` or `xml.savefile`.

## Quick Start

```lua
import("core.base.xml")

local doc = assert(xml.decode([[
<?xml version="1.0"?>
<root id="1">
  <item id="foo">hello</item>
</root>
]]))

local item = assert(xml.find(doc, "//item[@id='foo']"))
item.attrs.lang = "en"             -- mutate attrs directly
item.children = {xml.text("world")} -- replace existing text node
table.insert(doc.children, xml.comment("generated by xmake"))

local pretty = assert(xml.encode(doc, {pretty = true}))
assert(xml.savefile("out.xml", doc, {pretty = true}))
```

## Streaming Example

```lua
local found
xml.scan(plist_text, function(node)
    if node.name == "key" and xml.text_of(node) == "NSPrincipalClass" then
        found = node
        return false -- early terminate
    end
end)
```

`xml.scan` walks nodes as they are completed; returning `false` stops the scan immediately. This is ideal for large files (e.g. Info.plist) when you only need a few entries.

## Options Summary

| Option                | Applies to      | Description |
|----------------------|-----------------|-------------|
| `trim_text = true`   | `xml.decode`, `xml.scan` | Strip leading/trailing spaces inside text nodes. Disabled by default to avoid data loss. |
| `keep_whitespace_nodes = true` | `xml.decode`, `xml.scan` | Preserve whitespace-only text nodes (by default they are discarded unless `trim_text` produced non-empty content). |
| `pretty = true` / `indent` / `indentchar` | `xml.encode`, `xml.savefile` | Enable formatting and control indentation. |

## API Reference

### `xml.new(opt)`

Create a custom node. `opt` may contain `name`, `kind`, `attrs`, `children`, and `text`. Usually you call the dedicated helpers below instead of `xml.new` directly.

### Element/Text Helpers

```lua
local textnode    = xml.text("hello")
local empty       = xml.empty("br", {class = "line"})
local comment     = xml.comment("generated by xmake")
local cdata_node  = xml.cdata("if (value < 1) {...}")
local doctype     = xml.doctype('plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"')
```

All helpers return node tables that you can insert into `children`.

### `xml.decode(data, opt)`

Parse an XML string into a node tree. Returns the single root element when there is exactly one element, or all top-level nodes when multiple elements exist. On failure returns `nil, err`.

Supports:

- Comments, CDATA, DOCTYPE (stored in `root.prolog` when present).
- Unquoted attributes such as `<item flag=true path=/tmp/file>`.
- XPath-friendly structure (`name`, `attrs`, `children`).
- `trim_text` and `keep_whitespace_nodes` options described above.

### `xml.encode(node, opt)`

Serialize a node tree back into XML. Set `{pretty = true, indent = 2}` for multi-line output or pass a custom `indentchar`.

### `xml.loadfile(path, opt)` / `xml.savefile(path, node, opt)`

Convenience wrappers that call `io.readfile`/`io.writefile` and reuse the decode/encode options.

### `xml.text_of(node)`

Concatenate all direct text children and return the combined string. Useful for quickly reading `<string>...</string>` values.

### `xml.find(node, path)`

XPath-like lookup supporting:

- `/` child axis, `//` descendant axis.
- Wildcards (`*`) and node tests (`text()`, `comment()`, `cdata()`, `doctype()`).
- Attribute predicates (`[@id='foo']`, `[@enabled]`), text predicates (`[text()='value']`), positional indexes (`[2]`).

Returns the first node that matches or `nil` if nothing is found.

### `xml.scan(data, callback, opt)`

Streaming parser. Calls `callback(node)` for each completed node; returning `false` stops the scan early. Accepts the same options as `xml.decode` (`trim_text`, `keep_whitespace_nodes`). Nodes produced by `xml.scan` share the same structure as `xml.decode`.

## Attribute Parsing Notes

- Both quoted and unquoted values are supported (`a="1 2"`, `b='foo'`, `c=bare`).
- Attribute names may include colons, dashes, or underscores.
- Entity references inside attribute values are decoded (`&amp;` → `&`).

## Example: Parsing and Updating an Info.plist

```lua
import("core.base.xml")

local plist = assert(xml.loadfile("Info.plist"))
local dict = assert(xml.find(plist, "plist/dict"))
local version_key

for i = 1, #dict.children, 2 do
    local key = dict.children[i]
    local value = dict.children[i + 1]
    if key and value and xml.text_of(key) == "CFBundleShortVersionString" then
        version_key = value
        break
    end
end

if version_key then
    version_key.children = {xml.text("2.0")}
    assert(xml.savefile("Info.plist", plist, {pretty = true}))
end
```

This example demonstrates decoding, querying via DOM traversal, mutating nodes, and writing the file back with pretty formatting.

