### PR TITLE
fix(actions): add build target validation

### DIFF
--- a/xmake/actions/build/main.lua
+++ b/xmake/actions/build/main.lua
@@ -198,6 +198,8 @@ function main(opt)
     -- config it first
     local targetname, group_pattern = action_utils.get_target_and_group()
     task.run("config", {}, {disable_dump = true})
+
+    -- check target name
     if targetname then
         assert(check_targetname(targetname))
     end


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/7378#issuecomment-4046670222

## Problem:
Invalid target will be built as "ok".

## Solution:
Introduce `import("private.detect.check_targetname")` to check target names.