### PR TITLE
update the swig module to make it compatible with JDK 1.8

### DIFF
--- a/xmake/rules/swig/build_module_file.lua
+++ b/xmake/rules/swig/build_module_file.lua
@@ -40,8 +40,9 @@ function find_user_outdir(fileconfig)
 end
 
 function jar_build(target, fileconfig, opt)
-    local javac = assert(find_tool("javac"), "javac not found!")
-    local jar = assert(find_tool("jar"), "jar not found!")
+    -- compatible with JDK 1.8
+    local javac = assert(find_tool("javac", {check = "-version"}), "javac not found!")
+    local jar = assert(find_tool("jar", {check = function (tool) end}), "jar not found!")
 
     local java_src_dir = path.join(target:autogendir(), "rules", "swig")
     local java_class_dir = java_src_dir
@@ -66,7 +67,7 @@ function jar_build(target, fileconfig, opt)
 
     -- compile to class file
     progress.show(opt.progress, "${color.build.object}compiling.javac %s class file", target:name())
-    os.vrunv(javac.program, {"--release", "17", "-d", java_class_dir, "@" .. filelistname})
+    os.vrunv(javac.program, {"-d", java_class_dir, "@" .. filelistname})
 
     -- generate jar file
     progress.show(opt.progress, "${color.build.object}compiling.jar %s", target:name() .. ".jar")


### PR DESCRIPTION
更新 swig 模块，使其在打包 jar 的时候兼容 jdk1.8

主要是在 Windows 上使用 swig 模块遇到了问题，修复了一下，问题如下

```powershell
"C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.50.35717\\bin\\HostX64\\x64\\cl.exe" -c -nologo -MD -O2 -std:c++17 -Isrc "-IC:\\Program Files\\Eclipse Adoptium\\jdk-8.0.472.8-hotspot\\include" "-IC:\\Program Files\\Eclipse Adoptium\\jdk-8.0.472.8-hotspot\\include\\win32" /EHsc /utf-8 -external:W0 -external:IC:\Users\admin\AppData\Local\.xmake\packages\p\python\3.9.13\8044a4eddfe244698d75cacb936a6887\include -DNDEBUG -Fobuild\.objs\test\windows\x64\release\src\pyabi\pyabi.cpp.obj src\pyabi\pyabi.cpp
detectcache start
detectcache name: javac
detectcache result: nil
detectcache end
checkinfo: javac: 无效的标记: --version
用法: javac <options> <source files>
-help 用于列出可能的选项

checkinfo: javac: 无效的标记: --version
用法: javac <options> <source files>
-help 用于列出可能的选项

checking for javac ... no
error: @programdir\core\main.lua:274: @programdir\core\sandbox\modules\import\core\base\task.lua:65: @programdir\actions\build\main.lua:161: @programdir\modules\async\runjobs.lua:261: @programdir\rules\swig\build_module_file.lua:43: javac not found!
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:1148]: in function 'raiselevel'
    [@programdir\core\sandbox\modules\utils.lua:144]: in function 'assert'
    [@programdir\rules\swig\build_module_file.lua:43]: in function 'jar_build'
    [@programdir\rules\swig\build_module_file.lua:193]: in function 'swig_build_file'
    [@programdir\rules\swig\xmake.lua:129]: in function 'script_file'
    [@programdir\modules\private\action\build\target.lua:480]: in function 'job_func'
    [@programdir\modules\async\runjobs.lua:441]:

stack traceback:
        [C]: in function 'error'
        @programdir\core\base\os.lua:1148: in function 'os.raiselevel'
        (...tail calls...)
        @programdir\core\main.lua:274: in upvalue 'cotask'
        @programdir\core\base\scheduler.lua:514: in function <@programdir\core\base\scheduler.lua:507>
```

在 windows 上尝试 swig 模块，在寻找 javac 程序的时候出错，说找不到对应的程序

目前看来是 find_tool 函数调用 find_program 的时候，里面的 check 导致的

因为默认行为是检测 `--version` 参数，但是 jdk 1.8 里的 javac 没有 `--version` 只有 `-version`

check 可以通过下面的行为解决了

```lua
local javac = assert(find_tool("javac", {check = "-version"}), "javac not found!")
```

不过因为写死用 jdk 17 的原因炸了，这个删掉 release 参数就行

```powershell
C:\Program Files\Eclipse Adoptium\jdk-8.0.472.8-hotspot\bin\javac.exe --release 17 -d build\.gens\test\windows\x64\release\rules\swig @build\java\com\example\buildlist.txt
javac: 无效的标记: --release
用法: javac <options> <source files>
-help 用于列出可能的选项
error: @programdir\core\main.lua:274: @programdir\core\sandbox\modules\import\core\base\task.lua:65: @programdir\actions\build\main.lua:161: @programdir\modules\async\runjobs.lua:261: @programdir\core\sandbox\modules\os.lua:378: execv(C:\Program Files\Eclipse Adoptium\jdk-8.0.472.8-hotspot\bin\javac.exe --release 17 -d build\.gens\test\windows\x64\release\rules\swig @build\java\com\example\buildlist.txt) failed(2), unknown reason    
stack traceback:
    [C]: in function 'error'
    [@programdir\core\base\os.lua:1148]:
    [@programdir\core\sandbox\modules\os.lua:378]:
    [@programdir\core\sandbox\modules\os.lua:291]: in function 'vrunv'
    [@programdir\rules\swig\build_module_file.lua:70]: in function 'jar_build'
    [@programdir\rules\swig\build_module_file.lua:194]: in function 'swig_build_file'
    [@programdir\rules\swig\xmake.lua:129]: in function 'script_file'
    [@programdir\modules\private\action\build\target.lua:480]: in function 'job_func'
    [@programdir\modules\async\runjobs.lua:441]:

stack traceback:
        [C]: in function 'error'
        @programdir\core\base\os.lua:1148: in function 'base/os.raiselevel'
        (...tail calls...)
        @programdir\core\main.lua:274: in upvalue 'cotask'
        @programdir\core\base\scheduler.lua:514: in function <@programdir\core\base\scheduler.lua:507>
```

jar 程序在 jdk 1.8 下没有 help 没有 version，用 `-v` 也是输出到标准错误，我就直接过滤 check 行为了
