### PR TITLE
fix(xcode.application): bundle external dylibs in macOS apps

### DIFF
--- a/tests/projects/objc/macapp_external_dylib/ext/extfoo.c
+++ b/tests/projects/objc/macapp_external_dylib/ext/extfoo.c
@@ -1,0 +1,3 @@
+int extfoo_value(void) {
+    return 7;
+}

--- a/tests/projects/objc/macapp_external_dylib/src/Info.plist
+++ b/tests/projects/objc/macapp_external_dylib/src/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>demo</string>
+    <key>CFBundleIdentifier</key>
+    <string>io.xmake.demo.external</string>
+    <key>CFBundleName</key>
+    <string>demo</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+</dict>
+</plist>

--- a/tests/projects/objc/macapp_external_dylib/src/main.m
+++ b/tests/projects/objc/macapp_external_dylib/src/main.m
@@ -1,0 +1,7 @@
+#import <AppKit/AppKit.h>
+
+int extfoo_value(void);
+
+int main(void) {
+    return extfoo_value() == 7 ? 0 : 1;
+}

--- a/tests/projects/objc/macapp_external_dylib/test.lua
+++ b/tests/projects/objc/macapp_external_dylib/test.lua
@@ -1,0 +1,41 @@
+function _build_external_dylib()
+    local arch = os.arch()
+    local sdkdir = os.iorunv("xcrun", {"--sdk", "macosx", "--show-sdk-path"}):trim()
+    os.execv("xcrun", {
+        "--sdk", "macosx", "clang",
+        "-dynamiclib",
+        "-target", arch .. "-apple-macos",
+        "-isysroot", sdkdir,
+        "-install_name", "@rpath/libextfoo.dylib",
+        "-o", "ext/libextfoo.dylib",
+        "ext/extfoo.c"
+    })
+end
+
+function main(t)
+    if not is_host("macosx") then
+        return t:skip("wrong host platform")
+    end
+
+    local homedir = path.absolute("home")
+    os.setenv("HOME", homedir)
+    os.mkdir(homedir)
+    os.mkdir(path.join(homedir, ".xmake"))
+
+    _build_external_dylib()
+    local arch = os.arch()
+
+    local xmake = path.absolute(path.join(os.projectdir(), "build", "xmake"))
+    local xmake_program_dir = path.absolute(path.join(os.projectdir(), "xmake"))
+    os.setenv("XMAKE_PROGRAM_FILE", xmake)
+    os.setenv("XMAKE_PROGRAM_DIR", xmake_program_dir)
+
+    os.execv(xmake, {"f", "-p", "macosx", "-a", arch, "-c"})
+    os.execv(xmake, {"-vD"})
+
+    local appdir = path.join("build", "macosx", arch, "release", "demo.app", "Contents", "Frameworks")
+    local dylibfile = path.join(appdir, "libextfoo.dylib")
+    if not os.isfile(dylibfile) then
+        raise("missing external dylib in macOS app bundle: %s", dylibfile)
+    end
+end

--- a/tests/projects/objc/macapp_external_dylib/xmake.lua
+++ b/tests/projects/objc/macapp_external_dylib/xmake.lua
@@ -1,0 +1,10 @@
+add_rules("mode.release", "mode.debug")
+
+set_languages("c11", "objc")
+
+target("demo")
+    add_rules("xcode.application")
+    add_linkdirs("ext")
+    add_links("extfoo")
+    add_files("src/main.m")
+    add_files("src/Info.plist")

--- a/xmake/rules/xcode/application/build.lua
+++ b/xmake/rules/xcode/application/build.lua
@@ -28,7 +28,7 @@ import("private.utils.target", {alias = "target_utils"})
 import("utils.binary.deplibs", {alias = "get_depend_libraries"})
 import("utils.progress")
 
-local function _is_non_system_dylib(libfile)
+function _is_non_system_dylib(libfile)
     return libfile and libfile:endswith(".dylib")
        and not libfile:startswith("/usr/lib/")
        and not libfile:startswith("/System/Library/")

--- a/xmake/rules/xcode/application/build.lua
+++ b/xmake/rules/xcode/application/build.lua
@@ -22,8 +22,42 @@
 import("core.base.option")
 import("core.theme.theme")
 import("core.project.depend")
+import("lib.detect.find_library")
 import("private.tools.codesign")
+import("private.utils.target", {alias = "target_utils"})
+import("utils.binary.deplibs", {alias = "get_depend_libraries"})
 import("utils.progress")
+
+local function _is_non_system_dylib(libfile)
+    return libfile and libfile:endswith(".dylib")
+       and not libfile:startswith("/usr/lib/")
+       and not libfile:startswith("/System/Library/")
+end
+
+local function _get_target_linkdirs(target)
+    local linkdirs = {}
+    for _, values in ipairs(table.wrap(target:get_from("linkdirs", "*"))) do
+        for _, linkdir in ipairs(table.wrap(values)) do
+            table.insert(linkdirs, path.absolute(linkdir))
+        end
+    end
+    return table.unique(linkdirs)
+end
+
+local function _get_target_linklibfiles(target)
+    local linkdirs = _get_target_linkdirs(target)
+    local libfiles = {}
+    for _, values in ipairs(table.wrap(target:get_from("links", "*"))) do
+        for _, link in ipairs(table.wrap(values)) do
+            local libinfo = find_library(link, linkdirs, {plat = target:plat(), kind = "shared"})
+            if libinfo then
+                table.insert(libfiles, path.join(libinfo.linkdir, libinfo.filename))
+            end
+        end
+    end
+    return table.unique(libfiles)
+end
+
 function main (target, opt)
 
     -- get app and resources directory
@@ -51,18 +85,46 @@ function main (target, opt)
         try { function () os.vrunv("install_name_tool", {"-delete_rpath", "@loader_path", targetfile}) end }
         os.vrunv("install_name_tool", {"-add_rpath", "@executable_path/../Frameworks", targetfile})
 
-        -- copy dependent dynamic libraries and frameworks
+        -- copy dependent frameworks and dynamic libraries
+        local frameworks_to_copy = {}
+        local framework_targetfiles = {}
         for _, dep in ipairs(target:orderdeps()) do
-            if dep:kind() == "shared" then
-                if not os.isdir(frameworksdir) then
-                    os.mkdir(frameworksdir)
-                end
-                local frameworkdir = dep:data("xcode.bundle.rootdir")
-                if dep:rule("xcode.framework") and frameworkdir then
-                    os.cp(frameworkdir, frameworksdir, {symlink = true})
-                else
-                    os.vcp(dep:targetfile(), frameworksdir)
-                end
+            local frameworkdir = dep:data("xcode.bundle.rootdir")
+            if dep:rule("xcode.framework") and frameworkdir then
+                table.insert(frameworks_to_copy, frameworkdir)
+                framework_targetfiles[path.absolute(dep:targetfile())] = true
+            end
+        end
+        local libfiles = {}
+        target_utils.get_target_libfiles(target, libfiles, target:targetfile(), {})
+        table.join2(libfiles, _get_target_linklibfiles(target))
+        local dependfiles = get_depend_libraries(target:targetfile(), {
+            plat = target:plat(),
+            arch = target:arch(),
+            recursive = true,
+            resolve_path = true,
+            resolve_hint_paths = libfiles
+        })
+        for _, dependfile in ipairs(table.wrap(dependfiles)) do
+            if _is_non_system_dylib(dependfile) then
+                table.insert(libfiles, dependfile)
+            end
+        end
+        local dylibs_to_copy = {}
+        for _, libfile in ipairs(table.unique(libfiles)) do
+            if not framework_targetfiles[path.absolute(libfile)] then
+                table.insert(dylibs_to_copy, libfile)
+            end
+        end
+        if #frameworks_to_copy > 0 or #dylibs_to_copy > 0 then
+            if not os.isdir(frameworksdir) then
+                os.mkdir(frameworksdir)
+            end
+            for _, frameworkdir in ipairs(frameworks_to_copy) do
+                os.cp(frameworkdir, frameworksdir, {symlink = true})
+            end
+            for _, libfile in ipairs(dylibs_to_copy) do
+                os.vcp(libfile, frameworksdir)
             end
         end
 
@@ -109,4 +171,3 @@ function main (target, opt)
 
     end, {dependfile = target:dependfile(bundledir), files = {bundledir, target:targetfile()}, changed = target:is_rebuilt()})
 end
-


### PR DESCRIPTION
## Summary

Bundle non-target macOS dylibs into `xcode.application` app bundles in
addition to shared target and framework dependencies.

This fixes app bundles that link external or package-provided `.dylib`
files and otherwise end up with a binary that depends on `@rpath/...`
entries that are never copied into `Contents/Frameworks`.

Fixes #7452.

## Changes

- keep explicit framework-target bundle copying
- reuse existing target/package shared library collection via `get_target_libfiles()`
- resolve declared shared `links` against merged `linkdirs` to find non-target dylibs
- walk the app binary dylib dependencies and copy non-system dylibs into `Contents/Frameworks`
- add a regression test that builds an external dylib and verifies it is bundled into a macOS app

## Why

`xcode.application` already performs partial app-bundle assembly by rewriting
rpath and copying shared target/framework dependencies.

However, it did not bundle non-target dylibs linked through raw
`add_linkdirs()` / `add_links()` usage, leaving the generated `.app`
incomplete relative to the app binary's load commands.

This patch makes that behavior consistent for macOS app bundles without
changing the separate duplicate-`LC_RPATH` issue, which is intentionally
left out of this change.

## Testing

- ran `build/xmake l tests/run.lua macapp_external_dylib`
- result: `1 test(s) succeed`
- smoke-built existing fixtures:
  - `tests/projects/objc/macapp_with_shared`
  - `tests/projects/objc/macapp_with_framework`
