### PR TITLE
fix(deb): Avoid passing empty PATH arguments to debuild

### DIFF
--- a/xmake/plugins/pack/deb/main.lua
+++ b/xmake/plugins/pack/deb/main.lua
@@ -259,7 +259,7 @@ function _pack_deb(debuild, package)
     local debuild_args = {}
     local pathenv = os.getenv("PATH")
 
-    if pathenv then
+    if pathenv and pathenv ~= "" then
         table.insert(debuild_args, "-e")
         table.insert(debuild_args, "PATH=" .. pathenv)
     end

--- a/xmake/plugins/pack/deb/main.lua
+++ b/xmake/plugins/pack/deb/main.lua
@@ -256,7 +256,18 @@ function _pack_deb(debuild, package)
 
     -- build package
     -- https://github.com/xmake-io/xmake/issues/7626
-    os.vrunv(debuild, {"-e", "PATH=" .. (os.getenv("PATH") or ""), "-us", "-uc"}, {curdir = sourcedir})
+    local debuild_args = {}
+    local pathenv = os.getenv("PATH")
+
+    if pathenv then
+        table.insert(debuild_args, "-e")
+        table.insert(debuild_args, "PATH=" .. pathenv)
+    end
+
+    table.insert(debuild_args, "-us")
+    table.insert(debuild_args, "-uc")
+
+    os.vrunv(debuild, debuild_args, {curdir = sourcedir})
 
     -- copy deb file
     os.vcp(path.join(path.directory(sourcedir), "*.deb"), package:outputfile())


### PR DESCRIPTION
见：#7626 #7627