### PR TITLE
fix components typo to make the package instance happy

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2222,7 +2222,7 @@ function _instance:components_deps()
         for _, name in ipairs(table.wrap(self:get("components"))) do
             components_deps[name] = self:extraconf("components", name, "deps") or self:component(name):get("deps")
         end
-        self._COMPONENTS_DEPS = component_deps
+        self._COMPONENTS_DEPS = components_deps
     end
     return components_deps
 end


### PR DESCRIPTION
~~_This pr won't change, break or fix anything, because this variable key seems to be not used at all._~~

"Without this fix, the dependencies would be recalculated on every call to components_deps(), which could impact performance, especially in projects with many components."
--Gemini