### PR TITLE
fix: preserve target link flags in rpath probes

### DIFF
--- a/tests/projects/c/rpath_with_ldflags_probe/foo.c
+++ b/tests/projects/c/rpath_with_ldflags_probe/foo.c
@@ -1,0 +1,4 @@
+int foo(void)
+{
+    return 42;
+}

--- a/tests/projects/c/rpath_with_ldflags_probe/main.c
+++ b/tests/projects/c/rpath_with_ldflags_probe/main.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+
+int foo(void);
+
+int main(void)
+{
+    printf("foo=%d\n", foo());
+    return 0;
+}

--- a/tests/projects/c/rpath_with_ldflags_probe/repro-gcc.sh
+++ b/tests/projects/c/rpath_with_ldflags_probe/repro-gcc.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+real_gcc="${REAL_GCC:-gcc}"
+compile_only=0
+allow_link=0
+
+for arg in "$@"; do
+    case "$arg" in
+        -c|-S|-E)
+            compile_only=1
+            ;;
+        -shared|-Wl,--hash-style=gnu)
+            allow_link=1
+            ;;
+    esac
+done
+
+if [[ "$compile_only" -eq 1 || "$allow_link" -eq 1 ]]; then
+    exec "$real_gcc" "$@"
+fi
+
+echo "repro-gcc: synthetic link failure for bare flag probes" >&2
+exit 1

--- a/tests/projects/c/rpath_with_ldflags_probe/test.lua
+++ b/tests/projects/c/rpath_with_ldflags_probe/test.lua
@@ -5,10 +5,11 @@ function main(t)
         return t:skip("wrong host platform")
     end
 
-    os.execv("chmod", {"+x", "repro-gcc.sh"})
+    local targetfile = path.join(os.scriptdir(), "bin", "demo")
+    os.execv("chmod", {"+x", path.join(os.scriptdir(), "repro-gcc.sh")})
     t:build()
 
-    local rpaths = rpath.list("bin/demo") or {}
+    local rpaths = rpath.list(targetfile) or {}
     t:require(table.contains(rpaths, path.join(os.scriptdir(), "lib")))
-    t:require(os.iorun("env -u LD_LIBRARY_PATH ./bin/demo"):trim() == "foo=42")
+    t:require(os.iorunv("env", {"-u", "LD_LIBRARY_PATH", targetfile}):trim() == "foo=42")
 end

--- a/tests/projects/c/rpath_with_ldflags_probe/test.lua
+++ b/tests/projects/c/rpath_with_ldflags_probe/test.lua
@@ -1,0 +1,14 @@
+import("utils.binary.rpath")
+
+function main(t)
+    if not is_host("linux") then
+        return t:skip("wrong host platform")
+    end
+
+    os.execv("chmod", {"+x", "repro-gcc.sh"})
+    t:build()
+
+    local rpaths = rpath.list("bin/demo") or {}
+    t:require(table.contains(rpaths, path.join(os.scriptdir(), "lib")))
+    t:require(os.iorun("env -u LD_LIBRARY_PATH ./bin/demo"):trim() == "foo=42")
+end

--- a/tests/projects/c/rpath_with_ldflags_probe/xmake.lua
+++ b/tests/projects/c/rpath_with_ldflags_probe/xmake.lua
@@ -1,0 +1,31 @@
+add_rules("mode.debug", "mode.release")
+
+toolchain("repro-gcc")
+    set_kind("standalone")
+    set_toolset("cc", path.join(os.scriptdir(), "repro-gcc.sh"))
+    set_toolset("ld", path.join(os.scriptdir(), "repro-gcc.sh"))
+    set_toolset("sh", path.join(os.scriptdir(), "repro-gcc.sh"))
+    set_toolset("ar", "ar")
+
+    on_check(function ()
+        return import("lib.detect.find_tool")("gcc")
+    end)
+
+toolchain_end()
+
+target("foo")
+    set_kind("shared")
+    set_toolchains("repro-gcc")
+    set_targetdir(path.join(os.scriptdir(), "lib"))
+    add_files("foo.c")
+
+target("demo")
+    set_kind("binary")
+    set_toolchains("repro-gcc")
+    set_targetdir(path.join(os.scriptdir(), "bin"))
+    add_deps("foo")
+    add_files("main.c")
+    add_linkdirs(path.join(os.scriptdir(), "lib"))
+    add_links("foo")
+    add_rpathdirs(path.join(os.scriptdir(), "lib"))
+    add_ldflags("-Wl,--hash-style=gnu")

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -751,6 +751,20 @@ function nf_linkdir(self, dir)
     return {"-L" .. path.translate(dir)}
 end
 
+local function _nf_rpathdir_hasflags_opt(self, opt)
+    local sysflags = table.wrap(self:_sysflags(self:kind(), "ldflags"))
+    local target = opt and opt.target
+    if target then
+        table.join2(sysflags, target:get("ldflags"))
+        if self:kind() == "sh" then
+            table.join2(sysflags, target:get("shflags"))
+        end
+    end
+    if #sysflags > 0 then
+        return {sysflags = sysflags}
+    end
+end
+
 -- make the rpathdir flag
 function nf_rpathdir(self, dir, opt)
     if self:is_plat("windows", "mingw") then
@@ -762,7 +776,8 @@ function nf_rpathdir(self, dir, opt)
         return
     end
     dir = path.translate(dir)
-    if self:has_flags("-Wl,-rpath=" .. dir, "ldflags") then
+    local hasflags_opt = _nf_rpathdir_hasflags_opt(self, opt)
+    if self:has_flags("-Wl,-rpath=" .. dir, "ldflags", hasflags_opt) then
         local flags = {"-Wl,-rpath=" .. (dir:gsub("@[%w_]+", function (name)
             local maps = {["@loader_path"] = "$ORIGIN", ["@executable_path"] = "$ORIGIN"}
             return maps[name]
@@ -770,9 +785,9 @@ function nf_rpathdir(self, dir, opt)
         -- add_rpathdirs("...", {runpath = false})
         -- https://github.com/xmake-io/xmake/issues/5109
         if extra then
-            if extra.runpath == false and self:has_flags("-Wl,-rpath=" .. dir .. ",--disable-new-dtags", "ldflags") then
+            if extra.runpath == false and self:has_flags("-Wl,-rpath=" .. dir .. ",--disable-new-dtags", "ldflags", hasflags_opt) then
                 flags[1] = flags[1] .. ",--disable-new-dtags"
-            elseif extra.runpath == true and self:has_flags("-Wl,-rpath=" .. dir .. ",--enable-new-dtags", "ldflags") then
+            elseif extra.runpath == true and self:has_flags("-Wl,-rpath=" .. dir .. ",--enable-new-dtags", "ldflags", hasflags_opt) then
                 flags[1] = flags[1] .. ",--enable-new-dtags"
             end
         end
@@ -781,7 +796,7 @@ function nf_rpathdir(self, dir, opt)
             table.insert(flags, 1, "-Wl,-zorigin")
         end
         return flags
-    elseif self:has_flags("-Xlinker -rpath -Xlinker " .. dir, "ldflags") then
+    elseif self:has_flags("-Xlinker -rpath -Xlinker " .. dir, "ldflags", hasflags_opt) then
         return {"-Xlinker", "-rpath", "-Xlinker", (dir:gsub("%$ORIGIN", "@loader_path"))}
     end
 end

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -752,16 +752,16 @@ function nf_linkdir(self, dir)
 end
 
 local function _nf_rpathdir_hasflags_opt(self, opt)
-    local sysflags = table.wrap(self:_sysflags(self:kind(), "ldflags"))
+    local linkflags = table.join({}, table.wrap(self:_sysflags(self:kind(), self:kind() == "sh" and "shflags" or "ldflags")))
     local target = opt and opt.target
     if target then
-        table.join2(sysflags, target:get("ldflags"))
+        table.join2(linkflags, table.wrap(target:get("ldflags")))
         if self:kind() == "sh" then
-            table.join2(sysflags, target:get("shflags"))
+            table.join2(linkflags, table.wrap(target:get("shflags")))
         end
     end
-    if #sysflags > 0 then
-        return {sysflags = sysflags}
+    if #linkflags > 0 then
+        return {sysflags = linkflags}
     end
 end
 


### PR DESCRIPTION
Summary
- Preserve target link flags during the gcc/clang rpath probe so rpath detection uses the same link context as the real target link step.
- Add a Linux regression test for this rpath probe path.
- fixes #5852

Root cause
- The previous logic dropped target ldflags/shflags when running the gcc/clang rpath probe.
- That lost the target link context during the probe, caused false negatives, and left the final link command without the expected rpath.

Fix
- Restore the target link flags in the gcc/clang rpath probe, including the relevant target ldflags/shflags.
- Add a Linux regression test to cover this case and prevent future regressions.

Validation
- Verified the fix through the updated gcc/clang rpath probe flow.
- Added a Linux regression test that exercises the probe with target link flags preserved.
