### PR TITLE
fix(package): split global flags for build envs

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1289,7 +1289,7 @@ function _instance:build_envs(lazy_loading)
         setmetatable(build_envs, { __index = function (tbl, key)
             local result = {}
             local value = config.get(key)
-            if builtin_configs:has(key) and type(value) == "string" then
+            if value and builtin_configs:has(key) and type(value) == "string" then
                 value = os.argv(value)
             end
             if value == nil then

--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -1289,6 +1289,9 @@ function _instance:build_envs(lazy_loading)
         setmetatable(build_envs, { __index = function (tbl, key)
             local result = {}
             local value = config.get(key)
+            if builtin_configs:has(key) and type(value) == "string" then
+                value = os.argv(value)
+            end
             if value == nil then
                 value = self:tool(key)
             end


### PR DESCRIPTION
### Summary
- parse global CLI builtin flag configs with argv semantics when package build environments read them
- keep package/tool-specific flag values unchanged, so `package.tools.cmake` and other tools still expect arrays from their direct inputs
- prevent global values like `--ldflags="-static -fuse-ld=mold"` from becoming a quoted single linker argument in package builds that forward build env flags to CMake

### Original issue
For package builds that consume `package:build_getenv("ldflags")`, a global CLI value such as `--ldflags="-static -fuse-ld=mold"` was previously stored as one string item. When a build helper later formatted that item with `os.args()`, it became a quoted single argument like `"-static -fuse-ld=mold"`.

If this value was forwarded to `CMAKE_EXE_LINKER_FLAGS`, CMake compiler checks or `try_compile` could invoke the compiler with one invalid argument instead of two separate flags:

```text
cc: error: unrecognized command-line option ‘-static -fuse-ld=mold’
/usr/bin/cc "-static -fuse-ld=mold" ...
```

This change limits the string splitting to the global builtin flag config entry point in `package:build_envs()`. Direct package configs and tool options remain array-based.

### Verification
- Ran a local CMake xrepo package configure with `--toolchain=gcc --ldflags="-static -fuse-ld=mold"`; CMake received `CMAKE_EXE_LINKER_FLAGS=  -static -fuse-ld=mold -m64`, and Ninja linked with `-static -fuse-ld=mold` as separate flags.