### PR TITLE
fix linux module intermediate filenames

### DIFF
--- a/xmake/rules/platform/linux/module/driver_modules.lua
+++ b/xmake/rules/platform/linux/module/driver_modules.lua
@@ -361,14 +361,15 @@ function link(target, opt)
         if ldflags_o then
             table.join2(argv, ldflags_o)
         end
-        local targetfile_o = target:objectfile(targetfile)
+        local targetfile_base = path.join(path.directory(target:objectfile(targetfile)), target:basename())
+        local targetfile_o = targetfile_base .. ".o"
         table.join2(argv, "-o", targetfile_o)
         table.join2(argv, objectfiles)
         os.mkdir(path.directory(targetfile_o))
         os.vrunv(ld, argv)
 
         -- generate target.mod
-        local targetfile_mod = targetfile_o:gsub("%.o$", ".mod")
+        local targetfile_mod = targetfile_base .. ".mod"
         io.writefile(targetfile_mod, table.concat(objectfiles, "\n") .. "\n\n")
 
         -- generate .sourcename.o.cmd
@@ -399,8 +400,8 @@ function link(target, opt)
         os.vrunv(modpost, argv)
 
         -- compile target.mod.c
-        local targetfile_mod_c = targetfile_o:gsub("%.o$", ".mod.c")
-        local targetfile_mod_o = targetfile_o:gsub("%.o$", ".mod.o")
+        local targetfile_mod_c = targetfile_base .. ".mod.c"
+        local targetfile_mod_o = targetfile_base .. ".mod.o"
         local compinst = target:compiler("cc")
         target:fileconfig_set(targetfile_mod_c, {defines = "KBUILD_BASENAME=\"" .. path.basename(targetfile_mod_c) .. "\""})
         if option.get("verbose") then
@@ -425,7 +426,6 @@ function link(target, opt)
         if ldflags_ko then
             table.join2(argv, ldflags_ko)
         end
-        local targetfile_o = target:objectfile(targetfile)
         table.join2(argv, "-o", targetfile, targetfile_o, targetfile_mod_o)
         if modulecommon_objectfile then
             table.insert(argv, modulecommon_objectfile)


### PR DESCRIPTION
## Summary
- generate linux kernel module intermediate files from the target basename instead of the final `.ko` path
- make `modpost` consume `hello.o` instead of `hello.ko.o`
- avoid the bogus `*.ko.ko` module name and undefined symbol warnings reported in #5721

## Root cause
`platform.linux.module` previously called `target:objectfile(targetfile)` where `targetfile` already ended with `.ko`. That produced intermediate paths like `hello.ko.o`, which then flowed into `modules.order`/`modpost` and could be rendered as `hello.ko.ko` in warnings.

This patch switches the intermediate basename to `target:basename()`, so the generated files become `hello.o`, `hello.mod`, `hello.mod.c`, and `hello.mod.o`.

## Test plan
- [x] verified `git diff master...HEAD` only contains this single fix commit
- [x] confirmed the generated intermediate names on this branch are based on the module basename, not the final `.ko` path
- [x] attempted to rebuild `tests/projects/linux/driver/hello_custom` against `/lib/modules/$(uname -r)/build`; the local machine currently hits an existing GCC 15 / kernel headers compatibility issue (`false`/`bool` in kernel headers) before the `modpost` stage, so it cannot be used here to fully exercise the warning path

Made with [Cursor](https://cursor.com)