### PR TITLE
hide configfile print behind verbose flag

### DIFF
--- a/xmake/actions/config/configfiles.lua
+++ b/xmake/actions/config/configfiles.lua
@@ -362,7 +362,9 @@ function _generate_configfile(srcfile, dstfile, fileinfo, targets, preprocessors
     end
 
     -- trace
-    cprint("generating %s ... ${color.success}${text.success}", srcfile)
+    if option.get("verbose") then
+        cprint("${dim}generating %s ... ${color.success}${text.success}", srcfile)
+    end
 end
 
 -- the main entry function


### PR DESCRIPTION
- side note: there should probably be a `vcprint` function like `vprint` but for color

