### PR TITLE
fix(emsdk): improve emcc detection logic by adding fallback search

### DIFF
--- a/xmake/modules/detect/sdks/find_emsdk.lua
+++ b/xmake/modules/detect/sdks/find_emsdk.lua
@@ -61,6 +61,8 @@ function _find_emsdk(sdkdir)
     table.insert(subdirs, path.join("*", "emscripten"))
     local emcc = find_file("emcc", sdkdir, {suffixes = subdirs})
     emcc = emcc or find_file("emcc.py", sdkdir, {suffixes = subdirs})
+    emcc = emcc or find_file("emcc", sdkdir)
+    emcc = emcc or find_file("emcc.py", sdkdir)
     if emcc then
         emscripten = path.directory(emcc)
     end


### PR DESCRIPTION
Sometimes I get troubles with Arch Linux. Since I installed it using sudo pacman -S emscripten we need to extend detection.

My logs are

<details><summary>Details</summary>

```
          -> mode: release
      -> platforms: @bsd, @windows, @cygwin, @macosx, @msys, @linux
      -> requires:
         -> plat: linux
         -> arch: x86_64
         -> configs:
            -> pic: true
            -> debug: false
            -> shared: false
      -> configs:
      -> configs (builtin):
         -> debug: Enable debug symbols. (default: false)
         -> shared: Build shared library. (default: false)
         -> pic: Enable the position independent code. (default: true)
         -> lto: Enable the link-time build optimization. (type: boolean)
         -> asan: Enable the address sanitizer. (type: boolean)
         -> runtimes: Set the compiler runtimes.
            -> values: {"MT","MTd","MD","MDd","c++_static","c++_shared","stdc++_static","stdc++_shared"}
         -> vs_runtime: Set vs compiler runtime.
            -> values: {"MT","MTd","MD","MDd"}
         -> toolchains: Set package toolchains only for cross-compilation.
         -> cflags: Set the C compiler flags.
         -> cxflags: Set the C/C++ compiler flags.
         -> cxxflags: Set the C++ compiler flags.
         -> asflags: Set the assembler flags.
         -> ldflags: Set the binary linker flags.
         -> shflags: Set the shared library linker flags.

    require(expat): 
      -> description: XML 1.0 parser
      -> version: 2.8.1
      -> license: MIT
      -> urls:
         -> default:
            -> https://github.com/libexpat/libexpat/releases/download/R_2_8_1/expat-2.8.1.tar.bz2
               -> f5833dd2e1cd7739ec9182804a1a29c4f0cc7c2f26b633d3a2188b7766a88ecb
      -> repo: local-repo /home/lin/xmake-repo 
      -> deps:
         -> ninja
         -> cmake
      -> cachedir: /home/lin/.xmake/cache/packages/2607/e/expat/2.8.1
      -> installdir: /home/lin/.xmake/packages/e/expat/2.8.1/46753e6d27b14236b43502cb2c3973ba
      -> searchdirs: 
      -> searchnames:
         -> expat-2.8.1.tar.bz2
finding expat from xmake ..
checking for xmake::expat ... no
finding expat from vcpkg ..
checking for brew ... no
finding expat from conan ..
checking for expat ... no
      -> fetchinfo: 2.8.1, remote(in local-repo)
      -> platforms: all
      -> requires:
         -> plat: wasm
         -> arch: wasm32
         -> configs:
            -> char_type: char
            -> pic: true
            -> debug: false
            -> shared: false
      -> configs:
         -> char_type: Character type to use (default: char)
            -> values: {"char","ushort","wchar_t"}
      -> configs (builtin):
         -> debug: Enable debug symbols. (default: false)
         -> shared: Build shared library. (default: false)
         -> pic: Enable the position independent code. (default: true)
         -> lto: Enable the link-time build optimization. (type: boolean)
         -> asan: Enable the address sanitizer. (type: boolean)
         -> runtimes: Set the compiler runtimes.
            -> values: {"MT","MTd","MD","MDd","c++_static","c++_shared","stdc++_static","stdc++_shared"}
         -> vs_runtime: Set vs compiler runtime.
            -> values: {"MT","MTd","MD","MDd"}
         -> toolchains: Set package toolchains only for cross-compilation.
         -> cflags: Set the C compiler flags.
         -> cxflags: Set the C/C++ compiler flags.
         -> cxxflags: Set the C++ compiler flags.
         -> asflags: Set the assembler flags.
         -> ldflags: Set the binary linker flags.
         -> shflags: Set the shared library linker flags.

    require(dbus): 
      -> description: D-Bus is a message bus system, a simple way for applications to talk to one another.
      -> version: 1.16.2
      -> license: GPL-2.0-or-later
      -> urls:
         -> default:
            -> https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-1.16.2/dbus-dbus-1.16.2.tar.gz
               -> d77cc71acd93e85f2bd2a6fe3a40e5bd023519e3e9fa9b5361e7109f42b74060
      -> repo: local-repo /home/lin/xmake-repo 
      -> deps:
         -> ninja
         -> cmake
         -> expat
      -> cachedir: /home/lin/.xmake/cache/packages/2607/d/dbus/1.16.2
      -> installdir: /home/lin/.xmake/packages/d/dbus/1.16.2/d74c3d6bd69d4dc29db9ec70cf3489e3
      -> searchdirs: 
      -> searchnames:
         -> dbus-1.16.2.tar.gz
         -> dbus-dbus-1.16.2.tar.gz
finding dbus from xmake ..
checking for xmake::dbus ... no
finding dbus from vcpkg ..
finding dbus from conan ..
checking for dbus ... no
      -> fetchinfo: 1.16.2, remote(in local-repo)
      -> platforms: all
      -> requires:
         -> plat: wasm
         -> arch: wasm32
         -> configs:
            -> pic: true
            -> debug: false
            -> shared: true
      -> configs:
         -> shared: Build shared library. (default: true) (readonly)
         -> system_bus_address: D-Bus system bus address.
      -> configs (builtin):
         -> debug: Enable debug symbols. (default: false)
         -> pic: Enable the position independent code. (default: true)
         -> lto: Enable the link-time build optimization. (type: boolean)
         -> asan: Enable the address sanitizer. (type: boolean)
         -> runtimes: Set the compiler runtimes.
            -> values: {"MT","MTd","MD","MDd","c++_static","c++_shared","stdc++_static","stdc++_shared"}
         -> vs_runtime: Set vs compiler runtime.
            -> values: {"MT","MTd","MD","MDd"}
         -> toolchains: Set package toolchains only for cross-compilation.
         -> cflags: Set the C compiler flags.
         -> cxflags: Set the C/C++ compiler flags.
         -> cxxflags: Set the C++ compiler flags.
         -> asflags: Set the assembler flags.
         -> ldflags: Set the binary linker flags.
         -> shflags: Set the shared library linker flags.

wasm32 { 
  "wasm32",
  "wasm64" 
}

checking for platform ... wasm (wasm32)
checking for emsdk directory ... /usr/lib/emscripten
configure
{
    ndk_stdcxx = true
    builddir = build
    ccache = true
    emsdk = /usr/lib/emscripten
    plat = wasm
    arch = wasm32
    kind = static
    host = linux
    network = public
    theme = default
    mode = release
    clean = true
    proxy_pac = pac.lua
}
testing to check packages ...
checking for git ... /usr/bin/git
/usr/bin/git rev-parse HEAD
testing to install packages ...
checking for git ... /usr/bin/git
checking for gzip ... /usr/bin/gzip
checking for tar ... /usr/bin/tar
/usr/bin/git rev-parse HEAD
checking for gcc ... /usr/bin/gcc
checking for Ascend SDK directory ... no
checking for zig ... /usr/bin/zig
checkinfo: cannot runv(nim --version), No such file or directory
checking for nim ... no
checking for dotnet ... /usr/bin/dotnet
checking for .NET SDK version ... 10.0.300
checking for .NET SDK directory ... /usr/share/dotnet/sdk/10.0.300
checking for ninja ... no
checking for cmake ... no
finding expat from xmake ..
checking for xmake::expat ... no
finding expat from vcpkg ..
checking for brew ... no
finding expat from conan ..
checking for expat ... no
checking for curl ... /usr/bin/curl
pinging the host(github.com) ... 243 ms
pinging the host(gitlab.freedesktop.org) ... 515 ms
/usr/bin/tar -xf /home/lin/.xmake/cache/packages/2607/e/expat/2.8.1/expat-2.8.1.tar.bz2 -C source.tmp
checking for emcc ... /usr/lib/emscripten/emcc
checking for the c compiler (cc) ... emcc
checking for ninja ... /home/lin/.xmake/packages/n/ninja/v1.13.2/0a9451759a4647b5923438b464085dd6/bin/ninja
checking for em++ ... /usr/lib/emscripten/em++
checking for the linker (ld) ... em++
error: @programdir/modules/package/tools/cmake.lua:605: emscripten not found!
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:1193]: in function 'raiselevel'
    [@programdir/core/sandbox/modules/utils.lua:144]: in function 'assert'
    [@programdir/modules/package/tools/cmake.lua:605]: in function '_get_configs_for_wasm'
    [@programdir/modules/package/tools/cmake.lua:933]: in function '_get_configs'
    [@programdir/modules/package/tools/cmake.lua:1309]: in function 'configure'
    [@programdir/modules/package/tools/cmake.lua:1368]: in function 'install'
    [/home/lin/xmake-repo/packages/e/expat/xmake.lua:49]: in function 'script'
    [...dir/modules/private/action/require/impl/utils/filter.lua:114]: in function 'call'
    [.../modules/private/action/require/impl/actions/install.lua:484]:

  => install expat 2.8.1 .. failed
error: @programdir/core/main.lua:274: @programdir/modules/async/runjobs.lua:282: .../modules/private/action/require/impl/actions/install.lua:596: install failed!
stack traceback:
    [C]: in function 'error'
    [@programdir/core/base/os.lua:1193]:
    [.../modules/private/action/require/impl/actions/install.lua:596]: in function 'catch'
    [@programdir/core/sandbox/modules/try.lua:123]: in function 'try'
    [.../modules/private/action/require/impl/actions/install.lua:451]:
    [...modules/private/action/require/impl/install_packages.lua:514]: in function 'job_func'
    [@programdir/modules/async/runjobs.lua:462]:

stack traceback:
        [C]: in global 'error'
        @programdir/core/base/os.lua:1193: in function 'base/os.raiselevel'
        (...tail calls...)
        @programdir/core/main.lua:274: in upvalue 'cotask'
        @programdir/core/base/scheduler.lua:531: in function <@programdir/core/base/scheduler.lua:524>
error: execv(/home/lin/.local/bin/xmake require -f -y --build -v -D --shallow --extra={configs={shared=true}} dbus) failed(255), unknown reason
```

</details> 
