### PR TITLE
fix_libc++_cannot_find_stdmodule

### DIFF
--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -254,6 +254,13 @@ function parse_link_files(filepath)
     return path.join(path.directory(filepath), target)
 end
 
+function get_original_file(filepath)
+    while os.islink(filepath) do
+        filepath = parse_link_files(filepath)
+    end
+    return filepath
+end
+
 function get_stdmodules(target)
     local cpplib = get_cpplibrary_name(target)
     if cpplib then
@@ -287,7 +294,7 @@ function get_stdmodules(target)
                 return {path.normalize(path.join(try_std_module_directory, "std.cppm")), path.normalize(path.join(try_std_module_directory, "std.compat.cppm"))}
             end
             -- then try the directory relative to clang bin directory
-            try_std_module_directory = path.join(path.directory(parse_link_files(get_clang_path(target))), std_module_directory)
+            try_std_module_directory = path.join(path.directory(get_original_file(get_clang_path(target))), std_module_directory)
             if os.isdir(try_std_module_directory) then
                 return {path.normalize(path.join(try_std_module_directory, "std.cppm")), path.normalize(path.join(try_std_module_directory, "std.compat.cppm"))}
             end


### PR DESCRIPTION
fix #7073 

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

