### PR TITLE
Fix pkgconfig path for bsd in meson.lua

### DIFF
--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -528,14 +528,14 @@ function buildenvs(package, opt)
     local CMAKE_INCLUDE_PATH = {}
     local CMAKE_PREFIX_PATH  = {}
     for _, dep in ipairs(package:librarydeps({private = true})) do
-        local pkgconfig
+        local pkgconfigs = {path.join(dep:installdir(), "lib", "pkgconfig")}
         if package:is_plat("bsd") then
-            pkgconfig = path.join(dep:installdir(), "libdata", "pkgconfig")
-        else
-            pkgconfig = path.join(dep:installdir(), "lib", "pkgconfig")
+            table.insert(pkgconfigs, path.join(dep:installdir(), "libdata", "pkgconfig"))
         end
-        if os.isdir(pkgconfig) then
-            table.insert(PKG_CONFIG_PATH, pkgconfig)
+        for _, pkgconfig in ipairs(pkgconfigs) do
+            if os.isdir(pkgconfig) then
+                table.insert(PKG_CONFIG_PATH, pkgconfig)
+            end
         end
         pkgconfig = path.join(dep:installdir(), "share", "pkgconfig")
         if os.isdir(pkgconfig) then

--- a/xmake/modules/package/tools/meson.lua
+++ b/xmake/modules/package/tools/meson.lua
@@ -528,7 +528,12 @@ function buildenvs(package, opt)
     local CMAKE_INCLUDE_PATH = {}
     local CMAKE_PREFIX_PATH  = {}
     for _, dep in ipairs(package:librarydeps({private = true})) do
-        local pkgconfig = path.join(dep:installdir(), "lib", "pkgconfig")
+        local pkgconfig
+        if package:is_plat("bsd") then
+            pkgconfig = path.join(dep:installdir(), "libdata", "pkgconfig")
+        else
+            pkgconfig = path.join(dep:installdir(), "lib", "pkgconfig")
+        end
         if os.isdir(pkgconfig) then
             table.insert(PKG_CONFIG_PATH, pkgconfig)
         end


### PR DESCRIPTION
BSD variants install .pc files for packages in `libdata/pkgconfig/`, not `lib/pkgconfig/`. This was causing errors when a package used pkg-config to find its dependencies.