### PR TITLE
fix(find_mingw): Support paths like 'mingw/current/bin' and 'mingw/ve…

### DIFF
--- a/xmake/modules/detect/sdks/find_mingw.lua
+++ b/xmake/modules/detect/sdks/find_mingw.lua
@@ -53,7 +53,7 @@ function _find_mingwdir(sdkdir, msystem)
                 local buildhash_pattern = string.rep('%x', 32)
                 local match_pattern = "[\\/]packages[\\/]%w[\\/].*mingw.*[\\/][^\\/]+[\\/]" .. buildhash_pattern .. "[\\/]bin"
                 for _, p in ipairs(path.splitenv(pathenv)) do
-                    if (p:find(match_pattern) or p:find(string.ipattern("mingw[%w%-%_%+]*[\\/]bin"))) and
+                    if (p:find(match_pattern) or p:find(string.ipattern("mingw[\\/]?[%w%-%_%+]*[\\/]bin"))) and
                         path.filename(p) == "bin" and os.isdir(p) then
                         sdkdir = path.directory(p)
                         break


### PR DESCRIPTION
## Summary
Fix mingw detection to support installation paths with intermediate directories, such as Scoop package manager.

## Problem
When MinGW is installed via Scoop, xmake fails to automatically detect the toolchain.
The detection logic uses a regex pattern `mingw[%w%-%_%+]*[\\/]bin` which only matches direct subdirectories like `mingw64/bin`. It cannot recognize paths with intermediate directories like `mingw/current/bin` or `mingw/version-x/bin`.
For example, Scoop installs to:
`.../apps/mingw/current/bin` or `.../apps/mingw/x86_64-w64-mingw32/bin`

## Solution
Modify the regex pattern in `xmake/modules/detect/sdks/find_mingw.lua` to allow one optional intermediate directory level:

`mingw%w%-%_%+*\\/bin` ==> `mingw[\\/]?[%w%-%_%+]*[\\/]bin`

