### PR TITLE
Fix zig cc stdlib and lto flags

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2426,9 +2426,9 @@ function _instance:_generate_lto_configs(sourcekind)
     if sourcekind then
         local _, cc = self:tool(sourcekind)
         local cflag = sourcekind == "cxx" and "cxxflags" or "cflags"
-        if cc == "cl" then
+        if cc == "cl" or cc == "clang_cl" then
             configs[cflag] = "-GL"
-        elseif cc == "clang" or cc == "clangxx" or cc == "clang_cl" then
+        elseif cc == "clang" or cc == "clangxx" or cc:startswith("zig") then
             configs[cflag] = "-flto=thin"
         elseif cc == "gcc" or cc == "gxx" then
             configs[cflag] = "-flto"
@@ -2440,7 +2440,7 @@ function _instance:_generate_lto_configs(sourcekind)
     if ld == "link" then
         configs.ldflags = "-LTCG"
         configs.shflags = "-LTCG"
-    elseif ld == "clang" or ld == "clangxx" then
+    elseif ld == "clang" or ld == "clangxx" or ld:startswith("zig") then
         configs.ldflags = "-flto=thin"
         configs.shflags = "-flto=thin"
     elseif ld == "gcc" or ld == "gxx" then

--- a/xmake/modules/core/tools/zig_cc.lua
+++ b/xmake/modules/core/tools/zig_cc.lua
@@ -30,3 +30,8 @@ function nf_strip(self, level)
     return maps[level]
 end
 
+-- make the runtime flag
+function nf_runtime(self, runtime, opt)
+    -- zig cc does not take -stdlib flag, it links the bundled libc++ statically
+    return
+end

--- a/xmake/rules/c++/config/optimization.lua
+++ b/xmake/rules/c++/config/optimization.lua
@@ -33,20 +33,20 @@ function _add_lto_optimization(target, sourcekind)
         mxx = "mxxflags"
     }
     local cflag = flagnames[sourcekind] or (sourcekind == "cxx" and "cxxflags" or "cflags")
-    if cc == "cl" then
+    if cc == "cl" or cc == "clang_cl" then
         target:add(cflag, "-GL")
-    elseif cc == "clang" or cc == "clangxx" or cc == "clang_cl" then
+    elseif cc == "clang" or cc == "clangxx" or cc:startswith("zig") then
         target:add(cflag, "-flto=thin")
     elseif cc == "gcc" or cc == "gxx" then
         target:add(cflag, "-flto")
     end
 
     -- add ldflags and shflags
-    local program, ld = target:tool("ld")
+    local _, ld = target:tool("ld")
     if ld == "link" then
         target:add("ldflags", "-LTCG")
         target:add("shflags", "-LTCG")
-    elseif ld == "clang" or ld == "clangxx" then
+    elseif ld == "clang" or ld == "clangxx" or ld:startswith("zig") then
         target:add("ldflags", "-flto=thin")
         target:add("shflags", "-flto=thin")
 
@@ -88,7 +88,7 @@ function _add_lto_optimization(target, sourcekind)
         end
     end
 
-    local program, ar = target:tool("ar")
+    local _, ar = target:tool("ar")
     if cc == "clang_cl" then
         if ld == "link" then
             wprint([[Unsupported toolset(%s) for lto, please use `set_toolset("ld", "lld-link")`]], ld)
@@ -109,4 +109,3 @@ function main(target, sourcekind)
         _add_lto_optimization(target, sourcekind)
     end
 end
-

--- a/xmake/toolchains/zigcc/xmake.lua
+++ b/xmake/toolchains/zigcc/xmake.lua
@@ -23,6 +23,7 @@ toolchain("zigcc")
     set_kind("standalone")
     set_homepage("https://ziglang.org/")
     set_description("Use zig cc/c++ as C/C++ Compiler")
+    set_runtimes("c++_static")
 
     on_check(function (toolchain)
         import("lib.detect.find_tool")


### PR DESCRIPTION
This PR addresses the following issues within the `zigcc` toolchain,

- Fix warnings on `-stdlib=` flags. zig cc does not take this flag, it always uses the bundled libc++.
- Support `build.optimization.lto` policy, expands the check to include zig cc.