### PR TITLE
[fix] swig jar package module

### DIFF
--- a/xmake/rules/swig/build_module_file.lua
+++ b/xmake/rules/swig/build_module_file.lua
@@ -70,7 +70,7 @@ function jar_build(target, fileconfig, opt)
 
     -- generate jar file
     progress.show(opt.progress, "${color.build.object}compiling.jar %s", target:name() .. ".jar")
-    os.vrunv(jar.program, {"-cf", path.join(java_src_dir, target:name() .. ".jar"), java_class_dir})
+    os.vrunv(jar.program, {"-cf", path.join(java_src_dir, target:name() .. ".jar"), "-C", java_class_dir, "."})
 
     os.tryrm(filelistname)
 end


### PR DESCRIPTION
之前的打包方式，打包后的类路径为

```shell
build..gens.mcrps.linux.x86_64.release.rules.swig.com.example.MyName;
```

build和gen之间还有个逗号，更无法解析了

↓↓↓

正常来说，类路径应该是

```shell
com.example.MyName
```

目前修改了一下打包参数，本地用 AOSC 系统测试是没问题的