### PR TITLE
fix(macOS): fix Mach host send-right leaks

### DIFF
--- a/core/src/xmake/os/cpuinfo.c
+++ b/core/src/xmake/os/cpuinfo.c
@@ -70,8 +70,9 @@ static tb_float_t xm_os_cpuinfo_usagerate() {
     processor_info_array_t cpuinfo;
     mach_msg_type_number_t cpuinfo_count;
     static tb_hong_t s_time = 0;
+    host_t host = mach_host_self();
     if (tb_mclock() - s_time > 1000 &&
-        host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &cpu_count, &cpuinfo, &cpuinfo_count) ==
+        host_processor_info(host, PROCESSOR_CPU_LOAD_INFO, &cpu_count, &cpuinfo, &cpuinfo_count) ==
             KERN_SUCCESS) {
         static processor_info_array_t s_cpuinfo_prev = tb_null;
         static mach_msg_type_number_t s_cpuinfo_count_prev = 0;
@@ -100,6 +101,7 @@ static tb_float_t xm_os_cpuinfo_usagerate() {
         s_cpuinfo_prev = cpuinfo;
         s_cpuinfo_count_prev = cpuinfo_count;
     }
+    mach_port_deallocate(mach_task_self(), host);
     return cpu_count > 0 ? usagerate / cpu_count : 0;
 #elif defined(TB_CONFIG_OS_WINDOWS)
     // kernel include idle_time

--- a/core/src/xmake/os/meminfo.c
+++ b/core/src/xmake/os/meminfo.c
@@ -61,7 +61,10 @@ static tb_bool_t xm_os_meminfo_stats(tb_int_t *ptotalsize, tb_int_t *pavailsize)
 #if defined(TB_CONFIG_OS_MACOSX)
     vm_statistics64_data_t vmstat;
     mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
-    if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info_t)&vmstat, &count) == KERN_SUCCESS) {
+    host_t host = mach_host_self();
+    kern_return_t result = host_statistics64(host, HOST_VM_INFO64, (host_info_t)&vmstat, &count);
+    mach_port_deallocate(mach_task_self(), host);
+    if (result == KERN_SUCCESS) {
         tb_int_t pagesize = (tb_int_t)tb_page_size();
         tb_int64_t totalsize = (tb_int64_t)(vmstat.inactive_count + vmstat.free_count + vmstat.active_count +
                                             vmstat.wire_count


### PR DESCRIPTION
mach_host_self() increments the task send-right user-reference count, but the CPU and memory queries did not release those references.

Reuse each returned host port for its query and deallocate it afterward on both successful and failed query paths.

