### PR TITLE
Move clang pch to its own module

### DIFF
--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -292,3 +292,39 @@ function nf_runtime(self, runtime, opt)
     end
     return maps and maps[runtime]
 end
+
+-- make the c precompiled header flag
+function nf_pcheader(self, pcheaderfile, opt)
+    if self:kind() == "cc" then
+        local target = opt.target
+        local pcoutputfile = target:pcoutputfile("c")
+        return {"-include", pcheaderfile, "-include-pch", pcoutputfile}
+    end
+end
+
+-- make the c++ precompiled header flag
+function nf_pcxxheader(self, pcheaderfile, opt)
+    if self:kind() == "cxx" then
+        local target = opt.target
+        local pcoutputfile = target:pcoutputfile("cxx")
+        return {"-include", pcheaderfile, "-include-pch", pcoutputfile}
+    end
+end
+
+-- make the objc precompiled header flag
+function nf_pmheader(self, pcheaderfile, opt)
+    if self:kind() == "mm" then
+        local target = opt.target
+        local pcoutputfile = target:pcoutputfile("m")
+        return {"-include", pcheaderfile, "-include-pch", pcoutputfile}
+    end
+end
+
+-- make the objc++ precompiled header flag
+function nf_pmxxheader(self, pcheaderfile, opt)
+    if self:kind() == "mxx" then
+        local target = opt.target
+        local pcoutputfile = target:pcoutputfile("mxx")
+        return {"-include", pcheaderfile, "-include-pch", pcoutputfile}
+    end
+end

--- a/xmake/modules/core/tools/gcc.lua
+++ b/xmake/modules/core/tools/gcc.lua
@@ -848,11 +848,7 @@ function nf_pcheader(self, pcheaderfile, opt)
     if self:kind() == "cc" then
         local target = opt.target
         local pcoutputfile = target:pcoutputfile("c")
-        if self:name():startswith("clang") then
-            return {"-include", pcheaderfile, "-include-pch", pcoutputfile}
-        else
-            return {"-I", path.directory(pcoutputfile), "-include", path.filename(pcheaderfile)}
-        end
+        return {"-I", path.directory(pcoutputfile), "-include", path.filename(pcheaderfile)}
     end
 end
 
@@ -861,11 +857,7 @@ function nf_pcxxheader(self, pcheaderfile, opt)
     if self:kind() == "cxx" then
         local target = opt.target
         local pcoutputfile = target:pcoutputfile("cxx")
-        if self:name():startswith("clang") then
-            return {"-include", pcheaderfile, "-include-pch", pcoutputfile}
-        else
-            return {"-I", path.directory(pcoutputfile), "-include", path.filename(pcheaderfile)}
-        end
+        return {"-I", path.directory(pcoutputfile), "-include", path.filename(pcheaderfile)}
     end
 end
 
@@ -874,11 +866,7 @@ function nf_pmheader(self, pcheaderfile, opt)
     if self:kind() == "mm" then
         local target = opt.target
         local pcoutputfile = target:pcoutputfile("m")
-        if self:name():startswith("clang") then
-            return {"-include", pcheaderfile, "-include-pch", pcoutputfile}
-        else
-            return {"-I", path.directory(pcoutputfile), "-include", path.filename(pcheaderfile)}
-        end
+        return {"-I", path.directory(pcoutputfile), "-include", path.filename(pcheaderfile)}
     end
 end
 
@@ -887,11 +875,7 @@ function nf_pmxxheader(self, pcheaderfile, opt)
     if self:kind() == "mxx" then
         local target = opt.target
         local pcoutputfile = target:pcoutputfile("mxx")
-        if self:name():startswith("clang") then
-            return {"-include", pcheaderfile, "-include-pch", pcoutputfile}
-        else
-            return {"-I", path.directory(pcoutputfile), "-include", path.filename(pcheaderfile)}
-        end
+        return {"-I", path.directory(pcoutputfile), "-include", path.filename(pcheaderfile)}
     end
 end
 


### PR DESCRIPTION
This PR refactors clang pch related logic to its own module instead of hardcoded in gcc. This fixes pch support for tools that inherit from clang like zig cc.