### PR TITLE
add requires api checker

### DIFF
--- a/tests/plugins/check/test.lua
+++ b/tests/plugins/check/test.lua
@@ -1,0 +1,37 @@
+function test_api_package_requires(t)
+    local outdata = os.iorunv("xmake", {"check", "api.package.requires"})
+
+    -- locally-defined package is found
+    t:require_not(outdata:find("unknown package 'foo'", 1, true))
+
+    -- invalid package is reported
+    t:require(outdata:find("unknown package 'invalid_package'", 1, true))
+
+    -- invalid namespace package is reported
+    t:require(outdata:find("unknown package 'invalid_ns_package'", 1, true))
+
+    -- system package is skipped
+    t:require_not(outdata:find("unknown package 'invalid_package_system'", 1, true))
+
+    -- 3rd-party package is skipped
+    t:require_not(outdata:find("unknown package 'vcpkg::invalid_package_3rd'", 1, true))
+
+    -- invalid configs are flagged in add_requires
+    t:require(outdata:find("unknown config value 'baz'", 1, true))
+
+    -- valid config and builtin configs are not flagged
+    t:require_not(outdata:find("unknown config value 'bar'", 1, true))
+    t:require_not(outdata:find("unknown config value 'shared'", 1, true))
+
+    -- configs on an invalid package are skipped
+    t:require_not(outdata:find("'abc'", 1, true))
+
+    -- invalid configs on a system package are flagged
+    t:require(outdata:find("unknown config value 'xyz'", 1, true))
+
+    -- configs on a 3rd-party package are skipped
+    t:require_not(outdata:find("'thirdparty_conf'", 1, true))
+
+    -- invalid configs inside a namespace are flagged
+    t:require(outdata:find("unknown config value 'namespaced_conf'", 1, true))
+end

--- a/tests/plugins/check/xmake.lua
+++ b/tests/plugins/check/xmake.lua
@@ -1,0 +1,17 @@
+package("foo")
+    add_configs("bar", {description = "Enable bar.", default = false, type = "boolean"})
+    on_install(function (package) end)
+package_end()
+
+add_requires("foo", {configs = {bar = true, baz = true, shared = true}})
+add_requires("invalid_package", {configs = {abc = true}})
+add_requires("invalid_package_system", {system = true, configs = {xyz = true}})
+add_requires("vcpkg::invalid_package_3rd", {configs = {thirdparty_conf = true}})
+
+namespace("ns1", function ()
+    add_requires("foo~foo2", {configs = {namespaced_conf = true}})
+    add_requires("invalid_ns_package")
+end)
+
+target("test")
+    set_kind("phony")

--- a/xmake/modules/private/action/require/impl/package.lua
+++ b/xmake/modules/private/action/require/impl/package.lua
@@ -202,6 +202,56 @@ function _load_package_from_base(package, basename, opt)
     end
 end
 
+-- load the package definition (project, repo, base, system)
+-- @param opt extra options, e.g. {displayname = ..., system = ..., locked_repo = ...}
+-- @return package, packagename, displayname, from_repo
+function _load_package_definition(packagename, requireinfo, opt)
+    opt = opt or {}
+    local displayname = opt.displayname
+
+    -- load package from project first
+    local package
+    if os.isfile(os.projectfile()) then
+        package = _load_package_from_project(packagename)
+        if package and package:namespace() then
+            packagename = package:namespace() .. "::" .. packagename
+            if displayname then
+                displayname = package:namespace() .. "::" .. displayname
+            end
+        end
+    end
+
+    -- load package from repositories
+    local from_repo = false
+    if not package then
+        package = _load_package_from_repository(packagename, {
+            plat = requireinfo.plat,
+            arch = requireinfo.arch,
+            name = requireinfo.reponame,
+            locked_repo = opt.locked_repo})
+        if package then
+            from_repo = true
+        end
+    end
+
+    -- load base package
+    if package and package:get("base") then
+        _load_package_from_base(package, package:get("base"), {
+            name = requireinfo.reponame, locked_repo = opt.locked_repo})
+    end
+
+    -- load package from system
+    local system = requireinfo.system
+    if system == nil then
+        system = opt.system
+    end
+    if not package and (system ~= false or packagename:find("::", 1, true)) then
+        package = _load_package_from_system(packagename)
+    end
+
+    return package, packagename, displayname, from_repo
+end
+
 -- has locked requires?
 function _has_locked_requires(opt)
     opt = opt or {}
@@ -930,45 +980,13 @@ function _load_package(packagename, requireinfo, opt)
     -- get locked requireinfo
     local locked_requireinfo = get_locked_requireinfo(requireinfo)
 
-    -- load package from project first
-    local package
-    if os.isfile(os.projectfile()) then
-        package = _load_package_from_project(packagename)
-        if package and package:namespace() then
-            packagename = package:namespace() .. "::" .. packagename
-            if displayname then
-                displayname = package:namespace() .. "::" .. displayname
-            end
-        end
-    end
-
-    -- load package from repositories
-    local from_repo = false
-    if not package then
-        package = _load_package_from_repository(packagename, {
-            plat = requireinfo.plat,
-            arch = requireinfo.arch,
-            name = requireinfo.reponame,
-            locked_repo = locked_requireinfo and locked_requireinfo.repo})
-        if package then
-            from_repo = true
-        end
-    end
-
-    -- load base package
-    if package and package:get("base") then
-        _load_package_from_base(package, package:get("base"), {
-            name = requireinfo.reponame, locked_repo = locked_requireinfo and locked_requireinfo.repo})
-    end
-
-    -- load package from system
-    local system = requireinfo.system
-    if system == nil then
-        system = opt.system
-    end
-    if not package and (system ~= false or packagename:find("::", 1, true)) then
-        package = _load_package_from_system(packagename)
-    end
+    -- load package definition
+    local package, from_repo
+    package, packagename, displayname, from_repo = _load_package_definition(packagename, requireinfo, {
+        displayname = displayname,
+        system = opt.system,
+        locked_repo = locked_requireinfo and locked_requireinfo.repo
+    })
 
     -- check unknown package
     if not package then
@@ -1653,6 +1671,27 @@ function load_requires(requires, requires_extra, opt)
         table.insert(requireitems, {name = packagename, info = requireinfo})
     end
     return requireitems
+end
+
+-- load the package definition only, without resolving or installing it
+function load_package_definition(packagename, requireinfo, opt)
+    opt = opt or {}
+    requireinfo = requireinfo or {}
+
+    -- strip trailing ~tag
+    if packagename:find('~', 1, true) then
+        packagename = packagename:split('~', {plain = true, limit = 2})[1]
+    end
+
+    local package
+    package, packagename = _load_package_definition(packagename, requireinfo, {system = opt.system})
+
+    -- add some builtin configurations to package
+    if package then
+        _add_package_configurations(package)
+    end
+
+    return package, packagename
 end
 
 -- load all required packages

--- a/xmake/modules/private/check/checker.lua
+++ b/xmake/modules/private/check/checker.lua
@@ -30,6 +30,7 @@ function checkers()
             -- package api checkers
             ["api.package.kind"]         = {description = "Check kind configuration in package.", load = true},
             ["api.package.versionfiles"] = {description = "Check versionfiles configuration in package.", download_failure = true},
+            ["api.package.requires"]     = {description = "Check api configurations in add_requires.", load = true},
             -- target api checkers
             ["api.target.version"]       = {description = "Check version configuration in target."},
             ["api.target.kind"]          = {description = "Check kind configuration in target.", build = true},

--- a/xmake/modules/private/check/checkers/api/api_checker.lua
+++ b/xmake/modules/private/check/checkers/api/api_checker.lua
@@ -25,6 +25,7 @@ import("core.package.package")
 import("core.project.project")
 import("private.check.checker")
 import("private.utils.target", {alias = "target_utils"})
+import("private.action.require.impl.package", {alias = "require_impl"})
 
 function _get_project_packages()
     local project_packages = _g.project_packages
@@ -130,6 +131,9 @@ function _check_instance(instance, apiname, valueset, level, opt)
         local instance_values = opt.values(instance)
         if instance_values then
             instance_valueset = hashset.from(instance_values)
+        else
+            -- values function opted out of checking this instance
+            return
         end
     end
     local values = instance:get(apiname)
@@ -175,6 +179,33 @@ function _check_instances(apiname, instance, instances_func, opt)
     end
 end
 
+-- load all `add_requires()` descriptors
+function _get_requires(opt)
+    local requires = _g.get_requires
+    if requires == nil then
+        requires = {}
+        local requires_str, requires_extra = project.requires_str()
+        if requires_str then
+            local sourceinfos = {}
+            table.join2(sourceinfos, project.get("__sourceinfo_requires"))
+            for _, namespace in ipairs(table.wrap(project.namespaces())) do
+                table.join2(sourceinfos, project.get(namespace .. "::__sourceinfo_requires"))
+            end
+
+            for _, item in ipairs(require_impl.load_requires(table.wrap(requires_str), requires_extra)) do
+                table.insert(requires, {
+                    name = item.name,
+                    info = item.info,
+                    package = require_impl.load_package_definition(item.name, item.info, opt),
+                    sourcename = "requires",
+                    sourceinfo = sourceinfos[item.info.originstr]})
+            end
+        end
+        _g.get_requires = requires
+    end
+    return requires
+end
+
 -- check flag
 -- @see https://github.com/xmake-io/xmake/issues/3594
 function check_flag(target, toolinst, flagkind, flag)
@@ -199,4 +230,40 @@ end
 function check_packages(apiname, opt)
     opt = opt or {}
     _check_instances(apiname, opt.package, _get_project_packages, opt)
+end
+
+-- get a `add_requires()` descriptor as an instance-like object
+function _require_instance(require)
+    return {
+        package = require.package,
+        get = function (self, apiname)
+            if apiname == "package" then
+                return {require.name}
+            end
+            return table.orderkeys(require.info[apiname] or {})
+        end,
+        sourceinfo = function (self, apiname, value)
+            return require.sourceinfo
+        end,
+        type = function (self)
+            return require.sourcename
+        end,
+        name = function (self)
+            return require.name
+        end}
+end
+
+-- check api configuration in `add_requires()`
+function check_requires(apiname, opt)
+    opt = opt or {}
+    opt.system = false
+    _check_instances(apiname, nil, function ()
+        local instances = {}
+        for _, require in ipairs(_get_requires(opt)) do
+            if not opt.package or (require.package and require.package:name() == opt.package:name()) then
+                table.insert(instances, _require_instance(require))
+            end
+        end
+        return instances
+    end, opt)
 end

--- a/xmake/modules/private/check/checkers/api/package/requires.lua
+++ b/xmake/modules/private/check/checkers/api/package/requires.lua
@@ -1,0 +1,44 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Copyright (C) 2015-present, Xmake Open Source Community.
+--
+-- @author      Shiffted
+-- @file        requires.lua
+--
+
+-- imports
+import(".api_checker")
+
+-- check api configurations in `add_requires`
+function main(opt)
+    opt = opt or {}
+
+    api_checker.check_requires("package", table.join(opt, {check = function(require_instance , value)
+        if not require_instance.package then
+            return false, string.format("unknown package '%s', not found in any repository", value)
+        end
+        return true
+    end}))
+
+    api_checker.check_requires("configs", table.join(opt, {values = function(require_instance)
+        local package = require_instance.package
+
+        -- skip unresolved and 3rd-party packages (e.g. vcpkg::, conan::)
+        if not package or package:name():find("::", 1, true) then
+            return nil
+        end
+        return package:get("configs") or {}
+    end}))
+end


### PR DESCRIPTION
https://github.com/xmake-io/xmake/issues/7378

Adds checker for `add_requires()` like discussed in https://github.com/xmake-io/xmake/pull/7394

This does not check configs from package deps, e.g.:
```lua
package("foo")
    add_deps("libsdl2", {configs = {invalid_conf = true}})
    on_install(function (package) end)
package_end()

add_requires("foo")
```
will not be checked.
