### PR TITLE
workaround for clangd drive letter casing issue

### DIFF
--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -212,7 +212,6 @@ function _make_arguments(jsonfile, arguments, opt)
     -- make body
     local projectdir = os.projectdir()
     -- workaround for drive letter casing issue, can be removed when clangd resolves https://github.com/clangd/vscode-clangd/pull/747
-    local lsp = _get_lsp()
     if is_host("windows") and (lsp == nil or lsp == "clangd") then
         projectdir = projectdir:gsub("^[A-Z]:", string.lower)
     end

--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -211,7 +211,9 @@ function _make_arguments(jsonfile, arguments, opt)
 
     -- make body
     local projectdir = os.projectdir()
-    if is_host("windows") then -- workaround for drive letter casing issue, can be removed when clangd resolves https://github.com/clangd/vscode-clangd/pull/747
+    -- workaround for drive letter casing issue, can be removed when clangd resolves https://github.com/clangd/vscode-clangd/pull/747
+    local lsp = _get_lsp()
+    if is_host("windows") and (lsp == nil or lsp == "clangd") then
         projectdir = projectdir:gsub("^[A-Z]:", string.lower)
     end
     jsonfile:printf(

--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -210,12 +210,16 @@ function _make_arguments(jsonfile, arguments, opt)
     end
 
     -- make body
+    local projectdir = os.projectdir()
+    if is_host("windows") then -- workaround for drive letter casing issue, can be removed when cland resolves https://github.com/clangd/vscode-clangd/pull/747
+        projectdir = projectdir:gsub("^([A-Z]):", function(d) return d:lower() .. ":" end)
+    end
     jsonfile:printf(
 [[%s{
   "directory": "%s",
   "arguments": ["%s"],
   "file": "%s"
-}]], (_g.firstline and "" or ",\n"), _escape_path(os.projectdir()), table.concat(arguments_escape, "\", \""), _escape_path(sourcefile))
+}]], (_g.firstline and "" or ",\n"), _escape_path(projectdir), table.concat(arguments_escape, "\", \""), _escape_path(sourcefile))
 
     -- clear first line marks
     _g.firstline = false

--- a/xmake/plugins/project/clang/compile_commands.lua
+++ b/xmake/plugins/project/clang/compile_commands.lua
@@ -211,8 +211,8 @@ function _make_arguments(jsonfile, arguments, opt)
 
     -- make body
     local projectdir = os.projectdir()
-    if is_host("windows") then -- workaround for drive letter casing issue, can be removed when cland resolves https://github.com/clangd/vscode-clangd/pull/747
-        projectdir = projectdir:gsub("^([A-Z]):", function(d) return d:lower() .. ":" end)
+    if is_host("windows") then -- workaround for drive letter casing issue, can be removed when clangd resolves https://github.com/clangd/vscode-clangd/pull/747
+        projectdir = projectdir:gsub("^[A-Z]:", string.lower)
     end
     jsonfile:printf(
 [[%s{


### PR DESCRIPTION
Windows 下 compile_commands.json 中盘符大写时，会导致对项目中变量重命名失败，这是 clangd 的 bug，但是一直不修，这里 workaround 一下