### PR TITLE
Fix msvc/intel/snippet detect when temp path contains spaces

### DIFF
--- a/xmake/modules/detect/sdks/find_iccenv.lua
+++ b/xmake/modules/detect/sdks/find_iccenv.lua
@@ -55,7 +55,7 @@ function _load_iclvars(iclvars_bat, arch, opt)
     -- run geniclvars.bat
     -- @note we use runv here so the bat path is not split on whitespace by os.argv,
     -- which breaks detection when the temp file lives under a path with spaces.
-    os.runv(geniclvars_bat, {})
+    os.runv(geniclvars_bat)
 
     -- load all envirnoment variables
     local variables = {}

--- a/xmake/modules/detect/sdks/find_iccenv.lua
+++ b/xmake/modules/detect/sdks/find_iccenv.lua
@@ -53,7 +53,9 @@ function _load_iclvars(iclvars_bat, arch, opt)
     file:close()
 
     -- run geniclvars.bat
-    os.run(geniclvars_bat)
+    -- @note we use runv here so the bat path is not split on whitespace by os.argv,
+    -- which breaks detection when the temp file lives under a path with spaces.
+    os.runv(geniclvars_bat, {})
 
     -- load all envirnoment variables
     local variables = {}

--- a/xmake/modules/detect/sdks/find_icxenv.lua
+++ b/xmake/modules/detect/sdks/find_icxenv.lua
@@ -55,7 +55,7 @@ function _load_icxvars(icxvars_bat, arch, opt)
     -- run genicxvars.bat
     -- @note we use runv here so the bat path is not split on whitespace by os.argv,
     -- which breaks detection when the temp file lives under a path with spaces.
-    os.runv(genicxvars_bat, {})
+    os.runv(genicxvars_bat)
 
     -- load all envirnoment variables
     local variables = {}

--- a/xmake/modules/detect/sdks/find_icxenv.lua
+++ b/xmake/modules/detect/sdks/find_icxenv.lua
@@ -53,7 +53,9 @@ function _load_icxvars(icxvars_bat, arch, opt)
     file:close()
 
     -- run genicxvars.bat
-    os.run(genicxvars_bat)
+    -- @note we use runv here so the bat path is not split on whitespace by os.argv,
+    -- which breaks detection when the temp file lives under a path with spaces.
+    os.runv(genicxvars_bat, {})
 
     -- load all envirnoment variables
     local variables = {}

--- a/xmake/modules/detect/sdks/find_ifortenv.lua
+++ b/xmake/modules/detect/sdks/find_ifortenv.lua
@@ -53,7 +53,9 @@ function _load_ifortvars(ifortvars_bat, arch, opt)
     file:close()
 
     -- run genifortvars.bat
-    os.run(genifortvars_bat)
+    -- @note we use runv here so the bat path is not split on whitespace by os.argv,
+    -- which breaks detection when the temp file lives under a path with spaces.
+    os.runv(genifortvars_bat, {})
 
     -- load all envirnoment variables
     local variables = {}

--- a/xmake/modules/detect/sdks/find_ifortenv.lua
+++ b/xmake/modules/detect/sdks/find_ifortenv.lua
@@ -55,7 +55,7 @@ function _load_ifortvars(ifortvars_bat, arch, opt)
     -- run genifortvars.bat
     -- @note we use runv here so the bat path is not split on whitespace by os.argv,
     -- which breaks detection when the temp file lives under a path with spaces.
-    os.runv(genifortvars_bat, {})
+    os.runv(genifortvars_bat)
 
     -- load all envirnoment variables
     local variables = {}

--- a/xmake/modules/detect/sdks/find_ifxenv.lua
+++ b/xmake/modules/detect/sdks/find_ifxenv.lua
@@ -53,7 +53,9 @@ function _load_ifxvars(ifxvars_bat, arch, opt)
     file:close()
 
     -- run genifxvars.bat
-    os.run(genifxvars_bat)
+    -- @note we use runv here so the bat path is not split on whitespace by os.argv,
+    -- which breaks detection when the temp file lives under a path with spaces.
+    os.runv(genifxvars_bat, {})
 
     -- load all envirnoment variables
     local variables = {}

--- a/xmake/modules/detect/sdks/find_ifxenv.lua
+++ b/xmake/modules/detect/sdks/find_ifxenv.lua
@@ -55,7 +55,7 @@ function _load_ifxvars(ifxvars_bat, arch, opt)
     -- run genifxvars.bat
     -- @note we use runv here so the bat path is not split on whitespace by os.argv,
     -- which breaks detection when the temp file lives under a path with spaces.
-    os.runv(genifxvars_bat, {})
+    os.runv(genifxvars_bat)
 
     -- load all envirnoment variables
     local variables = {}

--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -294,7 +294,9 @@ function _load_vcvarsall_impl(vcvarsall, vsver, arch, opt)
     file:close()
 
     -- run genvcvars.bat
-    local outdata, errdata = try {function () return os.iorun(genvcvars_bat) end}
+    -- @note we use iorunv here so the bat path is not split on whitespace by os.argv,
+    -- which breaks detection when the temp file lives under a path with spaces.
+    local outdata, errdata = try {function () return os.iorunv(genvcvars_bat, {}) end}
     if errdata and #errdata > 0 and option.get("verbose") and option.get("diagnosis") then
         cprint("${color.warning}checkinfo: ${clear dim}get vcvars error: %s", errdata)
     end

--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -296,7 +296,7 @@ function _load_vcvarsall_impl(vcvarsall, vsver, arch, opt)
     -- run genvcvars.bat
     -- @note we use iorunv here so the bat path is not split on whitespace by os.argv,
     -- which breaks detection when the temp file lives under a path with spaces.
-    local outdata, errdata = try {function () return os.iorunv(genvcvars_bat, {}) end}
+    local outdata, errdata = try {function () return os.iorunv(genvcvars_bat) end}
     if errdata and #errdata > 0 and option.get("verbose") and option.get("diagnosis") then
         cprint("${color.warning}checkinfo: ${clear dim}get vcvars error: %s", errdata)
     end

--- a/xmake/modules/lib/detect/check_cxsnippets.lua
+++ b/xmake/modules/lib/detect/check_cxsnippets.lua
@@ -259,13 +259,13 @@ function main(snippets, opt)
                 -- whitespace by os.argv. mostly hits on Windows where TEMP lives
                 -- under the user profile and may contain spaces.
                 if opt.output then
-                    local output = os.iorunv(binaryfile, {})
+                    local output = os.iorunv(binaryfile)
                     if output then
                         output = output:trim()
                     end
                     return true, output
                 else
-                    os.vrunv(binaryfile, {})
+                    os.vrunv(binaryfile)
                 end
             end
             local binary_match = opt.binary_match

--- a/xmake/modules/lib/detect/check_cxsnippets.lua
+++ b/xmake/modules/lib/detect/check_cxsnippets.lua
@@ -255,14 +255,17 @@ function main(snippets, opt)
                 linker.link("binary", {"cc", "cxx"}, objectfile, binaryfile, opt)
             end
             if opt.tryrun then
+                -- @note we use the *v variants so the binary path is not split on
+                -- whitespace by os.argv. mostly hits on Windows where TEMP lives
+                -- under the user profile and may contain spaces.
                 if opt.output then
-                    local output = os.iorun(binaryfile)
+                    local output = os.iorunv(binaryfile, {})
                     if output then
                         output = output:trim()
                     end
                     return true, output
                 else
-                    os.vrun(binaryfile)
+                    os.vrunv(binaryfile, {})
                 end
             end
             local binary_match = opt.binary_match

--- a/xmake/modules/lib/detect/check_fcsnippets.lua
+++ b/xmake/modules/lib/detect/check_fcsnippets.lua
@@ -118,13 +118,13 @@ function main(snippets, opt)
                 -- whitespace by os.argv. mostly hits on Windows where TEMP lives
                 -- under the user profile and may contain spaces.
                 if opt.output then
-                    local output = os.iorunv(binaryfile, {})
+                    local output = os.iorunv(binaryfile)
                     if output then
                         output = output:trim()
                     end
                     return true, output
                 else
-                    os.vrunv(binaryfile, {})
+                    os.vrunv(binaryfile)
                 end
             end
             local binary_match = opt.binary_match

--- a/xmake/modules/lib/detect/check_fcsnippets.lua
+++ b/xmake/modules/lib/detect/check_fcsnippets.lua
@@ -114,14 +114,17 @@ function main(snippets, opt)
                 linker.link("binary", linkerkind, objectfile, binaryfile, opt)
             end
             if opt.tryrun then
+                -- @note we use the *v variants so the binary path is not split on
+                -- whitespace by os.argv. mostly hits on Windows where TEMP lives
+                -- under the user profile and may contain spaces.
                 if opt.output then
-                    local output = os.iorun(binaryfile)
+                    local output = os.iorunv(binaryfile, {})
                     if output then
                         output = output:trim()
                     end
                     return true, output
                 else
-                    os.vrun(binaryfile)
+                    os.vrunv(binaryfile, {})
                 end
             end
             local binary_match = opt.binary_match


### PR DESCRIPTION
## Summary

- MSVC, Intel oneAPI (icl/icx/ifort/ifx) and `tryrun` C/C++/Fortran snippet detection fail on Windows when the user profile name contains a space (e.g. `C:\Users\Some Name\...`).
- With `xmake f --toolchain=msvc` (or `--toolchain=clang-cl`) the user gets a "toolchain not found" error; with plain `xmake f` xmake silently falls back to MinGW and prints no warning.
- Fix: at every affected call site, switch from `os.run` / `os.iorun` / `os.vrun` to the corresponding `*v` variant, so the temp file path is no longer parsed by `os.argv`.

## Root cause

The detection scripts in `xmake/modules/detect/sdks/` write a generated `.bat` under `os.tmpfile()` (which on Windows lives under the user profile) and run it via `os.iorun(genvcvars_bat)` or `os.run(...)`. These wrappers parse their `cmd` through `os.argv`, a POSIX-shell-style word splitter (`core/src/xmake/os/argv.c:83`). Without surrounding quotes the path gets shredded:

```
"C:\Users\Some Name\AppData\Local\Temp\.xmake\...\_genvcvars.bat"
    -> ["C:\Users\Some", "Name\AppData\...\_genvcvars.bat"]
```

`CreateProcess` then runs against the directory `C:\Users\Some` and fails with `ERROR_BAD_EXE_FORMAT (193)`. In `find_vstudio` the failure is swallowed by the surrounding `try {}` and turned into an empty `vcvarsall = {}`. The same root cause hits Intel oneAPI detection on Windows (`find_iccenv` / `find_icxenv` / `find_ifortenv` / `find_ifxenv`) and any `tryrun` feature probe in `check_cxsnippets` / `check_fcsnippets` (cross-platform but rarely tripped on POSIX).

## Fix

Switch every site that passes a single bare path to its `*v` variant. xmake's C-side `process._openv` already knows how to launch a `.bat` directly, so no `cmd.exe` wrapping is needed.

```diff
- local outdata, errdata = try {function () return os.iorun(genvcvars_bat) end}
+ local outdata, errdata = try {function () return os.iorunv(genvcvars_bat) end}
```

```diff
- os.run(geniclvars_bat)
+ os.runv(geniclvars_bat)
```

```diff
- local output = os.iorun(binaryfile)
+ local output = os.iorunv(binaryfile)
...
- os.vrun(binaryfile)
+ os.vrunv(binaryfile)
```

A short `@note` comment was added at each site so the choice does not get reverted later.

## Test plan

Verified on Windows 11 with a user profile path containing a space, with VS 2026 Community installed.

`xmake lua detect.sdks.find_vstudio` after the fix:

```json
{
  "2026" = {
    version = "18.0",
    vcvarsall_bat = "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvarsall.bat",
    vcvarsall = {
      arm64   = { VCToolsVersion = "14.50.35717", PATH = "...", LIB = "...", INCLUDE = "...", ... },
      arm64ec = { ... },
      x64     = { ... },
      x86     = { ... },
      arm     = { ... }
    }
  }
}
```

Before the fix `xmake lua detect.sdks.find_vstudio` shows

```
{
  "2026" = {
    version = "18.0",
    vcvarsall_bat = "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvarsall.bat",
    vcvarsall = { }
  }
}
```