### PR TITLE
fix(cmakelists): use target_link_libraries with $<TARGET_OBJECTS:%s> to link object files of object target

### DIFF
--- a/xmake/plugins/project/cmake/cmakelists.lua
+++ b/xmake/plugins/project/cmake/cmakelists.lua
@@ -1093,18 +1093,16 @@ function _add_target_link_libraries(cmakelists, target, outputdir)
 
     if #object_deps ~= 0 then
         if not has_links then
-            cmakelists:print("add_library(target_objectfiles_%s OBJECT IMPORTED GLOBAL)", key)
-            cmakelists:print("set_property(TARGET target_objectfiles_%s PROPERTY IMPORTED_OBJECTS", key)
+            cmakelists:print("target_link_libraries(%s PRIVATE", target:name())
             has_links = true
         end
         for _, dep in ipairs(object_deps) do
-            cmakelists:print("    " .. dep)
+            cmakelists:print("    $<TARGET_OBJECTS:%s>", dep)
         end
     end
 
     if has_links then
         cmakelists:print(")")
-        cmakelists:print("target_link_libraries(%s PRIVATE target_objectfiles_%s)", target:name(), key)
     end
 end
 


### PR DESCRIPTION
In the original `_add_target_link_libraries` function, it uses `set_property(TARGET target_objectfiles_%s PROPERTY IMPORTED_OBJECTS` to add obj files from another object target.
But according to [CMake's documentation](https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_OBJECTS.html), the `IMPORTED_OBJECTS ` is

> A [semicolon-separated list](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#cmake-language-lists) of absolute paths to the object files on disk for an [imported](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets) [object library](https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#object-libraries).

So, it doesn't accept target, as my screenshot showed:

<img width="1920" height="1032" alt="屏幕截图 2026-04-10 172818" src="https://github.com/user-attachments/assets/4c5b434a-fc21-4c93-8389-0577dc456e23" />

According to [CMake's document](https://cmake.org/cmake/help/latest/command/target_link_libraries.html#linking-object-libraries-via-target-objects), we can link object libraries via `$<TARGET_OBJECTS>`.  
After using `target_link_libraries(%s PRIVATE $<TARGET_OBJECTS:%s>)`, the CMake project configured correctly.

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/3b6331d7-6f10-4daf-9e30-46bd333e493d" />
