### PR TITLE
fix install script incompatibility with coreutils 9.10

### DIFF
--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -193,7 +193,7 @@ if test_eq "$branch" "__local__"; then
     fi
     cp -r . $projectdir
 elif test_eq "$branch" "__run__"; then
-    version=$(git ls-remote --tags "$gitrepo" | tail -c 7)
+    version=$(git ls-remote --tags "$gitrepo" | tail -c7)
     pack=gz
     mkdir -p $projectdir
     runfile_url="https://fastly.jsdelivr.net/gh/xmake-mirror/xmake-releases@$version/xmake-$version.$pack.run"


### PR DESCRIPTION
The newest version of GNU Coreutils (9.10) changed the cli parser. In the shell install script, the space in `tail -c 7` results in an error: `tail: cannot open '7' for reading.` Changing to `tail -c7` makes the error go away on 9.10 and works in older versions as well.