### PR TITLE
Support multiple targets for xmake build

### DIFF
--- a/xmake/actions/build/main.lua
+++ b/xmake/actions/build/main.lua
@@ -199,9 +199,11 @@ function main(opt)
     local targetname, group_pattern = action_utils.get_target_and_group()
     task.run("config", {}, {disable_dump = true})
 
-    -- check target name
+    -- check target names
     if targetname then
-        assert(check_targetname(targetname))
+        for _, name in ipairs(table.wrap(targetname)) do
+            assert(check_targetname(name))
+        end
     end
 
     -- enter project directory

--- a/xmake/actions/build/xmake.lua
+++ b/xmake/actions/build/xmake.lua
@@ -53,7 +53,7 @@ task("build")
                                                       "    - xmake --files='src/main.c" .. path.envsep() .. "src/test.c'"  }
 
                 ,   {}
-                ,   {nil, "targets",     "vs", nil   , "Targets to be built. It will build all default targets if this parameter is not specified."
+                ,   {nil, "target",     "vs", nil   , "Targets to be built. It will build all default targets if this parameter is not specified."
                                                     , values = function (complete, opt) return import("private.utils.complete_helper.targets")(complete, opt) end }
                 }
             }

--- a/xmake/actions/build/xmake.lua
+++ b/xmake/actions/build/xmake.lua
@@ -22,7 +22,7 @@ task("build")
     set_category("main")
     on_run("main")
     set_menu {
-                usage = "xmake [task] [options] [target]"
+                usage = "xmake [task] [options] [targets]"
             ,   description = "Build targets if no given tasks."
             ,   shortname = 'b'
             ,   options =
@@ -53,7 +53,7 @@ task("build")
                                                       "    - xmake --files='src/main.c" .. path.envsep() .. "src/test.c'"  }
 
                 ,   {}
-                ,   {nil, "target",     "v",  nil   , "The target name. It will build all default targets if this parameter is not specified."
+                ,   {nil, "targets",     "vs", nil   , "Targets to be built. It will build all default targets if this parameter is not specified."
                                                     , values = function (complete, opt) return import("private.utils.complete_helper.targets")(complete, opt) end }
                 }
             }


### PR DESCRIPTION
resolve: #7578

在工程具有多个目标的情况下，我们要一行命令构建它们，只能将这些目标设置为 set_default(true) 。但是一旦更改了xmake.lua，就会导致重新生成。

cmake 支持一次性指定多个要构建的目标，我认为这个特性很适合移植到 xmake 中来。
