### PR TITLE
Fix build zig hello world project without specifying zig toolchain

### DIFF
--- a/xmake/rules/zig/xmake.lua
+++ b/xmake/rules/zig/xmake.lua
@@ -22,10 +22,6 @@
 rule("zig.build")
     set_sourcekinds("zc")
     on_load(function (target)
-        local toolchains = target:get("toolchains") or get_config("toolchain")
-        if not toolchains or not table.contains(table.wrap(toolchains), "zig") then
-            target:add("toolchains", "zig")
-        end
         local cachedir = target:values("zig.cachedir") or path.join(target:objectdir(), "zig-cache")
         os.mkdir(cachedir)
         target:add("zcflags", "--cache-dir " .. cachedir)

--- a/xmake/toolchains/zigcc/xmake.lua
+++ b/xmake/toolchains/zigcc/xmake.lua
@@ -19,12 +19,33 @@
 --
 
 -- define toolchain
-toolchain("zig")
+toolchain("zigcc")
+    set_kind("standalone")
     set_homepage("https://ziglang.org/")
-    set_description("Zig Programming Language Compiler")
+    set_description("Zig CC - Use Zig as C/C++ Compiler")
 
     on_check(function (toolchain)
         import("lib.detect.find_tool")
+
+        -- @see https://github.com/xmake-io/xmake/issues/5610
+        function _setup_zigcc_wrapper(zig)
+            local script_suffix = is_host("windows") and ".cmd" or ""
+            for _, tool in ipairs({"cc", "c++", "ar", "ranlib", "lib", "ld.lld", "lld-link", "wasm-ld", "objcopy", "dlltool", "rc"}) do
+                local wrapper_path = path.join(os.tmpdir(), "zigcc", tool) .. script_suffix
+                if not os.isfile(wrapper_path) then
+                    if is_host("windows") then
+                        io.writefile(wrapper_path, ("@echo off\n\"%s\" %s %%*"):format(zig, tool))
+                    else
+                        io.writefile(wrapper_path, ("#!/bin/bash\nexec \"%s\" %s \"$@\""):format(zig, tool))
+                        os.runv("chmod", {"+x", wrapper_path})
+                    end
+                end
+                if (tool == "cc" or tool == "c++") and wrapper_path then
+                    wrapper_path = "zig_cc@" .. wrapper_path
+                end
+                toolchain:config_set("toolset_" .. tool, wrapper_path)
+            end
+        end
 
         local paths = {}
         for _, package in ipairs(toolchain:packages()) do
@@ -48,6 +69,7 @@ toolchain("zig")
             end
         end
         if zig then
+            _setup_zigcc_wrapper(zig)
             toolchain:config_set("zig", zig)
             toolchain:config_set("zig_version", zig_version)
             return true
@@ -60,7 +82,24 @@ toolchain("zig")
         local zig = toolchain:config("zig") or "zig"
         local zig_version = toolchain:config("zig_version")
 
-        -- set zig language toolset
+        -- set C/C++ toolset via zigcc wrappers
+        -- @see https://github.com/xmake-io/xmake/issues/955#issuecomment-766929692
+        toolchain:set("toolset", "cc",       toolchain:config("toolset_cc"))
+        toolchain:set("toolset", "cxx",      toolchain:config("toolset_c++"))
+        toolchain:set("toolset", "ld",       toolchain:config("toolset_c++"))
+        toolchain:set("toolset", "sh",       toolchain:config("toolset_c++"))
+        toolchain:set("toolset", "ar",       toolchain:config("toolset_ar"))
+        toolchain:set("toolset", "ranlib",   toolchain:config("toolset_ranlib"))
+        toolchain:set("toolset", "lib",      toolchain:config("toolset_lib"))
+        toolchain:set("toolset", "ld.lld",   toolchain:config("toolset_ld.lld"))
+        toolchain:set("toolset", "lld-link", toolchain:config("toolset_lld-link"))
+        toolchain:set("toolset", "wasm-ld",  toolchain:config("toolset_wasm-ld"))
+        toolchain:set("toolset", "objcopy",  toolchain:config("toolset_objcopy"))
+        toolchain:set("toolset", "as",       toolchain:config("toolset_cc"))
+        toolchain:set("toolset", "dlltool",  toolchain:config("toolset_dlltool"))
+        toolchain:set("toolset", "mrc",      toolchain:config("toolset_rc"))
+
+        -- also set zig language toolset
         toolchain:set("toolset", "zc",   zig)
         toolchain:set("toolset", "zcar", zig)
         toolchain:set("toolset", "zcld", zig)
@@ -103,7 +142,7 @@ toolchain("zig")
             end
 
             if toolchain:is_plat("cross") then
-                -- xmake f -p cross --toolchain=zig --cross=mips64el-linux-gnuabi64
+                -- xmake f -p cross --toolchain=zigcc --cross=mips64el-linux-gnuabi64
             elseif toolchain:is_plat("macosx") then
                 --@see https://github.com/ziglang/zig/issues/14226
                 target = arch .. "-macos-none"
@@ -124,6 +163,10 @@ toolchain("zig")
 
         -- set target flags
         if target then
+            toolchain:add("asflags", "-target", target)
+            toolchain:add("cxflags", "-target", target)
+            toolchain:add("shflags", "-target", target)
+            toolchain:add("ldflags", "-target", target)
             toolchain:add("zcflags", "-target", target)
             toolchain:add("zcldflags", "-target", target)
             toolchain:add("zcshflags", "-target", target)


### PR DESCRIPTION
Resolves: #7372 

Seems this prevent zig to work ;(

Code example https://ziglang.org/documentation/0.15.2/

```zig
const std = @import("std");

pub fn main() !void {
    try std.fs.File.stdout().writeAll("Hello, World!\n");
}
```

1. Use `--toolchain=zigcc` when need C/C++ wrapper. (`set_toolchains("zigcc")` or `xmake f --toolchain=zigcc`)
2. But use `--toolchain=zig` when need `.zig` language support. (`set_toolchains("zig")` or `xmake f --toolchain=zig`)
