### PR TITLE
Fix debug logging in cmake find_package

### DIFF
--- a/xmake/modules/package/manager/cmake/find_package.lua
+++ b/xmake/modules/package/manager/cmake/find_package.lua
@@ -131,7 +131,8 @@ function _find_package(cmake, name, opt)
     cmakefile:close()
     if option.get("diagnosis") then
         local cmakedata = io.readfile(filepath)
-        cprint("finding it from the generated CMakeLists.txt:\n${dim}%s", cmakedata)
+        cprint("finding it from the generated CMakeLists.txt:")
+        io.write(cmakedata .. "\n")
     end
 
     -- run cmake
@@ -151,7 +152,8 @@ function _find_package(cmake, name, opt)
         local flagsdata = io.readfile(flagsfile)
         if flagsdata then
             if option.get("diagnosis") then
-                cprint("finding includes from %s\n${dim}%s", flagsfile, flagsdata)
+                cprint("finding includes from %s", flagsfile)
+                io.write(flagsdata .. "\n")
             end
             for _, line in ipairs(flagsdata:split("\n", {plain = true})) do
                 if line:find("CXX_INCLUDES =", 1, true) then
@@ -191,7 +193,8 @@ function _find_package(cmake, name, opt)
         local linkdata = io.readfile(linkfile)
         if linkdata then
             if option.get("diagnosis") then
-                cprint("finding links from %s\n${dim}%s", linkfile, linkdata)
+                cprint("finding links from %s", linkfile)
+                io.write(linkdata .. "\n")
             end
             for _, line in ipairs(os.argv(linkdata)) do
                 local is_ldflags = false


### PR DESCRIPTION
Currently the cmake find_package function uses `cprint()` to display its debug output with different color (dimmed). Internally `cprint()` calls `colors.translate()`, which interprets the various `${color}` tags in the printed text. However these color tags look exactly like the CMake variable expansion tags `${VARIABLE}`, which causes `cprint()`, to print `VARIABLE` instead of the correct `${VARIABLE}`.

This is an example of the current (incorrect) debug output
```
finding it from the generated CMakeLists.txt:
cmake_minimum_required(VERSION 4.2.0-rc1)
project(find_package)
find_package(Boost REQUIRED )
if(Boost_FOUND)
   add_executable(test_Boost test.cpp)
   target_include_directories(test_Boost PRIVATE Boost_INCLUDE_DIR Boost_INCLUDE_DIRS BOOST_INCLUDE_DIR BOOST_INCLUDE_DIRS)
   target_include_directories(test_Boost PRIVATE Boost_CXX_INCLUDE_DIRS)
   target_link_libraries(test_Boost PRIVATE Boost::headers)
endif(Boost_FOUND)
```

The correct one should be
```
finding it from the generated CMakeLists.txt:
cmake_minimum_required(VERSION 4.2.0-rc1)
project(find_package)
find_package(Boost REQUIRED )
if(Boost_FOUND)
   add_executable(test_Boost test.cpp)
   target_include_directories(test_Boost PRIVATE ${Boost_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${BOOST_INCLUDE_DIR} ${BOOST_INCLUDE_DIRS})
   target_include_directories(test_Boost PRIVATE ${Boost_CXX_INCLUDE_DIRS})
   target_link_libraries(test_Boost PRIVATE Boost::headers)
endif(Boost_FOUND)
```

This PR replaces calls to `cprint()` with `print()` in the cmake `find_package()` function. Ideally there would be a way to print the debug output in dimmed color while not interpreting any color tags after the initial `{dim}` tag. However the `colors` module that does seem to allow that so the only feasible approach at the moment is just to not interpret any color tags altogether.