### PR TITLE
fix cl exception

### DIFF
--- a/xmake/modules/core/tools/cl.lua
+++ b/xmake/modules/core/tools/cl.lua
@@ -379,7 +379,7 @@ end
 function nf_exception(self, exp)
     local maps = {
         cxx = "/EHsc",
-        ["no-cxx"] = "/EHsc-"
+        ["no-cxx"] = "/EHs-c-"
     }
     return maps[exp]
 end


### PR DESCRIPTION
禁用c++异常是否应该是`/EHs-c-`？

[/EH（异常处理模型） | Microsoft Learn](https://learn.microsoft.com/zh-cn/cpp/build/reference/eh-exception-handling-model?view=msvc-170)
>`/EHsc-` 解释为 `/EHs /EHc-` 并且等效于 `/EHs`