### PR TITLE
fix "cannot find known tool script for ar.cmd"

### DIFF
--- a/xmake/modules/lib/detect/find_toolname.lua
+++ b/xmake/modules/lib/detect/find_toolname.lua
@@ -27,7 +27,7 @@ import("core.sandbox.module")
 -- we just remove some known extension, because we need to reverse others, e.g. ld.lld, ld64.lld
 --
 function _remove_suffix(name)
-    local exts = hashset.of("exe", "bat", "sh", "ps1", "ps")
+    local exts = hashset.of("exe", "bat", "cmd", "sh", "ps1", "ps")
     name = name:gsub("%.(%w+)", function (ext)
         ext = ext:lower()
         if exts:has(ext) then


### PR DESCRIPTION
使用zigcc构建静态工具链的时候会产生如下报错
<img width="2586" height="1372" alt="5241859cd399e4de46e4aceafbab81ae" src="https://github.com/user-attachments/assets/17c1a9b9-9eea-4095-8d0c-0da1bd40d41a" />
