### PR TITLE
feat: include packages in "build.merge_archive"

### DIFF
--- a/xmake/modules/private/utils/target.lua
+++ b/xmake/modules/private/utils/target.lua
@@ -289,3 +289,14 @@ function get_target_libfiles(target, libfiles, binaryfile, refs, opt)
     end
 end
 
+-- get values from target
+function get_values_from_target(target, name)
+    local values = table.clone(table.wrap(target:get(tostring(name))))
+    for _, value in ipairs((target:get_from(name, "option::*"))) do
+        table.join2(values, value)
+    end
+    for _, value in ipairs((target:get_from(name, "package::*"))) do
+        table.join2(values, value)
+    end
+    return values
+end

--- a/xmake/rules/utils/inherit_links/inherit_links.lua
+++ b/xmake/rules/utils/inherit_links/inherit_links.lua
@@ -18,17 +18,7 @@
 -- @file        inherit_links.lua
 --
 
--- get values from target
-function _get_values_from_target(target, name)
-    local values = table.clone(table.wrap(target:get(name)))
-    for _, value in ipairs((target:get_from(name, "option::*"))) do
-        table.join2(values, value)
-    end
-    for _, value in ipairs((target:get_from(name, "package::*"))) do
-        table.join2(values, value)
-    end
-    return values
-end
+import("private.utils.target", {alias = "target_utils"})
 
 -- @note we cannot directly set `{interface = true}`, because it will overwrite the previous configuration
 -- https://github.com/xmake-io/xmake/issues/1465
@@ -108,8 +98,17 @@ function main(target)
     --
     if target:data("inherit.links.exportlinks") ~= false then
         if target:is_static() or target:is_object() then
-            for _, name in ipairs({"rpathdirs", "frameworkdirs", "frameworks", "linkdirs", "links", "syslinks", "ldflags", "shflags"}) do
-                local values = _get_values_from_target(target, name)
+            local export_values = {"rpathdirs", "frameworkdirs", "frameworks", "syslinks", "shflags"};
+
+            if target:data("inherit.links.export_static") ~= false then
+                local link_settings = {"linkdirs", "links", "ldflags"}
+                for _, link_setting in ipairs(link_settings) do
+                    table.insert(export_values, link_setting)
+                end
+            end
+
+            for _, name in ipairs(export_values) do
+                local values = target_utils.get_values_from_target(target, name)
                 if values and #values > 0 then
                     _add_export_values(target, name, values)
                 end

--- a/xmake/rules/utils/merge_archive/xmake.lua
+++ b/xmake/rules/utils/merge_archive/xmake.lua
@@ -26,6 +26,8 @@ rule("utils.merge.archive")
         --
         -- @see https://github.com/xmake-io/xmake/issues/3404
         if target:policy("build.merge_archive") then
+            target:data_set("inherit.links.export_static", false)
+
             for _, dep in ipairs(target:orderdeps()) do
                 if dep:is_static() then
                     dep:data_set("inherit.links.deplink", false)
@@ -43,14 +45,28 @@ rule("utils.merge.archive")
     end)
 
     after_link(function (target, opt)
+        -- Returns full path of a given link archive, if found.
+        local function _resolve_link(linkdirs, link)
+            -- HELP: assume that 'linkpath' does not exists in multiple directories?
+            for _, linkdir in ipairs(linkdirs) do
+                local file_extension = target:is_plat("windows") and ".lib" or ".a"
+                local link_path = path.join(linkdir, "lib" .. link .. file_extension)
+                if os.exists(link_path) then
+                    return link_path
+                end
+            end
+        end
+
         if not target:is_static() then
             return
         end
         local sourcefiles = target:data("merge_archive.sourcefiles")
         if target:policy("build.merge_archive") or sourcefiles then
+            import("private.utils.target", {alias = "target_utils"})
             import("utils.archive.merge_staticlib")
             import("core.project.depend")
             import("utils.progress")
+
             local libraryfiles = {}
             if sourcefiles then
                 table.join2(libraryfiles, sourcefiles)
@@ -58,6 +74,15 @@ rule("utils.merge.archive")
                 for _, dep in ipairs(target:orderdeps()) do
                     if dep:is_static() then
                         table.insert(libraryfiles, dep:targetfile())
+                    end
+                end
+
+                -- TODO: what about syslinkdirs and syslinks?
+                local linkdirs = target_utils.get_values_from_target(target, "linkdirs")
+                for _, link in ipairs(target_utils.get_values_from_target(target, "links")) do
+                    local link_path = _resolve_link(linkdirs, link)
+                    if link_path then
+                        table.insert(libraryfiles, link_path)
                     end
                 end
             end


### PR DESCRIPTION
Fixes #7531 

POC that has some unanswered question left, hence the draft. Among them are:

- Make it a separate policy? (Sorry, I didn't see your suggestion in the issue discussion until now.) 
- Keep previous behavior and only make merging packages opt-in?
- Leave out syslinks and sysdirs? 
- Adding tests.
  - Asserts that packaged links are present in `ar -t`
  - Asserts that the respective links aren't inherited.
  - Inverse applied when policy is disabled.