### PR TITLE
feat: support building multiple targets

### DIFF
--- a/xmake/actions/build/main.lua
+++ b/xmake/actions/build/main.lua
@@ -61,7 +61,10 @@ function _try_build()
     -- rebuild it? do clean first
     local targetname = option.get("target")
     if option.get("rebuild") then
-        task.run("clean", {target = targetname})
+        -- the third-party buildsystem path does not support multiple targets,
+        -- so just clean the first given target (if any)
+        local cleanname = table.wrap(targetname)[1]
+        task.run("clean", {target = cleanname})
     end
 
     -- get the buildsystem tool
@@ -201,7 +204,9 @@ function main(opt)
 
     -- check target name
     if targetname then
-        assert(check_targetname(targetname))
+        for _, name in ipairs(table.wrap(targetname)) do
+            assert(check_targetname(name))
+        end
     end
 
     -- enter project directory

--- a/xmake/actions/build/xmake.lua
+++ b/xmake/actions/build/xmake.lua
@@ -53,7 +53,10 @@ task("build")
                                                       "    - xmake --files='src/main.c" .. path.envsep() .. "src/test.c'"  }
 
                 ,   {}
-                ,   {nil, "target",     "v",  nil   , "The target name. It will build all default targets if this parameter is not specified."
+                ,   {nil, "target",     "vs", nil   , "The target name(s). It will build all default targets if this parameter is not specified.",
+                                                      "e.g.",
+                                                      "    xmake build target1",
+                                                      "    xmake build target1 target2"
                                                     , values = function (complete, opt) return import("private.utils.complete_helper.targets")(complete, opt) end }
                 }
             }


### PR DESCRIPTION
Allow `xmake build target1 target2 ...` to build several named targets in a single invocation. Previously the `target` argument only accepted a single value.

The build pipeline already iterated target-name lists internally (get_root_targets and the post-build check both use table.wrap), so the only blockers were the CLI option declaration and a single-name validation call:

- build/xmake.lua: change the `target` argument from "v" (single value) to "vs" (value list), and add usage examples to --help.
- build/main.lua: validate each given name via check_targetname instead of assuming a single string.
- build/main.lua: in the no-xmake.lua third-party (_try_build) path, clean only the first given target, since that path has no concept of multiple xmake targets and trybuild never reads the target name anyway.

Single-target builds, the default (no-arg) build, --rebuild, --shallow, --group and --files all keep their existing behavior; programmatic callers that pass a single string (e.g. `xmake run` -> task.run("build", {target=...})) are unaffected because everything downstream normalizes via table.wrap.

* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

