### PR TITLE
为cuda arch添加后缀支持

### DIFF
--- a/xmake/rules/cuda/gencodes/xmake.lua
+++ b/xmake/rules/cuda/gencodes/xmake.lua
@@ -71,6 +71,11 @@ rule("cuda.gencodes")
             local v_arch = nil
             local r_archs = {}
 
+            -- full legal value list could be found in nvcc docs
+            -- https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-name-gpuname-arch
+            -- examples: sm_75, compute_75, sm_90a, compute_100, sm_100f, compute_100a, etc.
+            -- For robustness, xmake support a unoffical format: sm75, compute75, etc. New version still support it.
+            -- examples: sm75, compute75, sm90a, compute100, sm100f, compute100a, etc.
             local function parse_arch(value, prefix, know_list)
                 if not value:startswith(prefix) then
                     return nil
@@ -79,6 +84,8 @@ rule("cuda.gencodes")
                 if arch_str:startswith("_") then
                     arch_str = arch_str:sub(2)
                 end
+
+                -- a legal arch_str should be like: 75, 90a, 100f, etc.
                 local arch_ver, suffix = arch_str:match("^(%d+)([af]?)$")
                 local arch = tonumber(arch_ver)
                 if arch == nil then


### PR DESCRIPTION
#6910 的work around方案，手动更新数字列表而不是自动获取，但增加后缀支持
关于后缀支持，可以参考[NVCC doc](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-name-gpuname-arch)
注意：改动前，xmake支持非标准连接符号（如sm-90 sm@90等），改动后，将只支持下划线和无连接符号（sm_90和sm90）