### PR TITLE
feat(check): add checker for add_requires()/add_requireconfs()

### DIFF
--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -1691,4 +1691,3 @@ function load_packages(requires, opt)
     end
     return packages
 end
-

--- a/xmake/modules/private/check/checker.lua
+++ b/xmake/modules/private/check/checker.lua
@@ -29,6 +29,7 @@ function checkers()
             -- package api checkers
             ["api.package.kind"]         = {description = "Check kind configuration in package.", load = true},
             ["api.package.versionfiles"] = {description = "Check versionfiles configuration in package.", download_failure = true},
+            ["api.package.configs"]      = {description = "Check package configs in add_requires()/add_requireconfs().", load = true},
             -- target api checkers
             ["api.target.version"]       = {description = "Check version configuration in target."},
             ["api.target.kind"]          = {description = "Check kind configuration in target.", build = true},

--- a/xmake/modules/private/check/checker.lua
+++ b/xmake/modules/private/check/checker.lua
@@ -29,7 +29,7 @@ function checkers()
             -- package api checkers
             ["api.package.kind"]         = {description = "Check kind configuration in package.", load = true},
             ["api.package.versionfiles"] = {description = "Check versionfiles configuration in package.", download_failure = true},
-            ["api.package.configs"]      = {description = "Check package configs in add_requires()/add_requireconfs().", load = true},
+            ["api.package.configs"]      = {description = "Check package configs in add_requires()/add_requireconfs().", load = true, private = true},
             -- target api checkers
             ["api.target.version"]       = {description = "Check version configuration in target."},
             ["api.target.kind"]          = {description = "Check kind configuration in target.", build = true},
@@ -76,18 +76,20 @@ function complete(complete, opt)
         function ()
             local list = {}
             local groupstats = {}
-            for name, _ in table.orderpairs(checkers()) do
-                local groupname = name:split(".", {plain = true})[1]
-                groupstats[groupname] = (groupstats[groupname] or 0) + 1
-                if not complete then
-                    local limit = 16
-                    if groupstats[groupname] < limit then
+            for name, info in table.orderpairs(checkers()) do
+                if not info.private then
+                    local groupname = name:split(".", {plain = true})[1]
+                    groupstats[groupname] = (groupstats[groupname] or 0) + 1
+                    if not complete then
+                        local limit = 16
+                        if groupstats[groupname] < limit then
+                            table.insert(list, name)
+                        elseif groupstats[groupname] == limit then
+                            table.insert(list, "...")
+                        end
+                    elseif name:startswith(complete) then
                         table.insert(list, name)
-                    elseif groupstats[groupname] == limit then
-                        table.insert(list, "...")
                     end
-                elseif name:startswith(complete) then
-                    table.insert(list, name)
                 end
             end
             return list

--- a/xmake/modules/private/check/checkers/api/package/configs.lua
+++ b/xmake/modules/private/check/checkers/api/package/configs.lua
@@ -1,0 +1,42 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, Xmake Open Source Community.
+--
+-- @author      Willaaaaaaa
+-- @file        configs.lua
+--
+
+import("core.base.hashset")
+import("private.check.checker")
+
+function main(opt)
+    opt = opt or {}
+    local package = opt.package
+    if not package then
+        return
+    end
+
+    local valid_configs = hashset.from(table.wrap(package:get("configs")))
+    local requireinfo = package:requireinfo()
+    local required_configs = requireinfo and requireinfo.configs or {}
+    for name, _ in pairs(required_configs) do
+        if not valid_configs:has(name) then
+            opt.show(string.format(
+                "package(%s %s): invalid config(%s) is ignored, please run `xmake require --info %s` to get all valid configurations!",
+                package:displayname(), package:version_str(), name, package:name()))
+            checker.update_stats("warning")
+        end
+    end
+end

--- a/xmake/plugins/check/main.lua
+++ b/xmake/plugins/check/main.lua
@@ -30,13 +30,15 @@ function _show_list()
     local checkers = checker.checkers()
     local groups = {}
     for name, info in table.orderpairs(checkers) do
-        local groupname = name:split(".", {plain = true})[1]
-        if not groups[groupname] then
-            table.insert(tbl, {})
-            table.insert(tbl, {groupname:sub(1, 1):upper() .. groupname:sub(2) .. " checkers:"})
-            groups[groupname] = true
+        if not info.private then
+            local groupname = name:split(".", {plain = true})[1]
+            if not groups[groupname] then
+                table.insert(tbl, {})
+                table.insert(tbl, {groupname:sub(1, 1):upper() .. groupname:sub(2) .. " checkers:"})
+                groups[groupname] = true
+            end
+            table.insert(tbl, {{"  " .. name, style = "${color.dump.string_quote}"}, info.description})
         end
-        table.insert(tbl, {{"  " .. name, style = "${color.dump.string_quote}"}, info.description})
     end
     cprint(text.table(tbl))
 end
@@ -45,7 +47,7 @@ end
 function _show_info(name)
     local checkers = checker.checkers()
     local info = checkers[name]
-    if info then
+    if info and not info.private then
         cprint("${color.dump.string}checker${clear}(%s):", name)
         cprint("  -> ${color.dump.string_quote}description${clear}: %s", info.description)
     else
@@ -62,11 +64,11 @@ function _check(group_or_name, arguments)
     -- get checkers
     local checked_checkers = {}
     local checkers = checker.checkers()
-    if checkers[group_or_name] then
+    if checkers[group_or_name] and not checkers[group_or_name].private then
         table.insert(checked_checkers, group_or_name)
     else
-        for name, _ in table.orderpairs(checkers) do
-            if name:startswith(group_or_name .. ".") then
+        for name, info in table.orderpairs(checkers) do
+            if not info.private and name:startswith(group_or_name .. ".") then
                 table.insert(checked_checkers, name)
             end
         end


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/7378#issue-4032290385

## Problem:
Currently, function `_check_package_configurations()` only checks `package:configs()`, which only contains configs that exist in package descriptions. So we using `add_requires(pkg[invalid_config])` will never show an error/a warning.

## Solution:
Register a private checker `api.package.configs` to check if user specified configs are valid.