### PR TITLE
Fix LTO regression for clang-cl introduced in #7525

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2426,9 +2426,9 @@ function _instance:_generate_lto_configs(sourcekind)
     if sourcekind then
         local _, cc = self:tool(sourcekind)
         local cflag = sourcekind == "cxx" and "cxxflags" or "cflags"
-        if cc == "cl" or cc == "clang_cl" then
+        if cc == "cl" then
             configs[cflag] = "-GL"
-        elseif cc == "clang" or cc == "clangxx" or cc:startswith("zig") then
+        elseif cc == "clang" or cc == "clangxx" or cc == "clang_cl" or cc:startswith("zig") then
             configs[cflag] = "-flto=thin"
         elseif cc == "gcc" or cc == "gxx" then
             configs[cflag] = "-flto"

--- a/xmake/rules/c++/config/optimization.lua
+++ b/xmake/rules/c++/config/optimization.lua
@@ -33,9 +33,9 @@ function _add_lto_optimization(target, sourcekind)
         mxx = "mxxflags"
     }
     local cflag = flagnames[sourcekind] or (sourcekind == "cxx" and "cxxflags" or "cflags")
-    if cc == "cl" or cc == "clang_cl" then
+    if cc == "cl" then
         target:add(cflag, "-GL")
-    elseif cc == "clang" or cc == "clangxx" or cc:startswith("zig") then
+    elseif cc == "clang" or cc == "clangxx" or cc == "clang_cl" or cc:startswith("zig") then
         target:add(cflag, "-flto=thin")
     elseif cc == "gcc" or cc == "gxx" then
         target:add(cflag, "-flto")


### PR DESCRIPTION
## Summary

PR #7525 ("Fix zig cc stdlib and lto flags") accidentally regrouped `clang_cl` into the MSVC `cl` branch of the LTO logic, switching its compile flag from `-flto=thin` to `-GL`. This PR moves `clang_cl` back into the Clang/LLVM branch, restoring the behavior established in `d4b5d636` (Feb 2025).

## The regression

In both `xmake/core/package/package.lua` and `xmake/rules/c++/config/optimization.lua`, #7525 changed:

```lua
-- before #7525 (correct)
if cc == "cl" then
    -- -GL
elseif cc == "clang" or cc == "clangxx" or cc == "clang_cl" then
    -- -flto=thin

-- after #7525 (broken)
if cc == "cl" or cc == "clang_cl" then
    -- -GL
elseif cc == "clang" or cc == "clangxx" or cc:startswith("zig") then
    -- -flto=thin
```

The zig-cc additions from #7525 are correct and untouched here. Only the misplacement of `clang_cl` is reverted.

## Why `-GL` is wrong for clang-cl

clang-cl is the MSVC-compatible driver of Clang/LLVM, not MSVC. It does **not** honor MSVC's `/GL` semantically — verified directly against the LLVM source (see references below):

1. In `Options.td`, `_SLASH_GL` is defined as a bare `CLFlag<"GL">` with **no `Alias<flto_EQ>`** and no other mapping.
2. `_SLASH_GL` has **zero references** anywhere in `clang/lib/` — no driver or frontend code ever calls `Args.hasArg(OPT__SLASH_GL)` or `getLastArg(OPT__SLASH_GL)`.
3. The official driver test `cl-options.c` explicitly classifies `/GL` under `// Unsupported but parsed options. Check that we don't error on them.` — clang-cl parses it without rejecting, but performs no semantic action.
4. `Driver::setLTOMode` only inspects `OPT_flto_EQ` / `OPT_fno_lto`. `isUsingLTO()` is never set by `/GL`.

Net effect after #7525, when building with clang-cl + `build.optimization.lto`:

- LTO is **not** enabled (no LLVM bitcode emitted; `-LTCG` at link time has nothing to consume).
- Because the arg is never claimed, clang's driver emits a `warn_drv_unused_argument` diagnostic. With `-Werror` or `-Werror=unused-command-line-argument` — a common configuration in CI builds — the compilation hard-fails with:
  ```
  clang-cl: error: argument unused during compilation: '-GL' [-Werror,-Wunused-command-line-argument]
  ```

`-flto=thin` is the canonical Clang/LLVM ThinLTO flag and is accepted by clang-cl directly (no `/clang:` passthrough needed). The downstream `clang_cl + lld-link + llvm-ar` enforcement in `optimization.lua` is already built around the LLVM toolchain link path, so restoring `-flto=thin` keeps the whole pipeline consistent.

## References

LLVM source:

- [`clang/include/clang/Options/Options.td`](https://github.com/llvm/llvm-project/blob/main/clang/include/clang/Options/Options.td) — `_SLASH_GL` definition (bare `CLFlag`, no alias)
- [`clang/test/Driver/cl-options.c`](https://github.com/llvm/llvm-project/blob/main/clang/test/Driver/cl-options.c) — `/GL` listed under "Unsupported but parsed options"
- [`clang/lib/Driver/Driver.cpp`](https://github.com/llvm/llvm-project/blob/main/clang/lib/Driver/Driver.cpp) — `setLTOMode` only reads `OPT_flto_EQ` / `OPT_fno_lto`; unclaimed args emit `warn_drv_unused_argument`

xmake history:

- Initial clang-cl LTO support: `d4b5d636` (Feb 2025) — established `clang_cl` → `-flto=thin`
- Regression: #7525 / `bbcf7a801` (May 2026)
