### PR TITLE
Fix *bsd cross build for autoconf

### DIFF
--- a/xmake/modules/package/tools/autoconf.lua
+++ b/xmake/modules/package/tools/autoconf.lua
@@ -179,8 +179,16 @@ function _get_configs(package, configs)
                 loong64 = "loongarch64-linux-gnu"
             }
             table.insert(configs, "--host=" .. (triples[package:arch()] or triples.i386))
-	elseif package:is_plat("bsd") and package:is_cross() then
-            table.insert(configs, "--host=x86_64-freebsd")
+        elseif package:is_plat("bsd") and package:is_cross() then
+            local triples = {
+                i386   = "i386-freebsd",
+                x86_64 = "x86_64-freebsd",
+                ["arm64-v8a"] = "aarch64-freebsd",
+                arm64 = "aarch64-freebsd",
+                ppc64 = "powerpc64le-freebsd",
+                riscv64 = "riscv64-freebsd"
+            }
+            table.insert(configs, "--host=" .. (triples[package:arch()] or triples.i386))
         elseif package:is_plat("cross") and package:targetos() then
             local host = package:arch()
             if package:is_arch("arm64") then


### PR DESCRIPTION
在 #7324 里提到的 *bsd 交叉编译问题
在 *bsd 交叉编译时 autoconf 配置缺少了 --host 参数导致错误