### PR TITLE
vsxmake: custom source types in Solution Explorer

### DIFF
--- a/xmake/plugins/project/vsxmake/vsxmake.lua
+++ b/xmake/plugins/project/vsxmake/vsxmake.lua
@@ -150,6 +150,12 @@ function _buildparams(info, target, default)
         elseif args.filecs then -- for c#
             local files = info._targets[target].sourcefiles
             table.insert(r, _filter_files(files, {".cs"}))
+        elseif args.filenone then -- for custom build steps
+            local files = info._targets[target].sourcefiles
+            table.insert(r, _filter_files(files, nil, {
+                ".c", ".cpp", ".cc", ".cxx", ".mpp", ".mxx", ".cppm", ".ixx",
+                ".cu", ".obj", ".o", ".rc", ".ui", ".qrc", ".ts", ".cs"
+            }))
         elseif args.incc then
             local files = table.join(info._targets[target].headerfiles or {}, info._targets[target].extrafiles)
             table.insert(r, _filter_files(files, nil, {".natvis"}))

--- a/xmake/scripts/vsxmake/vsproj/templates/vcxproj.filters/#target#.vcxproj.filters
+++ b/xmake/scripts/vsxmake/vsproj/templates/vcxproj.filters/#target#.vcxproj.filters
@@ -50,6 +50,9 @@
 #Import(File.qrc)#
 #Import(File.ts)#
   </ItemGroup>
+  <ItemGroup>
+#Import(File.none)#
+  </ItemGroup>
   <Import Condition="Exists('$(MSBuildThisFileDirectory)\Xmake.Custom.files.filters')"
     Project="$(MSBuildThisFileDirectory)\Xmake.Custom.files.filters" />
 </Project>

--- a/xmake/scripts/vsxmake/vsproj/templates/vcxproj.filters/File.none(filenone)
+++ b/xmake/scripts/vsxmake/vsproj/templates/vcxproj.filters/File.none(filenone)
@@ -1,0 +1,3 @@
+    <None Include="#path#">
+      <Filter>#dir#</Filter>
+    </None>

--- a/xmake/scripts/vsxmake/vsproj/templates/vcxproj/#target#.vcxproj
+++ b/xmake/scripts/vsxmake/vsproj/templates/vcxproj/#target#.vcxproj
@@ -52,6 +52,9 @@
 #Import(File.qrc)#
 #Import(File.ts)#
   </ItemGroup>
+  <ItemGroup>
+#Import(File.none)#
+  </ItemGroup>
   <!-- <ItemGroup>
 #Import(ProjectRef)#
   </ItemGroup> -->

--- a/xmake/scripts/vsxmake/vsproj/templates/vcxproj/File.none(filenone)
+++ b/xmake/scripts/vsxmake/vsproj/templates/vcxproj/File.none(filenone)
@@ -1,0 +1,1 @@
+    <None Include="#path#" />


### PR DESCRIPTION
This allows seeing source files added by add_files but not directly supported by xmake (e.g. when support is provided by a custom build rule).

Rationale: I have a custom build rule for HLSL shaders, and this change is required to to see their source files in Visual Studio's Solution Explorer.

P.S. should I also add support to the legacy `vs` project generator, or is doing just `vsxmake` sufficient?