### PR TITLE
fix(c++/modules): avoid leaking private dep flags to rebuilt BMIs

### DIFF
--- a/core/xpack.lua
+++ b/core/xpack.lua
@@ -40,14 +40,15 @@ xpack("xmake")
             else
                 local arch = package:arch()
                 local url_7z = "https://github.com/xmake-mirror/7zip/releases/download/24.08/7z24.08-" .. arch .. ".zip"
-                local curl_version = "8.11.0_4"
-                local url_curl = "https://curl.se/windows/dl-" .. curl_version .. "/curl-" .. curl_version
+                local curl_version = "8.19.0_6"
+                local curl_version_win32 = "8.14.1_1"
+                local url_curl
                 if package:is_arch("x64", "x86_64") then
-                    url_curl = url_curl .. "-win64-mingw.zip"
+                    url_curl = "https://curl.se/windows/dl-" .. curl_version .. "/curl-" .. curl_version .. "-win64-mingw.zip"
                 elseif package:is_arch("arm64") then
-                    url_curl = url_curl .. "-win64a-mingw.zip"
+                    url_curl = "https://curl.se/windows/dl-" .. curl_version .. "/curl-" .. curl_version .. "-win64a-mingw.zip"
                 else
-                    url_curl = url_curl .. "-win32-mingw.zip"
+                    url_curl = "https://curl.se/windows/dl-" .. curl_version_win32 .. "/curl-" .. curl_version_win32 .. "-win32-mingw.zip"
                 end
                 local archive_7z = path.join(package:builddir(), "7z.zip")
                 local archive_curl = path.join(package:builddir(), "curl.zip")

--- a/tests/projects/c++/modules/reuse_strict_private_defines/src/include/public_config.h
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/src/include/public_config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define PUBLIC_CONFIG_VALUE 0

--- a/tests/projects/c++/modules/reuse_strict_private_defines/src/main.cpp
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/src/main.cpp
@@ -1,0 +1,5 @@
+import mod;
+
+int main() {
+    return foo();
+}

--- a/tests/projects/c++/modules/reuse_strict_private_defines/src/mod.cpp
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/src/mod.cpp
@@ -1,0 +1,7 @@
+#include <public_config.h>
+
+module mod;
+
+int foo() {
+    return PUBLIC_CONFIG_VALUE;
+}

--- a/tests/projects/c++/modules/reuse_strict_private_defines/src/mod.cpp
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/src/mod.cpp
@@ -1,3 +1,5 @@
+module;
+
 #include <public_config.h>
 
 module mod;

--- a/tests/projects/c++/modules/reuse_strict_private_defines/src/mod.mpp
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/src/mod.mpp
@@ -1,0 +1,3 @@
+export module mod;
+
+export int foo();

--- a/tests/projects/c++/modules/reuse_strict_private_defines/test.lua
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/test.lua
@@ -1,0 +1,34 @@
+inherit(".test_base")
+
+local PRIVATE_DEFINE = "PRIVATE_DEP_DEFINE_DO_NOT_PROPAGATE"
+local PUBLIC_SYSINCLUDEDIR = path.translate(path.absolute("src/include"))
+
+function _build()
+    local outdata = os.iorun("xmake -r -vD")
+    local leaked = false
+    local missing_sysincludedir = true
+    for line in outdata:gmatch("[^\r\n]+") do
+        if line:find("Consumer", 1, true) then
+            if line:find(PRIVATE_DEFINE, 1, true) then
+                leaked = true
+            end
+            if line:find(PUBLIC_SYSINCLUDEDIR, 1, true) then
+                missing_sysincludedir = false
+            end
+        end
+    end
+    if leaked then
+        raise("Private dependency defines leaked into Consumer module rebuilds under reuse.strict\n%s", outdata)
+    end
+    if missing_sysincludedir then
+        raise("Missing public sysincludedir in Consumer module rebuilds under reuse.strict\n%s", outdata)
+    end
+    os.run("xmake -vD")
+end
+
+function main(_)
+    local clang_options = {compiler = "clang", version = CLANG_MIN_VER, build = _build}
+    local gcc_options = {compiler = "gcc", version = GCC_MIN_VER, build = _build}
+    local msvc_options = {version = MSVC_MIN_VER, build = _build}
+    run_tests(clang_options, gcc_options, msvc_options)
+end

--- a/tests/projects/c++/modules/reuse_strict_private_defines/test.lua
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/test.lua
@@ -13,26 +13,30 @@ function _build()
     if ci_is_running() then
         flags = "-vD"
     end
-    local outdata = os.iorun("xmake -r " .. flags)
     local leaked = false
     local missing_sysincludedir = true
-    for line in outdata:gmatch("[^\r\n]+") do
-        if line:find("Consumer", 1, true) then
-            if line:find(PRIVATE_DEFINE, 1, true) then
-                leaked = true
-            end
-            if line:find(PUBLIC_SYSINCLUDEDIR, 1, true) then
-                missing_sysincludedir = false
+    local outdata = try { function () return os.iorun("xmake -rv") end }
+    if outdata then
+        for line in outdata:gmatch("[^\r\n]+") do
+            if line:find("Consumer", 1, true) then
+                if line:find(PRIVATE_DEFINE, 1, true) then
+                    leaked = true
+                end
+                if line:find(PUBLIC_SYSINCLUDEDIR, 1, true) then
+                    missing_sysincludedir = false
+                end
             end
         end
+        if leaked then
+            raise("Private dependency defines leaked into Consumer module rebuilds under reuse.strict\n%s", outdata)
+        end
+        if missing_sysincludedir then
+            raise("Missing public sysincludedir in Consumer module rebuilds under reuse.strict\n%s", outdata)
+        end
+    else
+        -- maybe build failed, we need to see verbose errors
+        os.run("xmake " .. flags)
     end
-    if leaked then
-        raise("Private dependency defines leaked into Consumer module rebuilds under reuse.strict\n%s", outdata)
-    end
-    if missing_sysincludedir then
-        raise("Missing public sysincludedir in Consumer module rebuilds under reuse.strict\n%s", outdata)
-    end
-    os.run("xmake " .. flags)
 end
 
 function main(_)

--- a/tests/projects/c++/modules/reuse_strict_private_defines/test.lua
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/test.lua
@@ -1,10 +1,19 @@
 inherit(".test_base")
+import("utils.ci.is_running", {alias = "ci_is_running"})
+
+local CLANG_MIN_VER = is_subhost("windows") and "19" or "17"
+local GCC_MIN_VER = "11"
+local MSVC_MIN_VER = "14.29"
 
 local PRIVATE_DEFINE = "PRIVATE_DEP_DEFINE_DO_NOT_PROPAGATE"
 local PUBLIC_SYSINCLUDEDIR = path.translate(path.absolute("src/include"))
 
 function _build()
-    local outdata = os.iorun("xmake -r -vD")
+    local flags = ""
+    if ci_is_running() then
+        flags = "-vD"
+    end
+    local outdata = os.iorun("xmake -r " .. flags)
     local leaked = false
     local missing_sysincludedir = true
     for line in outdata:gmatch("[^\r\n]+") do
@@ -23,7 +32,7 @@ function _build()
     if missing_sysincludedir then
         raise("Missing public sysincludedir in Consumer module rebuilds under reuse.strict\n%s", outdata)
     end
-    os.run("xmake -vD")
+    os.run("xmake " .. flags)
 end
 
 function main(_)

--- a/tests/projects/c++/modules/reuse_strict_private_defines/test.lua
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/test.lua
@@ -6,7 +6,7 @@ local GCC_MIN_VER = "11"
 local MSVC_MIN_VER = "14.29"
 
 local PRIVATE_DEFINE = "PRIVATE_DEP_DEFINE_DO_NOT_PROPAGATE"
-local PUBLIC_SYSINCLUDEDIR = path.translate(path.absolute("src/include"))
+local PUBLIC_SYSINCLUDEDIR = path.translate("src/include")
 
 function _build()
     local flags = ""

--- a/tests/projects/c++/modules/reuse_strict_private_defines/xmake.lua
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/xmake.lua
@@ -1,0 +1,16 @@
+add_rules("mode.debug", "mode.release")
+
+set_languages("cxx20")
+
+target("Producer")
+    set_kind("shared")
+    add_defines("PRIVATE_DEP_DEFINE_DO_NOT_PROPAGATE")
+    add_sysincludedirs("src/include", {public = true})
+    add_files("src/mod.mpp", {public = true})
+    add_files("src/mod.cpp")
+
+target("Consumer")
+    set_kind("binary")
+    set_policy("build.c++.modules.reuse.strict", true)
+    add_deps("Producer")
+    add_files("src/main.cpp")

--- a/tests/projects/c++/modules/reuse_strict_private_defines/xmake.lua
+++ b/tests/projects/c++/modules/reuse_strict_private_defines/xmake.lua
@@ -1,9 +1,9 @@
 add_rules("mode.debug", "mode.release")
 
-set_languages("cxx20")
+set_languages("c++20")
 
 target("Producer")
-    set_kind("shared")
+    set_kind("static")
     add_defines("PRIVATE_DEP_DEFINE_DO_NOT_PROPAGATE")
     add_sysincludedirs("src/include", {public = true})
     add_files("src/mod.mpp", {public = true})

--- a/xmake/rules/c++/modules/scanner.lua
+++ b/xmake/rules/c++/modules/scanner.lua
@@ -283,9 +283,12 @@ function _get_targetdeps_modules(target)
                             fileconfig.undefines = _fileconfig.undefines
                             fileconfig.includedirs = _fileconfig.includedirs
                         end
+                        -- only propagate public/interface defines, not private ones
+                        -- e.g. add_defines("LIB") is private and should not leak into the consumer's BMI
+                        -- @see https://github.com/xmake-io/xmake/issues/7436
                         fileconfig.defines = table.join(fileconfig.defines or {}, dep:get("defines", {interface = true}) or {})
                         fileconfig.undefines = table.join(fileconfig.undefines or {}, dep:get("undefines", {interface = true}) or {})
-                        fileconfig.includedirs = table.join(fileconfig.includedirs or {}, dep:get("includedirs", {interface = true}) or {}, dep:get("sysincludedirs", {interface = true}) or {})
+                        fileconfig.includedirs = table.join(fileconfig.includedirs or {}, dep:get("includedirs", {interface = true}) or {})
                         if not dep:is_phony() then
                             if target:namespace() == dep:namespace() then
                                 fileconfig.from_dep = dep:name()
@@ -385,7 +388,7 @@ function _patch_sourcebatch(target, sourcebatch)
                 local strict = target:policy("build.c++.modules.reuse.strict") or
                                target:policy("build.c++.modules.tryreuse.discriminate_on_defines")
                 local dep = target:dep(fileconfig.from_dep)
-                assert(dep, "dep target <%s> for <%s> not found", fileconfig.from_dep, target:fullname())
+                assert(dep, "dep target(%s) for target(%s) not found", fileconfig.from_dep, target:fullname())
                 local can_reuse = nocheck or _are_flags_compatible(target, dep, sourcefile, {strict = strict})
                 if can_reuse then
                     local _reused, from = support.is_reused(dep, sourcefile)
@@ -556,7 +559,7 @@ function _schedule_module_dependencies_scan(target, jobgraph, sourcebatch)
                         local changed = memcache:get2(target:fullname(), "modules.changed")
                         if changed then
                             modules = modules or {}
-                            local moduleinfo = support.load_moduleinfo(target, sourcefile)
+                            local moduleinfo = assert(support.load_moduleinfo(target, sourcefile))
                             local module, headerunitsinfo = _parse_moduleinfo(target, moduleinfo)
                             modules[module.sourcefile] = module
                             for _, headerunitinfo in ipairs(headerunitsinfo) do
@@ -883,7 +886,15 @@ end
 
 function get_modules(target)
     local modules = support.localcache():get2(target:fullname(), "c++.modules")
-    assert(modules, "no modules! (" .. target:fullname() .. ")")
+    if not modules then
+        local targets = support.memcache():get("targets")
+        assert(targets, "module scanner did not run, maybe a custom `on_prepare()` script overrides the modules one.")
+
+        local target_fullname = target:fullname()
+        assert(targets[target_fullname], "module scanner did not run for target(%s), maybe a custom `on_prepare()` script overrides the modules one.", target_fullname)
+        assert(targets[target_fullname].finished_parsing, "target(%s): tried getting modules before scanner finished parsing.", target_fullname)
+        assert(false, "target(%s): no modules found!", target_fullname)
+    end
     return modules
 end
 

--- a/xmake/rules/c++/modules/scanner.lua
+++ b/xmake/rules/c++/modules/scanner.lua
@@ -283,9 +283,9 @@ function _get_targetdeps_modules(target)
                             fileconfig.undefines = _fileconfig.undefines
                             fileconfig.includedirs = _fileconfig.includedirs
                         end
-                        fileconfig.defines = table.join(fileconfig.defines or {}, dep:get("defines") or {})
-                        fileconfig.undefines = table.join(fileconfig.undefines or {}, dep:get("undefines") or {})
-                        fileconfig.includedirs = table.join(fileconfig.includedirs or {}, dep:get("includedirs") or {})
+                        fileconfig.defines = table.join(fileconfig.defines or {}, dep:get("defines", {interface = true}) or {})
+                        fileconfig.undefines = table.join(fileconfig.undefines or {}, dep:get("undefines", {interface = true}) or {})
+                        fileconfig.includedirs = table.join(fileconfig.includedirs or {}, dep:get("includedirs", {interface = true}) or {}, dep:get("sysincludedirs", {interface = true}) or {})
                         if not dep:is_phony() then
                             if target:namespace() == dep:namespace() then
                                 fileconfig.from_dep = dep:name()


### PR DESCRIPTION
## Summary

Only inherit interface-visible `defines`, `undefines`, and `includedirs`
when collecting module fileconfigs from dependency targets.

This prevents private producer flags from leaking into consumer-side BMI
rebuilds under `build.c++.modules.reuse.strict`.

## Changes

- switch dep module fileconfig inheritance to `dep:get(..., {interface = true})`
- add a regression test covering a shared-library producer with a private define
- verify the consumer-side rebuild does not include the producer's private define

## Why

The previous code pulled dependency target flags with full visibility,
which let private defines from the producer affect a rebuilt BMI in the
consumer target.

That is incorrect for module reuse under strict mode, where the consumer
should only inherit dependency usage requirements.

## Testing

- added `tests/projects/c++/modules/reuse_strict_private_defines`
- built local `xmake` and ran:
  - `build/xmake l tests/run.lua reuse_strict_private_defines`

Note: on this macOS environment the module test harness skips actual
modules builds with Apple Clang because `clang-scan-deps` is unavailable,
so full runtime validation should come from CI / supported toolchains.
