### PR TITLE
Add custom module resolvers for import()

### DIFF
--- a/tests/apis/add_moduleresolver/test.lua
+++ b/tests/apis/add_moduleresolver/test.lua
@@ -5,5 +5,6 @@ function main(test)
     -- running executable directly instead.
     local xmake = os.programfile()
 
-    os.execv(xmake, {"f", "-c", "-D", "-y"})
+    local ok = os.execv(xmake, {"f", "-c", "-D", "-y"})
+    assert(ok == 0, "xmake config failed")
 end

--- a/tests/apis/add_moduleresolver/test.lua
+++ b/tests/apis/add_moduleresolver/test.lua
@@ -1,0 +1,9 @@
+function main(test)
+    -- The generic test:build() helper shells out to `xmake` by name. That fails
+    -- when testing from a local build tree where xmake is available as the
+    -- current program but is not installed system-wide. Invoke the currently
+    -- running executable directly instead.
+    local xmake = os.programfile()
+
+    os.execv(xmake, {"f", "-c", "-D", "-y"})
+end

--- a/tests/apis/add_moduleresolver/xmake.lua
+++ b/tests/apis/add_moduleresolver/xmake.lua
@@ -1,0 +1,48 @@
+-- This test covers the public project API:
+--
+--   add_moduleresolver(...)
+--
+-- The lower-level add_resolver test exercises the resolver engine directly.
+-- This file intentionally registers resolvers through the public project API so
+-- we know normal xmake.lua authors can use the feature without importing
+-- internal modules.
+
+local generatedir = path.join(os.tmpdir(), "xmake-test-add-moduleresolver")
+local modulefile = path.join(generatedir, "generated", "hello.lua")
+
+
+add_moduleresolver(function (name, ctx)
+    if name == "generated.public_api" then
+        return ctx.file(modulefile)
+    end
+
+    if name == "virtual.public_api" then
+        return ctx.module({
+            hello = function ()
+                return "hello from public api module"
+            end
+        })
+    end
+
+    return ctx.miss()
+end)
+
+target("test")
+    set_kind("phony")
+
+    on_load(function ()
+        os.tryrm(generatedir)
+        os.mkdir(path.directory(modulefile))
+
+        io.writefile(modulefile, [[
+function hello()
+    return "hello from generated public api file"
+end
+]])
+
+        local generated = import("generated.public_api", {anonymous = true})
+        assert(generated.hello() == "hello from generated public api file")
+
+        local virtual = import("virtual.public_api", {anonymous = true})
+        assert(virtual.hello() == "hello from public api module")
+    end)

--- a/tests/apis/add_resolver/test.lua
+++ b/tests/apis/add_resolver/test.lua
@@ -1,0 +1,365 @@
+function _import_sandbox_module()
+    -- Pull in the sandbox module helpers used by these tests.
+    import("core.sandbox.module", {
+        alias = "sandbox_module",
+        rootdir = path.join(os.programdir(), "core", "sandbox", "modules", "import")
+    })
+    return sandbox_module
+end
+
+function _clear_resolvers()
+    -- Reset resolver state between tests.
+    local sandbox_module = _import_sandbox_module()
+    sandbox_module.clear_resolvers()
+end
+
+function _assert_equal(actual, expected)
+    -- Slightly nicer assert output when values do not match.
+    assert(actual == expected, string.format("expected %s, got %s", tostring(expected), tostring(actual)))
+end
+
+function _test_module_result()
+    -- Resolver returns a module table directly.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "virtual.hello" then
+            return ctx.module({
+                hello = function ()
+                    return "hello from resolver"
+                end
+            })
+        end
+        return ctx.miss()
+    end)
+
+    local mod = import("virtual.hello", {anonymous = true})
+    _assert_equal(mod.hello(), "hello from resolver")
+
+    sandbox_module.clear_resolvers()
+end
+
+function _test_file_result()
+    -- Resolver returns a generated Lua file.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    local moduledir = path.join(os.tmpdir(), "xmake-test-add-resolver-file")
+    local modulefile = path.join(moduledir, "generated", "hello.lua")
+
+    os.tryrm(moduledir)
+    os.mkdir(path.directory(modulefile))
+
+    io.writefile(modulefile, [[
+function hello()
+    return "hello from generated file"
+end
+]])
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "generated.hello" then
+            return ctx.file(modulefile)
+        end
+        return ctx.miss()
+    end)
+
+    local mod = import("generated.hello", {anonymous = true})
+    _assert_equal(mod.hello(), "hello from generated file")
+
+    sandbox_module.clear_resolvers()
+    os.tryrm(moduledir)
+end
+
+function _test_string_result_is_file_result()
+    -- Raw string paths should behave the same as ctx.file().
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    local moduledir = path.join(os.tmpdir(), "xmake-test-add-resolver-string")
+    local modulefile = path.join(moduledir, "generated", "string_hello.lua")
+
+    os.tryrm(moduledir)
+    os.mkdir(path.directory(modulefile))
+
+    io.writefile(modulefile, [[
+function hello()
+    return "hello from string file"
+end
+]])
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "generated.string_hello" then
+            return modulefile
+        end
+        return ctx.miss()
+    end)
+
+    local mod = import("generated.string_hello", {anonymous = true})
+    _assert_equal(mod.hello(), "hello from string file")
+
+    sandbox_module.clear_resolvers()
+    os.tryrm(moduledir)
+end
+
+function _test_raw_table_result_is_module_result()
+    -- Plain tables should be treated as module results.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "virtual.raw_table" then
+            return {
+                value = function ()
+                    return 42
+                end
+            }
+        end
+        return ctx.miss()
+    end)
+
+    local mod = import("virtual.raw_table", {anonymous = true})
+    _assert_equal(mod.value(), 42)
+
+    sandbox_module.clear_resolvers()
+end
+
+function _test_miss_falls_through_to_later_resolver()
+    -- ctx.miss() should fall through to the next resolver.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    sandbox_module.add_resolver(function (name, ctx)
+        return ctx.miss()
+    end)
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "virtual.fallback" then
+            return ctx.module({
+                value = function ()
+                    return "fallback"
+                end
+            })
+        end
+        return ctx.miss()
+    end)
+
+    local mod = import("virtual.fallback", {anonymous = true})
+    _assert_equal(mod.value(), "fallback")
+
+    sandbox_module.clear_resolvers()
+end
+
+function _test_nil_falls_through_to_later_resolver()
+    -- nil should behave the same as ctx.miss().
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    sandbox_module.add_resolver(function (name, ctx)
+        return nil
+    end)
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "virtual.nil_fallback" then
+            return ctx.module({
+                value = function ()
+                    return "nil fallback"
+                end
+            })
+        end
+        return ctx.miss()
+    end)
+
+    local mod = import("virtual.nil_fallback", {anonymous = true})
+    _assert_equal(mod.value(), "nil fallback")
+
+    sandbox_module.clear_resolvers()
+end
+
+function _test_cache_reuses_module_result()
+    -- Resolver-backed modules should still use the normal cache.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    local calls = 0
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "virtual.cached" then
+            calls = calls + 1
+            return ctx.module({
+                calls = function ()
+                    return calls
+                end
+            })
+        end
+        return ctx.miss()
+    end)
+
+    local first = import("virtual.cached", {anonymous = true})
+    local second = import("virtual.cached", {anonymous = true})
+
+    assert(first == second)
+    _assert_equal(first.calls(), 1)
+    _assert_equal(second.calls(), 1)
+    _assert_equal(calls, 1)
+
+    sandbox_module.clear_resolvers()
+end
+
+function _test_nocache_reruns_resolver()
+    -- nocache should force the resolver to run every time.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    local calls = 0
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "virtual.nocache" then
+            calls = calls + 1
+            return ctx.module({
+                calls = function ()
+                    return calls
+                end
+            })
+        end
+        return ctx.miss()
+    end)
+
+    local first = import("virtual.nocache", {anonymous = true, nocache = true})
+    local second = import("virtual.nocache", {anonymous = true, nocache = true})
+
+    assert(first ~= second)
+    _assert_equal(first.calls(), 2)
+    _assert_equal(second.calls(), 2)
+    _assert_equal(calls, 2)
+
+    sandbox_module.clear_resolvers()
+end
+
+function _test_file_result_is_cached_by_logical_name()
+    -- File-backed modules should cache by logical module name.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    local moduledir = path.join(os.tmpdir(), "xmake-test-add-resolver-file-cache")
+    local modulefile = path.join(moduledir, "generated", "cached_file.lua")
+    local calls = 0
+
+    os.tryrm(moduledir)
+    os.mkdir(path.directory(modulefile))
+
+    io.writefile(modulefile, [[
+function value()
+    return "cached file"
+end
+]])
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "generated.cached_file" then
+            calls = calls + 1
+            return ctx.file(modulefile)
+        end
+        return ctx.miss()
+    end)
+
+    local first = import("generated.cached_file", {anonymous = true})
+    local second = import("generated.cached_file", {anonymous = true})
+
+    assert(first == second)
+    _assert_equal(first.value(), "cached file")
+    _assert_equal(second.value(), "cached file")
+    _assert_equal(calls, 1)
+
+    sandbox_module.clear_resolvers()
+    os.tryrm(moduledir)
+end
+
+function _test_normal_module_precedence()
+    -- Normal modules should win over resolver-backed ones.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    local moduledir = path.join(os.tmpdir(), "xmake-test-add-resolver-precedence")
+    local modulefile = path.join(moduledir, "real", "hello.lua")
+
+    os.tryrm(moduledir)
+    os.mkdir(path.directory(modulefile))
+
+    io.writefile(modulefile, [[
+function hello()
+    return "hello from normal module"
+end
+]])
+
+    sandbox_module.add_directories(moduledir)
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "real.hello" then
+            return ctx.module({
+                hello = function ()
+                    return "hello from resolver"
+                end
+            })
+        end
+        return ctx.miss()
+    end)
+
+    local mod = import("real.hello", {anonymous = true})
+    _assert_equal(mod.hello(), "hello from normal module")
+
+    sandbox_module.clear_resolvers()
+    os.tryrm(moduledir)
+end
+
+function _test_module_tables_can_use_kind_field()
+    -- A normal "kind" field should not get treated specially.
+    local sandbox_module = _import_sandbox_module()
+
+    sandbox_module.clear_resolvers()
+
+    sandbox_module.add_resolver(function (name, ctx)
+        if name == "virtual.kind_field" then
+            return {
+                kind = "example",
+                value = function ()
+                    return "kind field preserved"
+                end
+            }
+        end
+        return ctx.miss()
+    end)
+
+    local mod = import("virtual.kind_field", {anonymous = true})
+
+    _assert_equal(mod.kind, "example")
+    _assert_equal(mod.value(), "kind field preserved")
+
+    sandbox_module.clear_resolvers()
+end
+
+function main()
+    -- Run the resolver test suite and clean up afterwards.
+    _test_module_result()
+    _test_file_result()
+    _test_string_result_is_file_result()
+    _test_raw_table_result_is_module_result()
+    _test_miss_falls_through_to_later_resolver()
+    _test_nil_falls_through_to_later_resolver()
+    _test_cache_reuses_module_result()
+    _test_nocache_reruns_resolver()
+    _test_file_result_is_cached_by_logical_name()
+    _test_normal_module_precedence()
+    _test_module_tables_can_use_kind_field()
+
+    _clear_resolvers()
+end

--- a/tests/apis/add_resolver/xmake.lua
+++ b/tests/apis/add_resolver/xmake.lua
@@ -1,0 +1,25 @@
+-- Test project for the module resolver API.
+--
+-- Run from this directory with:
+--   xmake add_resolver
+--
+-- The actual assertions live in test.lua so they can follow the existing
+-- Xmake API-test pattern: the xmake.lua file wires a command/task, and the
+-- test module owns the test cases.
+
+add_moduledirs("$(projectdir)/test")
+add_moduledirs("test")
+
+task("foo")
+    set_category("plugin")
+
+    on_run(function ()
+        import("test", {alias = "add_resolver_test"})
+        local modules = import("core.sandbox.module")
+        add_resolver_test.main()
+    end)
+
+    set_menu {
+        usage = "xmake add_resolver",
+        description = "Run module resolver API tests"
+    }

--- a/xmake/core/project/project.lua
+++ b/xmake/core/project/project.lua
@@ -185,6 +185,20 @@ function project._api_add_moduledirs(interp, ...)
     end
 end
 
+-- add a custom module resolver
+--
+-- @param interp    the project interpreter instance
+-- @param resolver  the resolver callback, e.g. function (name, ctx) ... end
+--
+-- Module resolvers are fallback providers for import(...). They run after
+-- normal module-directory lookup fails and can provide generated, virtual or
+-- otherwise dynamic modules while preserving normal import semantics for
+-- callers.
+function project._api_add_moduleresolver(interp, resolver)
+    assert(type(resolver) == "function", "module resolver must be a function")
+    sandbox_module.add_resolver(resolver)
+end
+
 -- add plugin directories load all plugins from the given directories
 function project._api_add_plugindirs(interp, ...)
     local plugindirs = {}
@@ -682,6 +696,7 @@ function project.apis()
         ,   {"has_package",             project._api_has_package       }
             -- add_xxx
         ,   {"add_moduledirs",          project._api_add_moduledirs    }
+        ,   {"add_moduleresolver",      project._api_add_moduleresolver}
         ,   {"add_plugindirs",          project._api_add_plugindirs    }
         ,   {"add_platformdirs",        project._api_add_platformdirs  }
         ,   {"add_toolchaindirs",       project._api_add_toolchaindirs }

--- a/xmake/core/sandbox/modules/import/core/sandbox/module.lua
+++ b/xmake/core/sandbox/modules/import/core/sandbox/module.lua
@@ -134,7 +134,7 @@ function core_sandbox_module._normalize_resolver_result(result)
         return core_sandbox_module._resolver_result("module", result)
     end
 
-    return result
+    return nil 
 end
 
 -- make the context object passed to custom module resolvers
@@ -158,7 +158,7 @@ function core_sandbox_module._make_resolver_context(name)
     end
 
     function ctx.file(filepath)
-        assert(filepath, "ctx.file(...) requires a file path")
+        assert(type(filepath) == "string", "ctx.file(...) requires a file path string")
         return core_sandbox_module._resolver_result("file", filepath)
     end
 
@@ -187,13 +187,16 @@ function core_sandbox_module._load_resolver_result(name, result, opt)
         return false
     elseif result.kind == "file" then
         local filepath = result.value
-        if not os.isfile(filepath) then
-            return true, nil, string.format("resolver returned missing module file: %s", filepath)
+        if type(filepath) ~= "string" or not os.isfile(filepath) then
+            return true, nil, string.format("resolver returned missing or invalid module file: %s", tostring(filepath))
         end
 
         local module, errors = core_sandbox_module._loadfile(filepath, opt.instance)
         return true, module, errors
     elseif result.kind == "module" then
+        if type(result.value) ~= "table" then
+            return true, nil, string.format("resolver returned invalid module table: %s", tostring(result.value))
+        end
         return true, result.value, nil
     else
         return true, nil, string.format("unknown module resolver result kind: %s", tostring(result.kind))

--- a/xmake/core/sandbox/modules/import/core/sandbox/module.lua
+++ b/xmake/core/sandbox/modules/import/core/sandbox/module.lua
@@ -41,6 +41,227 @@ local MODULE_KIND_LUADIR  = 2
 local MODULE_KIND_BINARY  = 3
 local MODULE_KIND_SHARED  = 4
 
+
+-- get registered custom module resolvers
+--
+-- @return          the shared resolver list
+--
+-- Resolver state is stored in memcache instead of a module-local table because
+-- this importer can be loaded through different sandbox/import paths. Using
+-- memcache ensures resolver registration and resolver lookup see the same
+-- shared registry.
+function core_sandbox_module.resolvers()
+    local resolvers = memcache.get("core_sandbox_module", "resolvers")
+    if not resolvers then
+        resolvers = {}
+        memcache.set("core_sandbox_module", "resolvers", resolvers)
+    end
+    return resolvers
+end
+
+-- add a custom module resolver
+--
+-- @param resolver  the resolver callback, e.g. function (name, ctx) ... end
+--
+-- A resolver is called only after normal module-directory lookup fails. It can
+-- provide generated, virtual or otherwise non-file-discovered modules without
+-- requiring callers to use a different import API.
+function core_sandbox_module.add_resolver(resolver)
+    assert(type(resolver) == "function", "module resolver must be a function")
+    table.insert(core_sandbox_module.resolvers(), resolver)
+end
+
+-- clear registered custom module resolvers
+--
+-- This is primarily used by tests and reload paths so resolver state cannot
+-- leak between independent runs.
+function core_sandbox_module.clear_resolvers()
+    memcache.set("core_sandbox_module", "resolvers", {})
+end
+
+-- make an explicit resolver result
+--
+-- @param kind      the resolver result kind, e.g. file, module or miss
+-- @param value     the payload associated with the result kind
+-- @param opt       optional result fields
+-- @return          a tagged resolver result table
+--
+-- Resolver callbacks may return plain strings or tables for convenience, but
+-- context helpers like ctx.file(...) and ctx.module(...) produce explicit
+-- resolver result tables. The private marker prevents ordinary module export
+-- tables from being mistaken for resolver control data.
+function core_sandbox_module._resolver_result(kind, value, opt)
+    opt = opt or {}
+
+    -- Explicit marker so arbitrary module export tables are never confused
+    opt.__module_resolver_result = true
+    opt.kind = kind
+    opt.value = value
+
+    return opt
+end
+
+-- normalize a resolver callback result
+--
+-- @param result    the raw resolver callback result
+-- @return          nil for miss, or an explicit resolver result table
+--
+-- Convenience forms:
+--   nil             => resolver miss
+--   string          => file-backed module path
+--   table           => module export table
+--   marked table    => explicit resolver result from ctx.* helpers
+function core_sandbox_module._normalize_resolver_result(result)
+    if result == nil then
+        return nil
+    end
+
+    -- Convenience: raw string means file path.
+    if type(result) == "string" then
+        return core_sandbox_module._resolver_result("file", result)
+    end
+
+    -- Explicit resolver protocol object.
+    if type(result) == "table" and result.__module_resolver_result then
+        return result
+    end
+
+    -- Convenience: arbitrary table means module export table.
+    --
+    -- Module export tables are allowed to contain a `kind` field, so do not use
+    -- `kind == nil` as the discriminator.
+    if type(result) == "table" then
+        return core_sandbox_module._resolver_result("module", result)
+    end
+
+    return result
+end
+
+-- make the context object passed to custom module resolvers
+--
+-- @param name      the requested module name
+-- @return          resolver context helpers
+--
+-- The context gives resolvers an explicit way to describe what they resolved:
+-- ctx.miss() says the resolver did not handle the name, ctx.file(path) resolves
+-- to a Lua module file, and ctx.module(table) resolves to an in-memory module
+-- export table.
+function core_sandbox_module._make_resolver_context(name)
+    local ctx = {}
+
+    function ctx.name()
+        return name
+    end
+
+    function ctx.miss()
+        return core_sandbox_module._resolver_result("miss")
+    end
+
+    function ctx.file(filepath)
+        assert(filepath, "ctx.file(...) requires a file path")
+        return core_sandbox_module._resolver_result("file", filepath)
+    end
+
+    function ctx.module(module)
+        assert(type(module) == "table", "ctx.module(...) requires a module table")
+        return core_sandbox_module._resolver_result("module", module)
+    end
+    
+    return ctx
+end
+
+-- load a normalized resolver result
+--
+-- @param name      the requested module name
+-- @param result    an explicit resolver result table
+-- @param opt       import options
+-- @return          found, module, errors/script
+--
+-- File-backed resolver results are loaded through the existing _loadfile(...)
+-- path so normal sandbox/module behavior is preserved. In-memory module results
+-- are returned directly and cached by the logical import name.
+function core_sandbox_module._load_resolver_result(name, result, opt)
+    opt = opt or {}
+
+    if result.kind == "miss" then
+        return false
+    elseif result.kind == "file" then
+        local filepath = result.value
+        if not os.isfile(filepath) then
+            return true, nil, string.format("resolver returned missing module file: %s", filepath)
+        end
+
+        local module, errors = core_sandbox_module._loadfile(filepath, opt.instance)
+        return true, module, errors
+    elseif result.kind == "module" then
+        return true, result.value, nil
+    else
+        return true, nil, string.format("unknown module resolver result kind: %s", tostring(result.kind))
+    end
+end
+
+-- find and load a module using custom resolvers
+--
+-- @param name      the requested module name
+-- @param opt       import options
+-- @return          found, module, errors/script
+--
+-- Resolvers are fallback providers. They run only after normal module lookup
+-- fails, which preserves existing module-file precedence and avoids accidental
+-- shadowing of built-in or project-local modules.
+function core_sandbox_module._find_and_load_by_resolvers(name, opt)
+    opt = opt or {}
+
+    local resolvers = core_sandbox_module.resolvers()
+    if #resolvers == 0 then
+        return false
+    end
+
+    -- Resolver-backed modules share the same cache table as normal imports.
+    -- The key is logical rather than filesystem based because a resolver may
+    -- provide a generated file, a virtual module table, or another provider
+    -- implementation for the same requested import name.
+    local modules = opt.modules
+    local modulekey = "resolver://" .. name
+
+    if modules and not opt.nocache and not opt.inherit then
+        local moduleinfo = modules[modulekey]
+        if moduleinfo then
+            return true, moduleinfo[1], moduleinfo[2]
+        end
+    end
+
+    local ctx = core_sandbox_module._make_resolver_context(name)
+
+    for _, resolver in ipairs(resolvers) do
+        local ok, result = utils.trycall(function ()
+            return resolver(name, ctx)
+        end)
+        if not ok then
+            local errors = string.format("module resolver failed for '%s': %s", name, tostring(result))
+
+            if modules and not opt.nocache then
+                modules[modulekey] = {nil, errors}
+            end
+
+            return true, nil, errors
+        end
+
+        result = core_sandbox_module._normalize_resolver_result(result)
+
+        if result and result.kind ~= "miss" then
+            local found, module, errors = core_sandbox_module._load_resolver_result(name, result, opt)
+            if found and modules and not opt.nocache then
+                modules[modulekey] = {module, errors}
+            end
+            return found, module, errors
+        end
+    end
+
+    return false
+end
+
+
 -- get module path from name
 function core_sandbox_module._modulepath(name)
 
@@ -403,6 +624,11 @@ function core_sandbox_module._find_and_load(name, opt)
             end
         end
     end
+
+    if not found then
+        found, module, errors = core_sandbox_module._find_and_load_by_resolvers(name, opt)
+    end
+
     return found, module, errors
 end
 


### PR DESCRIPTION
Feature request: https://github.com/xmake-io/xmake/issues/7566
Documentation PR: https://github.com/xmake-io/xmake-docs/pull/279

Adds custom module resolvers for `import(...)`.

Resolvers are fallback providers that run after normal module lookup fails. They allow projects to provide generated or virtual modules while preserving existing module lookup precedence and import semantics.

This includes:

- resolver registration in the import system
- resolver fallback loading
- logical-name-based resolver result caching
- `nocache` support
- file-backed resolver results via `ctx.file(...)`
- in-memory module results via `ctx.module(...)`
- public project API: `add_moduleresolver(...)`
- internal resolver behavior tests
- public API integration test

Tests run:

```sh
xmake l tests/run.lua add_resolver
xmake l tests/run.lua add_moduleresolver