### PR TITLE
print exact verbose logs for Go build process

### DIFF
--- a/xmake/rules/go/build/target.lua
+++ b/xmake/rules/go/build/target.lua
@@ -56,16 +56,13 @@ function build_sourcefiles(target, sourcebatch, opt)
     -- trace progress info
     progress.show(opt.progress, "${color.build.target}linking.$(mode) %s", path.filename(targetfile))
 
-    -- trace verbose info
-    vprint(compinst:buildcmd(sourcefiles, targetfile, {target = target, compflags = compflags}))
-
     -- flush io buffer to update progress info
     io.flush()
 
     -- build it (compile and link in one step for Go)
     -- Go builds packages, so we need to change to the source directory
-    local srcdir = path.directory(sourcefiles[1])
     local projectdir = os.projectdir()
+    local srcdir = path.absolute(path.directory(sourcefiles[1]), projectdir)
 
     -- convert targetfile to absolute path before changing directory
     -- targetfile is relative to project directory, so use projectdir as base
@@ -82,10 +79,26 @@ function build_sourcefiles(target, sourcebatch, opt)
         table.insert(rel_sourcefiles, rel_sourcefile)
     end
 
-    local oldir = os.cd(srcdir)
+    -- trace verbose info
+    vprint("changing working directory: %s", srcdir)
+
+    local original_dir = os.cd(srcdir)
+
+    -- trace verbose info
+    vprint(compinst:buildcmd(rel_sourcefiles, abs_targetfile, {target = target, compflags = compflags}))
+
     dependinfo.files = {}
-    assert(compinst:build(rel_sourcefiles, abs_targetfile, {target = target, dependinfo = dependinfo, compflags = compflags}))
-    os.cd(oldir)
+    local ok, errmsg = compinst:build(rel_sourcefiles, abs_targetfile, {target = target, dependinfo = dependinfo, compflags = compflags})
+
+    -- trace verbose info
+    vprint("restoring working directory: %s", original_dir)
+
+    -- restore the original working directory before asserting,
+    -- ensuring a consistent state for other tasks in the same process
+    -- even the build fails
+    os.cd(original_dir)
+
+    assert(ok, errmsg)
 
     -- update files and values to the dependent file
     dependinfo.values = depvalues
@@ -105,4 +118,3 @@ function main(target, opt)
         end
     end
 end
-


### PR DESCRIPTION
This PR supersedes #7334. See my [comment][comment] in #7334. Looking through the codebase of xmake, I found a lot of existing `vprint` usages for friendly debugging, not just printing the build commands. Verbose logs are generally for debugging purposes, so it's better for users to know what are being done exactly during the build process.

[comment]: https://github.com/xmake-io/xmake/pull/7334#issuecomment-3939981882