### PR TITLE
refactor(rules/verilator): Switch from cmake to json format for Verilator build file parsing

### DIFF
--- a/xmake/rules/verilator/verilator.lua
+++ b/xmake/rules/verilator/verilator.lua
@@ -124,10 +124,6 @@ function _get_lanuage_flags(target)
     end
 end
 
---- @brief get makefile type
---- @param verilator string verilator program path
---- @return boolean support_json Whether support json
---- @return string makefile_type Makefile type, json or cmake
 function _get_makefile_type(verilator)
     local tool = assert(find_tool("verilator", { program = verilator, version = true }), "verilator not found!")
     local version = tool.version
@@ -233,7 +229,7 @@ endmodule]])
     local languages = target:get("languages")
     local cxxlang = false
     for _, lang in ipairs(languages) do
-        if lang:startswith("cxx") or lang:startswith("c++") then
+        if lang:find("xx", 1, true) or lang:find("++", 1, true) then
             cxxlang = true
             break
         end


### PR DESCRIPTION
1. The "-make cmake" option of Verilator is deprecated and will be removed  in future. See [Deprecations](https://verilator.org/guide/latest/deprecations.html). Use "-make cmake" option in Verilator v5.042 will lead Verilator to return a non-zero value, thus the script reports an error.
2. Verilator can generate build options in json format which can be parsed easier, so we switch from cmake to json format.
3. Add new SystemVerilog language standard `v1800-2023` support.
4. Fix the issue with c++ language standard settings.

BREAKING CHANGE: CMake build file parsing is deprecated.
