### PR TITLE
Fix ninja project generator: emit build edge for Windows .rc resource files

### DIFF
--- a/xmake/plugins/project/ninja/build_ninja.lua
+++ b/xmake/plugins/project/ninja/build_ninja.lua
@@ -37,7 +37,8 @@ function _sourcebatch_is_built(sourcebatch)
     local rulename = sourcebatch.rulename
     if rulename == "c.build" or rulename == "c++.build"
         or rulename == "asm.build" or rulename == "cuda.build"
-        or rulename == "objc.build" or rulename == "objc++.build" then
+        or rulename == "objc.build" or rulename == "objc++.build"
+        or rulename == "win.sdk.resource" then
         return true
     end
 end


### PR DESCRIPTION
Fixes #7682

`xmake project -k ninja` emitted the `rule mrc` definition and listed the `.rc.obj` among the link inputs, but never generated a `build <obj>: mrc <src>` edge, because `_sourcebatch_is_built()` did not whitelist the `win.sdk.resource` rule. A clean ninja build therefore failed with:

```
ninja: error: 'build/.objs/hello/windows/x64/release/src/hello.rc.obj', needed by 'build/windows/x64/release/hello.exe', missing and no known rule to make it
```

This adds `win.sdk.resource` to the whitelist. The batch's sourcekind is `mrc`, matching the emitted rule name, so the generic `_add_build_for_objects()` path produces a correct edge.

Verified locally on Windows: with this change the generated `build.ninja` contains the `mrc` build edge and a clean ninja build of a project with `.rc` files (two targets) succeeds end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)