### PR TITLE
fix set_pcheader for msvc in c mode

### DIFF
--- a/xmake/modules/private/action/build/pcheader.lua
+++ b/xmake/modules/private/action/build/pcheader.lua
@@ -38,12 +38,24 @@ function config(target, langkind, opt)
             -- https://github.com/xmake-io/xmake/issues/2667
             -- https://github.com/xmake-io/xmake/issues/5858
             if not os.isfile(headerfile) then
-                io.writefile(headerfile, ([[
+                local langcxx = (langkind == "cxx" or langkind == "mxx")
+                local content
+                if langcxx then
+                    content = [[
 #pragma system_header
 #ifdef __cplusplus
 #include "%s"
 #endif // __cplusplus
-                ]]):format(path.absolute(pcheaderfile):gsub("\\", "/")))
+                    ]]
+                else
+                    content = [[
+#pragma system_header
+#ifndef __cplusplus
+#include "%s"
+#endif
+                    ]]
+                end
+                io.writefile(headerfile, content:format(path.absolute(pcheaderfile):gsub("\\", "/")))
             end
             -- we need only to add a header wrapper in .gch directory
             -- @see https://github.com/xmake-io/xmake/issues/5858#issuecomment-2506918167


### PR DESCRIPTION
On the Windows platform, when using MSVC compiler, the header file generated by the `set_pcheader` incorrectly uses the `#ifdef __cplusplus` conditional compilation statement, causing the feature to fail in C. This results in spurious LSP diagnostics and compilation failures in certain scenarios. After this fix, the behavior remains unchanged in C++, while in C, `#ifndef __cplusplus` will be used instead of completely removing the conditional check, in order to isolate the C/C++ environments.

------

在 Windows 平台，使用 MSVC 编译器时，`set_pcheader` 功能生成的用于中转的头文件错误地使用了 `#ifdef __cplusplus` 条件编译语句，致使该功能在 C 语言模式下失效，导致 lsp 的多余报错以及部分场景下的编译失败。修改后，在 C++ 模式下的行为保持不变，而 C 语言模式下将使用 `#ifndef __cplusplus` 而非完全删除该判断，用以隔离 C/C++ 环境。

