### PR TITLE
Update NDK's sdkver for riscv64 architecture

### DIFF
--- a/xmake/modules/detect/sdks/find_ndk.lua
+++ b/xmake/modules/detect/sdks/find_ndk.lua
@@ -95,7 +95,7 @@ function _find_ndk_sdkver(sdkdir, bindir, sysroot, arch)
     -- try to select the best compatible version
     local sdkver = "16"
     if use_llvm or arch == "arm64-v8a" or arch == "riscv64" then
-        sdkver = (arch == "riscv64") and "35" or "21"
+        sdkver = (arch == "riscv64") and "36" or "21"
     end
     if sysroot then
         if os.isdir(path.join(sysroot, "usr", "lib", triple, sdkver)) then


### PR DESCRIPTION
When the riscv64 architecture was first introduced, it was at 35, but that version was never usable outside of internal dev environments, the libraries for linking are actually in `36`.

<img width="1242" height="357" alt="image" src="https://github.com/user-attachments/assets/79b4694c-1987-46a6-a3d3-1e96ff1c22a7" />

vs.

<img width="1241" height="220" alt="image" src="https://github.com/user-attachments/assets/1fbc792e-b974-4b8d-ad82-9de65584d1ed" />
