### PR TITLE
WDK: Add shared directory to KMDF include path

### DIFF
--- a/xmake/rules/wdk/env/load.lua
+++ b/xmake/rules/wdk/env/load.lua
@@ -95,6 +95,7 @@ function kmdf(target)
     _base(target, "km")
 
     -- add include directories
+    target:add("sysincludedirs", path.join(wdk.includedir, wdk.sdkver, "shared"))
     if target:rule("wdk.driver") then
         target:add("sysincludedirs", path.join(wdk.includedir, wdk.sdkver, "km", "crt"))
     end


### PR DESCRIPTION
Fixes #7047.

### Test Code

#### xmake.lua

```lua
target("Test")
    add_rules("wdk.env.kmdf", "wdk.driver")
    add_files("Test.c")
```

#### Test.c

```c
#include <ntddk.h>
#include <dispmprt.h>

NTSTATUS DriverEntry(PDRIVER_OBJECT driverObject, PUNICODE_STRING registryPath) {
    return STATUS_SUCCESS;
}
```

#### Before:

```
error: Test.c
C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\km\dispmprt.h(25): fatal error C1083: 无法打开包括文件: “acpiioct.h”: No such file or directory
```

#### After:

```
(No error)
```
