### PR TITLE
fix qt cross

### DIFF
--- a/xmake/modules/detect/sdks/find_qt.lua
+++ b/xmake/modules/detect/sdks/find_qt.lua
@@ -208,8 +208,8 @@ function _get_qtenvs(qmake, sdkdir)
     local results
 
     -- Try with -qtconf first if sdkdir is provided
-    if sdkdir then
-        local conf_paths = {path.join(sdkdir, "bin", "target_qt.conf"), path.join(sdkdir, "bin", "qt.conf")}
+    if sdkdir then        
+        local conf_paths = {path.join(sdkdir, "bin", "target_qt.conf"), path.join(sdkdir, "bin", "qt.conf"), path.join(sdkdir, "qt.conf")}        
         for _, conf_path in ipairs(conf_paths) do
             if os.isfile(conf_path) then
                 results = try {function () return os.iorunv(qmake, {"-query", "-qtconf", conf_path}) end}
@@ -288,6 +288,19 @@ function _find_qt(sdkdir, sdkver, sdkdir_host)
     local includedir = qtenvs.QT_INSTALL_HEADERS
     local mkspecsdir = qtenvs.QMAKE_MKSPECS or path.join(qtenvs.QT_HOST_DATA, "mkspecs")
     local mkspec = qtenvs.QMAKE_XSPEC or qtenvs.QMAKE_SPEC
+
+    -- handle qt sysroot
+    if qtenvs.QT_SYSROOT and qtenvs.QT_SYSROOT ~= "" then
+        local qt_sysroot = qtenvs.QT_SYSROOT
+        sdkdir = qt_sysroot .. sdkdir
+        bindir = qt_sysroot .. bindir
+        libexecdir = qt_sysroot .. libexecdir
+        qmldir = qt_sysroot .. qmldir
+        libdir = qt_sysroot .. libdir
+        pluginsdir = qt_sysroot .. pluginsdir
+        includedir = qt_sysroot .. includedir
+    end
+
     -- for 6.2
     local bindir_host = qtenvs.QT_HOST_BINS
     if not bindir_host and libexecdir and is_plat("android", "iphoneos") then

--- a/xmake/modules/detect/sdks/find_qt.lua
+++ b/xmake/modules/detect/sdks/find_qt.lua
@@ -290,15 +290,15 @@ function _find_qt(sdkdir, sdkver, sdkdir_host)
     local mkspec = qtenvs.QMAKE_XSPEC or qtenvs.QMAKE_SPEC
 
     -- handle qt sysroot
-    if qtenvs.QT_SYSROOT and qtenvs.QT_SYSROOT ~= "" then
-        local qt_sysroot = qtenvs.QT_SYSROOT
-        sdkdir = qt_sysroot .. sdkdir
-        bindir = qt_sysroot .. bindir
-        libexecdir = qt_sysroot .. libexecdir
-        qmldir = qt_sysroot .. qmldir
-        libdir = qt_sysroot .. libdir
-        pluginsdir = qt_sysroot .. pluginsdir
-        includedir = qt_sysroot .. includedir
+    local qt_sysroot = qtenvs.QT_SYSROOT or ""
+    if #qt_sysroot > 0 and path.isdir(qt_sysroot) then        
+        sdkdir = path.join(qt_sysroot, sdkdir)
+        bindir = path.join(qt_sysroot, bindir)
+        libexecdir = path.join(qt_sysroot, libexecdir)
+        qmldir = path.join(qt_sysroot, qmldir)
+        libdir = path.join(qt_sysroot, libdir)
+        pluginsdir = path.join(qt_sysroot, pluginsdir)
+        includedir = path.join(qt_sysroot, includedir)
     end
 
     -- for 6.2

--- a/xmake/modules/detect/sdks/find_qt.lua
+++ b/xmake/modules/detect/sdks/find_qt.lua
@@ -209,7 +209,7 @@ function _get_qtenvs(qmake, sdkdir)
 
     -- Try with -qtconf first if sdkdir is provided
     if sdkdir then
-        local conf_paths = {path.join(sdkdir, "bin", "target_qt.conf"), path.join(sdkdir, "bin", "qt.conf"), path.join(sdkdir, "qt.conf")}        
+        local conf_paths = {path.join(sdkdir, "bin", "target_qt.conf"), path.join(sdkdir, "bin", "qt.conf"), path.join(sdkdir, "qt.conf")}
         for _, conf_path in ipairs(conf_paths) do
             if os.isfile(conf_path) then
                 results = try {function () return os.iorunv(qmake, {"-query", "-qtconf", conf_path}) end}

--- a/xmake/modules/detect/sdks/find_qt.lua
+++ b/xmake/modules/detect/sdks/find_qt.lua
@@ -208,7 +208,7 @@ function _get_qtenvs(qmake, sdkdir)
     local results
 
     -- Try with -qtconf first if sdkdir is provided
-    if sdkdir then        
+    if sdkdir then
         local conf_paths = {path.join(sdkdir, "bin", "target_qt.conf"), path.join(sdkdir, "bin", "qt.conf"), path.join(sdkdir, "qt.conf")}        
         for _, conf_path in ipairs(conf_paths) do
             if os.isfile(conf_path) then
@@ -291,7 +291,7 @@ function _find_qt(sdkdir, sdkver, sdkdir_host)
 
     -- handle qt sysroot
     local qt_sysroot = qtenvs.QT_SYSROOT or ""
-    if #qt_sysroot > 0 and path.isdir(qt_sysroot) then        
+    if #qt_sysroot > 0 and path.isdir(qt_sysroot) then
         sdkdir = path.join(qt_sysroot, sdkdir)
         bindir = path.join(qt_sysroot, bindir)
         libexecdir = path.join(qt_sysroot, libexecdir)

--- a/xmake/rules/qt/load.lua
+++ b/xmake/rules/qt/load.lua
@@ -37,7 +37,7 @@ function _link(target, linkdirs, framework, qt_sdkver, infix)
             else
                 debug_suffix = "d"
             end
-        elseif target:is_plat("android") or target:is_plat("linux") then
+        elseif target:is_plat("android") or target:is_plat("linux") or target:is_plat("cross") then
             debug_suffix = ""
         end
         if qt_sdkver:ge("5.0") then
@@ -67,7 +67,7 @@ function _find_static_links_3rd(target, linkdirs, qt_sdkver, libpattern)
         debug_suffix = "d"
     elseif target:is_plat("mingw") then
         debug_suffix = "d"
-    elseif target:is_plat("android") or target:is_plat("linux") then
+    elseif target:is_plat("android") or target:is_plat("linux") or target:is_plat("cross")  then
         debug_suffix = ""
     end
     for _, linkdir in ipairs(linkdirs) do
@@ -459,6 +459,8 @@ function main(target, opt)
         fallbackmkspec = "linux-g++"
         target:add("rpathdirs", qt.libdir)
         target:add("linkdirs", qt.libdir)
+    elseif target:is_plat("cross") then
+        _add_includedirs(target, qt.includedir)
     elseif target:is_plat("windows") then
         target:set("frameworks", nil)
         _add_includedirs(target, qt.includedir)


### PR DESCRIPTION
fix #7381

- find_qt.lua
qt.conf may be in the same directory as qmake.
should be handle QT_SYSROOT

- qt/load.lua
'cross' plat did not handle it properly.

