### PR TITLE
fix vcpkg find_package in manifest mode

### DIFF
--- a/xmake/modules/package/manager/vcpkg/find_package.lua
+++ b/xmake/modules/package/manager/vcpkg/find_package.lua
@@ -213,20 +213,19 @@ function _find_package(vcpkg, vcpkgdir, name, opt)
         depend_name = name .. "[" .. table.concat(required_features, ",") .. "]"
     end
     local result = nil
-    -- pre https://github.com/microsoft/vcpkg-tool/pull/1909
-    local argv_old = {"depend-info", depend_name, "--sort=reverse", "--triplet=" .. triplet}
-    -- post https://github.com/microsoft/vcpkg-tool/pull/1909
-    local argv_new = {"depend-info", "--sort=reverse", "--triplet=" .. triplet}
+    local argv = {"depend-info", depend_name, "--sort=reverse", "--triplet=" .. triplet}
 
     -- pass feature flags to depend-info when in manifest mode, otherwise depend-info will not show the complete dependency tree with features
     if manifest_mode then
-        table.insert(argv_old, 1, "--feature-flags=versions")
-        table.insert(argv_new, 1, "--feature-flags=versions")
+        table.insert(argv, 1, "--feature-flags=versions")
     end
 
-    local _, dependinfo = try { function () return os.iorunv(vcpkg, argv_old, manifest_mode and {curdir = opt.installdir} or nil) end }
+    local _, dependinfo = try { function () return os.iorunv(vcpkg, argv, manifest_mode and {curdir = opt.installdir} or nil) end }
     if manifest_mode and not dependinfo then
-        _, dependinfo = try { function () return os.iorunv(vcpkg, argv_new, manifest_mode and {curdir = opt.installdir} or nil) end }
+        -- fallback: newer vcpkg-tool no longer accepts the package name as a positional argument,
+        -- drop it and retry. see https://github.com/microsoft/vcpkg-tool/pull/1909
+        table.remove(argv, 3)
+        _, dependinfo = try { function () return os.iorunv(vcpkg, argv, {curdir = opt.installdir}) end }
     end
     if dependinfo then
         for _, line in ipairs(dependinfo:split("\n", {plain = true})) do

--- a/xmake/modules/package/manager/vcpkg/find_package.lua
+++ b/xmake/modules/package/manager/vcpkg/find_package.lua
@@ -225,7 +225,7 @@ function _find_package(vcpkg, vcpkgdir, name, opt)
     end
 
     local _, dependinfo = try { function () return os.iorunv(vcpkg, argv_old, manifest_mode and {curdir = opt.installdir} or nil) end }
-    if not dependinfo then
+    if manifest_mode and not dependinfo then
         _, dependinfo = try { function () return os.iorunv(vcpkg, argv_new, manifest_mode and {curdir = opt.installdir} or nil) end }
     end
     if dependinfo then

--- a/xmake/modules/package/manager/vcpkg/find_package.lua
+++ b/xmake/modules/package/manager/vcpkg/find_package.lua
@@ -213,14 +213,21 @@ function _find_package(vcpkg, vcpkgdir, name, opt)
         depend_name = name .. "[" .. table.concat(required_features, ",") .. "]"
     end
     local result = nil
-    local argv = {"depend-info", depend_name, "--sort=reverse", "--triplet=" .. triplet}
+    -- pre https://github.com/microsoft/vcpkg-tool/pull/1909
+    local argv_old = {"depend-info", depend_name, "--sort=reverse", "--triplet=" .. triplet}
+    -- post https://github.com/microsoft/vcpkg-tool/pull/1909
+    local argv_new = {"depend-info", "--sort=reverse", "--triplet=" .. triplet}
 
     -- pass feature flags to depend-info when in manifest mode, otherwise depend-info will not show the complete dependency tree with features
     if manifest_mode then
-        table.insert(argv, 1, "--feature-flags=versions")
+        table.insert(argv_old, 1, "--feature-flags=versions")
+        table.insert(argv_new, 1, "--feature-flags=versions")
     end
 
-    local _, dependinfo = try { function () return os.iorunv(vcpkg, argv, manifest_mode and {curdir = opt.installdir} or nil) end }
+    local _, dependinfo = try { function () return os.iorunv(vcpkg, argv_old, manifest_mode and {curdir = opt.installdir} or nil) end }
+    if not dependinfo then
+        _, dependinfo = try { function () return os.iorunv(vcpkg, argv_new, manifest_mode and {curdir = opt.installdir} or nil) end }
+    end
     if dependinfo then
         for _, line in ipairs(dependinfo:split("\n", {plain = true})) do
             if not line:startswith("vcpkg-") then


### PR DESCRIPTION
Fixes https://github.com/xmake-io/xmake/issues/7553
To test:
* Create two projects, add vcpkg as submodule, one project should have vcpkg checked out to `c3867e714dd3a51c272826eea77267876517ed99` (_pre_ [2026-04-08](https://github.com/microsoft/vcpkg-tool/releases/tag/2026-04-08), https://github.com/microsoft/vcpkg-tool/pull/1909) and another to master (_post_ [2026-04-08](https://github.com/microsoft/vcpkg-tool/releases/tag/2026-04-08), https://github.com/microsoft/vcpkg-tool/pull/1909)
* Use these `xmake.lua`s:
```
add_requires("vcpkg::zlib", {configs = {baseline = "c3867e714dd3a51c272826eea77267876517ed99"}})
target("test_vcpkg_old")
    set_kind("binary")
    add_files("src/*.cpp")
    add_packages("vcpkg::zlib")
```
```
add_requires("vcpkg::zlib", {configs = {baseline = "d015e31e90838a4c9dfa3eed45979bc70d9357fc"}})
target("test_vcpkg_new")
    set_kind("binary")
    add_files("src/*.cpp")
    add_packages("vcpkg::zlib")
```
With this fix, both projects should fetch zlib properly