### PR TITLE
 plugin/format: fix doubled paths for absolute header files on Windows

### DIFF
--- a/xmake/plugins/format/main.lua
+++ b/xmake/plugins/format/main.lua
@@ -185,12 +185,12 @@ function main()
         for _, target in ipairs(targets) do
             for _, source in ipairs(target:sourcefiles()) do
                 if _match_sourcefiles(source, filepatterns) then
-                    table.insert(sourcefiles, path.join(projectdir, source))
+                    table.insert(sourcefiles, path.absolute(source, projectdir))
                 end
             end
             for _, header in ipairs(target:headerfiles()) do
                 if _match_sourcefiles(header, filepatterns) then
-                    table.insert(sourcefiles, path.join(projectdir, header))
+                    table.insert(sourcefiles, path.absolute(header, projectdir))
                 end
             end
         end
@@ -199,12 +199,12 @@ function main()
             for _, sourcebatch in pairs(target:sourcebatches()) do
                 if _source_batch_should_format(sourcebatch) then
                     for _, source in ipairs(sourcebatch.sourcefiles) do
-                        table.insert(sourcefiles, path.join(projectdir, source))
+                        table.insert(sourcefiles, path.absolute(source, projectdir))
                     end
                 end
             end
             for _, header in ipairs(target:headerfiles()) do
-                table.insert(sourcefiles, path.join(projectdir, header))
+                table.insert(sourcefiles, path.absolute(header, projectdir))
             end
         end
     end


### PR DESCRIPTION
On Windows, path.join(projectdir, absolutePath) does not replace the path it concatenates it, producing malformed paths like:

C:/myproject/C:/full/path/to/header.h
Header files returned by target:headerfiles() are always absolute on Windows, which systematically triggered this bug. 

Logs:
```
xmake format
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\deps\ConcertoFramework\Src\Concerto\CppPlugin\CppPlugin.c
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\ClangParser\ClangParser.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\main.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\Plugin\PluginApi.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\Plugin\PluginRegistry.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\ChunkedStreamBuf.hpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\Defines.hpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\ClangParser\ClangParser.hpp
C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\ChunkedStreamBuf.hpp: invalid argument
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\Plugin\PluginRegistry.hpp
C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\Defines.hpp: invalid argument
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\Plugin\ReflectionGeneratorPlugin.hpp
C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\ClangParser\ClangParser.hpp: invalid argument
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\BuildLayout.cpp
C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\Plugin\PluginRegistry.hpp: invalid argument
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\Commands\Dialog\DialogCommands.cpp
C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\Plugin\ReflectionGeneratorPlugin.hpp: invalid argument
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\Commands\IpcDispatcherBridge.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\GraphicsApplicationComponent.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\main.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\TelemetryProducer.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\UiApplicationComponent.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\ViewportReceiver.cpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\BuildLayout.hpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\GraphicsApplicationComponent.hpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\TelemetryProducer.hpp
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\UiApplicationComponent.hpp
C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\BuildLayout.hpp: invalid argument
[  0%]: clang-format.formatting C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\ViewportReceiver.hpp
C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\Rbe\Studio\GraphicsApplicationComponent.hpp: invalid argument
error: execv(C:\Users\Arthur\AppData\Local\.xmake\packages\l\llvm\21.1.0\48d15c12938d434ba4d4fc39663938e0\bin\clang-format.exe -i C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\C:\Users\Arthur\Documents\ArthurVasseur\rbe-desktop\Src\..\deps\ConcertoFramework\Src\Concerto\PackageGenerator\ChunkedStreamBuf.hpp) failed(1), unknown reason
```
(The bug is triggered on the last line)