### PR TITLE
fix masm symbol flags for embed/edit levels (A4018)

### DIFF
--- a/xmake/modules/core/tools/ml.lua
+++ b/xmake/modules/core/tools/ml.lua
@@ -35,7 +35,7 @@ function init(self)
     self:set("mapflags",
     {
         -- symbols
-        ["-g"]                      = "-Z7"
+        ["-g"]                      = "-Zi"
     ,   ["-fvisibility=.*"]         = ""
 
         -- warnings
@@ -55,20 +55,14 @@ function init(self)
 end
 
 -- make the symbol flags
+--
+-- masm only supports -Zi/-Zd, the -Z7 and -ZI flags of cl.exe are rejected (A4018).
+-- -Zi already embeds debug info in the object file (masm has no compile-time pdb),
+-- so the "embed" and "edit" levels degrade to it.
 function nf_symbols(self, levels)
-    local flags = nil
-    local values = hashset.from(levels)
-    if values:has("debug") then
-        flags = {}
-        if values:has("edit") then
-            table.insert(flags, "-ZI")
-        elseif values:has("embed") then
-            table.insert(flags, "-Z7")
-        else
-            table.insert(flags, "-Zi")
-        end
+    if hashset.from(levels):has("debug") then
+        return {"-Zi"}
     end
-    return flags
 end
 
 -- make the warning flag


### PR DESCRIPTION
Fixes #7675

MASM (`ml.exe`/`ml64.exe`) only supports `-Zi`/`-Zd` for debug info; the cl.exe flags `-Z7` and `-ZI` are rejected with `warning A4018: invalid command-line option` ([ML and ML64 command-line reference](https://learn.microsoft.com/en-us/cpp/assembler/masm/ml-and-ml64-command-line-reference)). Because A4018 is a warning, the outcome depends on warning settings:

- without `-WX`: the flag is silently dropped and the assembled objects contain **no debug info**, despite `set_symbols("debug", "embed")` asking for it
- with `set_warnings(..., "error")`: hard build failure

Since MASM's `-Zi` writes debug info directly into the object file (there is no compile-time PDB for MASM), `-Zi` already is the embedded form — this PR makes the `embed` and `edit` levels degrade to `-Zi` in `nf_symbols`, and fixes the same problem in the gcc-style `mapflags` entry for `-g`.

`ml64.lua` inherits `ml.lua`, so both assemblers are covered; the ARM assembler modules are separate and unaffected.

Verified on ml64 14.51 (VS 2026) with a mixed C/MASM x64 project using `set_symbols("debug", "embed")` + `set_warnings("allextra", "error")`: before — `MASM : warning A4018:invalid command-line option : /Z7` (build failure under `-WX`); after — ml64 receives `-Zi -WX` with no diagnostics, cl.exe still correctly receives `-Z7`, build and run OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)