### PR TITLE
fix: fix deprecated warnings

### DIFF
--- a/core/src/xmake/binutils/ar/extractlib.c
+++ b/core/src/xmake/binutils/ar/extractlib.c
@@ -212,7 +212,7 @@ tb_bool_t xm_binutils_ar_extract(tb_stream_ref_t istream, tb_char_t const *outpu
             ok = tb_false;
         }
 
-        tb_stream_clos(ostream);
+        tb_stream_close(ostream);
         tb_stream_exit(ostream);
 
         tb_check_break(ok);

--- a/core/src/xmake/binutils/extractlib.c
+++ b/core/src/xmake/binutils/extractlib.c
@@ -129,7 +129,7 @@ tb_int_t xm_binutils_extractlib(lua_State *lua) {
     } while (0);
 
     if (istream) {
-        tb_stream_clos(istream);
+        tb_stream_close(istream);
         tb_stream_exit(istream);
     }
 

--- a/core/src/xmake/io/file_close.c
+++ b/core/src/xmake/io/file_close.c
@@ -68,7 +68,7 @@ tb_int_t xm_io_file_close(lua_State *lua) {
         }
 
         // close file
-        tb_stream_clos(file->u.file_ref);
+        tb_stream_close(file->u.file_ref);
         file->u.file_ref = tb_null;
 
         // exit fstream

--- a/core/src/xmake/io/file_write.c
+++ b/core/src/xmake/io/file_write.c
@@ -110,7 +110,7 @@ static tb_void_t xm_io_file_write_std(xm_io_file_t *file, tb_byte_t const *data,
     tb_check_return(type != XM_IO_FILE_TYPE_STDIN);
 
     // write data to stdout/stderr
-    tb_stdfile_writ(file->u.std_ref, data, size);
+    tb_stdfile_write(file->u.std_ref, data, size);
 }
 
 /* //////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Replace all functions marked as deprecated by tbox.

It generates lots of warnings:

```console
  core/src/xmake/binutils/extractlib.c: In function 'xm_binutils_extractlib':
  core/src/xmake/binutils/extractlib.c:132:9: warning: 'tb_stream_clos' is deprecated [-Wdeprecated-declarations]
           tb_stream_clos(istream);
           ^~~~~~~~~~~~~~
  In file included from core/src/tbox/tbox/src/tbox/../tbox/xml/prefix.h:30,
                   from core/src/tbox/tbox/src/tbox/../tbox/xml/xml.h:28,
                   from core/src/tbox/tbox/src/tbox/../tbox/tbox.h:29,
                   from core/src/xmake/binutils/../prefix/config.h:28,
  compiling.release core/src/xmake/binutils/rpath.c
                   from core/src/xmake/binutils/../prefix/prefix.h:27,
                   from core/src/xmake/binutils/../prefix.h:27,
                   from core/src/xmake/binutils/prefix.h:27,
                   from core/src/xmake/binutils/extractlib.c:31:
  core/src/tbox/tbox/src/tbox/../tbox/xml/../stream/stream.h:573:25: note: declared here
   tb_bool_t               tb_stream_clos(tb_stream_ref_t stream);
  compiling.release core/src/xmake/binutils/coff/bin2coff.c
                           ^~~~~~~~

  core/src/xmake/io/file_write.c: In function 'xm_io_file_write_std':
  core/src/xmake/io/file_write.c:113:5: warning: 'tb_stdfile_writ' is deprecated [-Wdeprecated-declarations]
       tb_stdfile_writ(file->u.std_ref, data, size);
       ^~~~~~~~~~~~~~~
  In file included from core/src/tbox/tbox/src/tbox/../tbox/xml/../platform/platform.h:48,
                   from core/src/tbox/tbox/src/tbox/../tbox/xml/prefix.h:33,
                   from core/src/tbox/tbox/src/tbox/../tbox/xml/xml.h:28,
                   from core/src/tbox/tbox/src/tbox/../tbox/tbox.h:29,
                   from core/src/xmake/io/../prefix/config.h:28,
                   from core/src/xmake/io/../prefix/prefix.h:27,
                   from core/src/xmake/io/../prefix.h:27,
                   from core/src/xmake/io/prefix.h:27,
                   from core/src/xmake/io/file_write.c:31:
  core/src/tbox/tbox/src/tbox/../tbox/xml/../platform/stdfile.h:126:25: note: declared here
   tb_bool_t               tb_stdfile_writ(tb_stdfile_ref_t file, tb_byte_t const* data, tb_size_t size);
                           ^~~~~~~~~~~~~~~
```
