### PR TITLE
Fix prefixname in swig.base rule

### DIFF
--- a/xmake/rules/swig/xmake.lua
+++ b/xmake/rules/swig/xmake.lua
@@ -50,6 +50,7 @@ rule("swig.base")
         elseif moduletype == "lua" then
             target:set("prefixname", "")
             if not target:is_plat("windows", "mingw")  then
+                target:set("prefixname", "lib")
                 target:set("extension", ".so")
             end
         elseif moduletype == "java" then


### PR DESCRIPTION
Add `lib` prefixname for swig.base rule with moduletype lua

No prefixname causes problems on linux since we wouldn't be able to link with it