### PR TITLE
Fix Xcode toolchain ignoring local config precedence

### DIFF
--- a/tests/modules/xcode_toolchain_config/test.lua
+++ b/tests/modules/xcode_toolchain_config/test.lua
@@ -1,0 +1,40 @@
+import("core.project.config")
+
+local function _import_xcode_check()
+    local rootdir = path.absolute(path.join(os.scriptdir(), "..", "..", "..", "xmake"))
+    return import("toolchains.xcode.check", {rootdir = rootdir, anonymous = true})
+end
+
+function test_prefers_toolchain_local_xcode_config(t)
+    if not is_host("macosx") then
+        return t:skip("wrong host platform")
+    end
+
+    local check = _import_xcode_check()
+    local old_xcode = config.get("xcode")
+    config.set("xcode", "/tmp/global-xcode", {force = true})
+    local toolchain = {
+        config = function (_, name)
+            if name == "xcode" then
+                return "/tmp/local-xcode"
+            end
+        end
+    }
+    t:are_equal(check.get_xcode(toolchain), "/tmp/local-xcode")
+    config.set("xcode", old_xcode, {force = true})
+end
+
+function test_falls_back_to_global_xcode_config(t)
+    if not is_host("macosx") then
+        return t:skip("wrong host platform")
+    end
+
+    local check = _import_xcode_check()
+    local old_xcode = config.get("xcode")
+    config.set("xcode", "/tmp/global-xcode", {force = true})
+    local toolchain = {
+        config = function () end
+    }
+    t:are_equal(check.get_xcode(toolchain), "/tmp/global-xcode")
+    config.set("xcode", old_xcode, {force = true})
+end

--- a/xmake/toolchains/xcode/check.lua
+++ b/xmake/toolchains/xcode/check.lua
@@ -26,6 +26,10 @@ import("private.utils.toolchain", {alias = "toolchain_utils"})
 import("private.utils.executable_path")
 import("private.tools.codesign")
 
+function get_xcode(toolchain)
+    return toolchain:config("xcode") or config.get("xcode")
+end
+
 -- print Xcode SDK summary (single line) and optional codesign infos
 function _show_checkinfo(toolchain, xcode, xcode_sdkver, target_minver)
     if xcode and xcode.sdkdir then
@@ -80,7 +84,7 @@ function main(toolchain)
 
     -- find xcode
     local xcode_sdkver = toolchain:config("xcode_sdkver") or config.get("xcode_sdkver")
-    local xcode = find_xcode(config.get("xcode"), {force = true, verbose = true,
+    local xcode = find_xcode(get_xcode(toolchain), {force = true, verbose = true,
                                                    sdkver = xcode_sdkver,
                                                    appledev = appledev,
                                                    plat = toolchain:plat(),


### PR DESCRIPTION
Fixes #7457

### Description
Updates `xmake/toolchains/xcode/check.lua` so that checking for the `xcode` configuration appropriately defaults first to the `toolchain:config("xcode")` dictionary before resorting to the global `config.get("xcode")`. An exported function `get_xcode()` is provided to handle this check.

Adds a regression toolchain test validating this exact requirement.