### PR TITLE
fix(semver): correct version selection

### DIFF
--- a/core/src/xmake/semver/select.c
+++ b/core/src/xmake/semver/select.c
@@ -49,6 +49,24 @@ static tb_bool_t xm_semver_is_exact_version(tb_char_t const *version_str, tb_siz
     }
     return tb_false;
 }
+static tb_long_t xm_semver_compare_with_build(semver_t const *left, semver_t const *right) {
+    tb_long_t result = semver_pcmp(left, right);
+    // xmake-repo orders build metadata as package revisions
+    return result ? result : tb_strcmp(left->build.raw ? left->build.raw : "",
+                                       right->build.raw ? right->build.raw : "");
+}
+static semver_t const *xm_semvers_find_newest(semvers_t const *versions) {
+    tb_assert_and_check_return_val(versions && versions->length, tb_null);
+
+    semver_t const *newest = &versions->data[0];
+    tb_size_t i = 0;
+    for (i = 1; i < versions->length; ++i) {
+        if (xm_semver_compare_with_build(&versions->data[i], newest) > 0) {
+            newest = &versions->data[i];
+        }
+    }
+    return newest;
+}
 static tb_bool_t xm_semver_select_from_versions_tags1(
     lua_State *lua, tb_int_t fromidx, semver_t *semver, semver_range_t const *range, semvers_t *matches) {
     // clear matches
@@ -75,22 +93,16 @@ static tb_bool_t xm_semver_select_from_versions_tags1(
     // no matches?
     tb_check_return_val(matches->length, tb_false);
 
-    // sort matches
-    semvers_psort(matches);
-
     // get the newest version
-    semver_t top = semvers_ppop(matches);
+    semver_t const *top = xm_semvers_find_newest(matches);
     lua_createtable(lua, 0, 2);
 
     // return results
-    lua_pushstring(lua, top.raw);
+    lua_pushstring(lua, top->raw);
     lua_setfield(lua, -2, "version");
 
     lua_pushstring(lua, fromidx == 2 ? "version" : "tag");
     lua_setfield(lua, -2, "source");
-
-    // exit the popped semver
-    semver_dtor(&top);
 
     return tb_true;
 }
@@ -167,21 +179,17 @@ static tb_bool_t xm_semver_select_latest_from_versions_tags(lua_State *lua,
     }
     tb_check_return_val(matches->length, tb_false);
 
-    // sort matches
-    semvers_psort(matches);
-
     // get the newest match
-    semver_t top = semvers_ppop(matches);
+    semver_t const *top = xm_semvers_find_newest(matches);
     lua_createtable(lua, 0, 2);
 
     // return results
-    lua_pushstring(lua, top.raw);
+    lua_pushstring(lua, top->raw);
     lua_setfield(lua, -2, "version");
 
     lua_pushstring(lua, fromidx == 2 ? "version" : "tag");
     lua_setfield(lua, -2, "source");
 
-    semver_dtor(&top);
     return tb_true;
 }
 

--- a/core/src/xmake/semver/select.c
+++ b/core/src/xmake/semver/select.c
@@ -216,26 +216,27 @@ tb_int_t xm_semver_select(lua_State *lua) {
         is_range = semver_rangen(&range, range_str, range_len) == 0;
         is_exact = xm_semver_is_exact_version(range_str, range_len);
 
-        // attempt to select version from the versions list first
-        if ((is_exact || !is_range) &&
-            xm_semver_select_from_versions_tags2(lua, 2, range_str, range_len)) {
-            ok = tb_true;
-            break;
-        }
-        if (is_range && xm_semver_select_from_versions_tags1(lua, 2, &semver, &range, &matches)) {
-            ok = tb_true;
-            break;
+        // matching order: versions exact -> tags exact -> versions range -> tags range
+        if (is_exact || !is_range) {
+            if (xm_semver_select_from_versions_tags2(lua, 2, range_str, range_len)) {
+                ok = tb_true;
+                break;
+            }
+            if (xm_semver_select_from_versions_tags2(lua, 3, range_str, range_len)) {
+                ok = tb_true;
+                break;
+            }
         }
 
-        // attempt to select version from the tags list
-        if ((is_exact || !is_range) &&
-            xm_semver_select_from_versions_tags2(lua, 3, range_str, range_len)) {
-            ok = tb_true;
-            break;
-        }
-        if (is_range && xm_semver_select_from_versions_tags1(lua, 3, &semver, &range, &matches)) {
-            ok = tb_true;
-            break;
+        if (is_range) {
+            if (xm_semver_select_from_versions_tags1(lua, 2, &semver, &range, &matches)) {
+                ok = tb_true;
+                break;
+            }
+            if (xm_semver_select_from_versions_tags1(lua, 3, &semver, &range, &matches)) {
+                ok = tb_true;
+                break;
+            }
         }
 
         // attempt to select version from the branches

--- a/core/src/xmake/semver/select.c
+++ b/core/src/xmake/semver/select.c
@@ -33,6 +33,14 @@
 /* //////////////////////////////////////////////////////////////////////////////////////
  * private implementation
  */
+static tb_bool_t xm_semver_is_exact_version(tb_char_t const *version_str, tb_size_t version_len) {
+    semver_t version = { 0 };
+    if (!semvern(&version, version_str, version_len)) {
+        semver_dtor(&version);
+        return tb_true;
+    }
+    return tb_false;
+}
 static tb_bool_t xm_semver_select_from_versions_tags1(
     lua_State *lua, tb_int_t fromidx, semver_t *semver, semver_range_t const *range, semvers_t *matches) {
     // clear matches
@@ -179,6 +187,7 @@ tb_int_t xm_semver_select(lua_State *lua) {
     // select version
     tb_bool_t ok = tb_false;
     tb_bool_t is_range = tb_false;
+    tb_bool_t is_exact = tb_false;
     tb_char_t const *range_str = tb_null;
     semver_t semver = { 0 };
     semvers_t matches = { 0 };
@@ -193,30 +202,28 @@ tb_int_t xm_semver_select(lua_State *lua) {
 
         // parse the version range string
         is_range = semver_rangen(&range, range_str, range_len) == 0;
-        if (is_range) {
-            // attempt to select version from the versions list first
-            if (xm_semver_select_from_versions_tags1(lua, 2, &semver, &range, &matches)) {
-                ok = tb_true;
-                break;
-            }
+        is_exact = xm_semver_is_exact_version(range_str, range_len);
 
-            // attempt to select version from the tags list
-            if (xm_semver_select_from_versions_tags1(lua, 3, &semver, &range, &matches)) {
-                ok = tb_true;
-                break;
-            }
-        } else {
-            // attempt to select version from the versions list first
-            if (xm_semver_select_from_versions_tags2(lua, 2, &semver, range_str, range_len)) {
-                ok = tb_true;
-                break;
-            }
+        // attempt to select version from the versions list first
+        if ((is_exact || !is_range) &&
+            xm_semver_select_from_versions_tags2(lua, 2, &semver, range_str, range_len)) {
+            ok = tb_true;
+            break;
+        }
+        if (is_range && xm_semver_select_from_versions_tags1(lua, 2, &semver, &range, &matches)) {
+            ok = tb_true;
+            break;
+        }
 
-            // attempt to select version from the tags list
-            if (xm_semver_select_from_versions_tags2(lua, 3, &semver, range_str, range_len)) {
-                ok = tb_true;
-                break;
-            }
+        // attempt to select version from the tags list
+        if ((is_exact || !is_range) &&
+            xm_semver_select_from_versions_tags2(lua, 3, &semver, range_str, range_len)) {
+            ok = tb_true;
+            break;
+        }
+        if (is_range && xm_semver_select_from_versions_tags1(lua, 3, &semver, &range, &matches)) {
+            ok = tb_true;
+            break;
         }
 
         // attempt to select version from the branches

--- a/core/src/xmake/semver/select.c
+++ b/core/src/xmake/semver/select.c
@@ -40,20 +40,49 @@ static tb_char_t const *xm_semver_skip_version_prefix(tb_char_t const *version_s
     }
     return version_str;
 }
-static tb_bool_t xm_semver_is_exact_version(tb_char_t const *version_str, tb_size_t version_len) {
+static tb_bool_t xm_semver_is_exact_version(
+    tb_char_t const *version_str, tb_size_t version_len, tb_bool_t *is_exact_with_build) {
+    *is_exact_with_build = tb_false;
     version_str = xm_semver_skip_version_prefix(version_str, &version_len);
     semver_t version = { 0 };
     if (!semvern(&version, version_str, version_len)) {
+        *is_exact_with_build = version.build.len > 0;
         semver_dtor(&version);
         return tb_true;
     }
     return tb_false;
 }
+static tb_long_t xm_semver_compare_build(semver_id_t const *left, semver_id_t const *right) {
+    while (left && right && left->len && right->len) {
+        if (left->numeric && right->numeric) {
+            if (left->num != right->num) {
+                return left->num > right->num ? 1 : -1;
+            }
+        } else {
+            tb_size_t size = left->len < right->len ? left->len : right->len;
+            tb_long_t result = tb_memcmp(left->raw, right->raw, size);
+            if (result) {
+                return result;
+            }
+            if (left->len != right->len) {
+                return left->len > right->len ? 1 : -1;
+            }
+        }
+        left = left->next;
+        right = right->next;
+    }
+    if (left && left->len) {
+        return 1;
+    }
+    if (right && right->len) {
+        return -1;
+    }
+    return 0;
+}
 static tb_long_t xm_semver_compare_with_build(semver_t const *left, semver_t const *right) {
     tb_long_t result = semver_pcmp(left, right);
     // xmake-repo orders build metadata as package revisions
-    return result ? result : tb_strcmp(left->build.raw ? left->build.raw : "",
-                                       right->build.raw ? right->build.raw : "");
+    return result ? result : xm_semver_compare_build(&left->build, &right->build);
 }
 static semver_t const *xm_semvers_find_newest(semvers_t const *versions) {
     tb_assert_and_check_return_val(versions && versions->length, tb_null);
@@ -107,8 +136,10 @@ static tb_bool_t xm_semver_select_from_versions_tags1(
     return tb_true;
 }
 static tb_bool_t xm_semver_select_from_versions_tags2(
-    lua_State *lua, tb_int_t fromidx, tb_char_t const *version_str, tb_size_t version_len) {
-    version_str = xm_semver_skip_version_prefix(version_str, &version_len);
+    lua_State *lua, tb_int_t fromidx, tb_char_t const *version_str, tb_size_t version_len, tb_bool_t is_exact) {
+    if (is_exact) {
+        version_str = xm_semver_skip_version_prefix(version_str, &version_len);
+    }
     lua_Integer i = 0;
     luaL_checktype(lua, fromidx, LUA_TTABLE);
     for (i = lua_objlen(lua, fromidx); i > 0; --i) {
@@ -118,9 +149,12 @@ static tb_bool_t xm_semver_select_from_versions_tags2(
         tb_char_t const *source_str = luaL_checkstring(lua, -1);
         tb_size_t source_len = tb_strlen(source_str);
         tb_size_t source_version_len = source_len;
-        tb_char_t const *source_version_str = xm_semver_skip_version_prefix(source_str, &source_version_len);
+        tb_char_t const *source_version_str = source_str;
+        // ignore a leading v/= prefix when comparing exact versions
+        if (is_exact) {
+            source_version_str = xm_semver_skip_version_prefix(source_str, &source_version_len);
+        }
         lua_pop(lua, 1);
-        // semver comparison ignores build metadata, so compare the normalized strings
         if (source_version_len == version_len && tb_strncmp(source_version_str, version_str, version_len) == 0) {
             lua_createtable(lua, 0, 2);
             lua_pushlstring(lua, source_str, source_len);
@@ -208,6 +242,7 @@ tb_int_t xm_semver_select(lua_State *lua) {
     tb_bool_t ok = tb_false;
     tb_bool_t is_range = tb_false;
     tb_bool_t is_exact = tb_false;
+    tb_bool_t is_exact_with_build = tb_false;
     tb_char_t const *range_str = tb_null;
     semver_t semver = { 0 };
     semvers_t matches = { 0 };
@@ -222,21 +257,22 @@ tb_int_t xm_semver_select(lua_State *lua) {
 
         // parse the version range string
         is_range = semver_rangen(&range, range_str, range_len) == 0;
-        is_exact = xm_semver_is_exact_version(range_str, range_len);
+        is_exact = xm_semver_is_exact_version(range_str, range_len, &is_exact_with_build);
 
         // matching order: versions exact -> tags exact -> versions range -> tags range
         if (is_exact || !is_range) {
-            if (xm_semver_select_from_versions_tags2(lua, 2, range_str, range_len)) {
+            if (xm_semver_select_from_versions_tags2(lua, 2, range_str, range_len, is_exact)) {
                 ok = tb_true;
                 break;
             }
-            if (xm_semver_select_from_versions_tags2(lua, 3, range_str, range_len)) {
+            if (xm_semver_select_from_versions_tags2(lua, 3, range_str, range_len, is_exact)) {
                 ok = tb_true;
                 break;
             }
         }
 
-        if (is_range) {
+        // a build-qualified exact version identifies a specific package revision
+        if (is_range && !is_exact_with_build) {
             if (xm_semver_select_from_versions_tags1(lua, 2, &semver, &range, &matches)) {
                 ok = tb_true;
                 break;

--- a/core/src/xmake/semver/select.c
+++ b/core/src/xmake/semver/select.c
@@ -33,7 +33,15 @@
 /* //////////////////////////////////////////////////////////////////////////////////////
  * private implementation
  */
+static tb_char_t const *xm_semver_skip_version_prefix(tb_char_t const *version_str, tb_size_t *version_len) {
+    if (*version_len && (version_str[0] == 'v' || version_str[0] == '=')) {
+        ++version_str;
+        --*version_len;
+    }
+    return version_str;
+}
 static tb_bool_t xm_semver_is_exact_version(tb_char_t const *version_str, tb_size_t version_len) {
+    version_str = xm_semver_skip_version_prefix(version_str, &version_len);
     semver_t version = { 0 };
     if (!semvern(&version, version_str, version_len)) {
         semver_dtor(&version);
@@ -87,7 +95,8 @@ static tb_bool_t xm_semver_select_from_versions_tags1(
     return tb_true;
 }
 static tb_bool_t xm_semver_select_from_versions_tags2(
-    lua_State *lua, tb_int_t fromidx, semver_t *semver, tb_char_t const *version_str, tb_size_t version_len) {
+    lua_State *lua, tb_int_t fromidx, tb_char_t const *version_str, tb_size_t version_len) {
+    version_str = xm_semver_skip_version_prefix(version_str, &version_len);
     lua_Integer i = 0;
     luaL_checktype(lua, fromidx, LUA_TTABLE);
     for (i = lua_objlen(lua, fromidx); i > 0; --i) {
@@ -96,8 +105,11 @@ static tb_bool_t xm_semver_select_from_versions_tags2(
 
         tb_char_t const *source_str = luaL_checkstring(lua, -1);
         tb_size_t source_len = tb_strlen(source_str);
+        tb_size_t source_version_len = source_len;
+        tb_char_t const *source_version_str = xm_semver_skip_version_prefix(source_str, &source_version_len);
         lua_pop(lua, 1);
-        if (source_len == version_len && tb_strncmp(source_str, version_str, version_len) == 0) {
+        // semver comparison ignores build metadata, so compare the normalized strings
+        if (source_version_len == version_len && tb_strncmp(source_version_str, version_str, version_len) == 0) {
             lua_createtable(lua, 0, 2);
             lua_pushlstring(lua, source_str, source_len);
             lua_setfield(lua, -2, "version");
@@ -206,7 +218,7 @@ tb_int_t xm_semver_select(lua_State *lua) {
 
         // attempt to select version from the versions list first
         if ((is_exact || !is_range) &&
-            xm_semver_select_from_versions_tags2(lua, 2, &semver, range_str, range_len)) {
+            xm_semver_select_from_versions_tags2(lua, 2, range_str, range_len)) {
             ok = tb_true;
             break;
         }
@@ -217,7 +229,7 @@ tb_int_t xm_semver_select(lua_State *lua) {
 
         // attempt to select version from the tags list
         if ((is_exact || !is_range) &&
-            xm_semver_select_from_versions_tags2(lua, 3, &semver, range_str, range_len)) {
+            xm_semver_select_from_versions_tags2(lua, 3, range_str, range_len)) {
             ok = tb_true;
             break;
         }

--- a/tests/modules/semver/test.lua
+++ b/tests/modules/semver/test.lua
@@ -30,6 +30,10 @@ function test_semver_select(t)
                         , "1.2.3"
                         , {"1.2.3+1", "1.2.3"})
 
+    _check_semver_select(t, {"1.2.3", "version"}
+                        , "=1.2.3"
+                        , {"1.2.3+7", "1.2.3"})
+
     _check_semver_select(t, {"1.2.9", "version"}
                         , "1.2"
                         , {"1.2", "1.2.9"})
@@ -43,6 +47,14 @@ function test_semver_select(t)
                         , {"v1.2.3+7"}
                         , {"1.2.3"})
 
+    _check_semver_select(t, {"v1.2.3+7", "version"}
+                        , "1.2.3+7"
+                        , {"v1.2.3+8", "v1.2.3+7"})
+
+    _check_semver_select(t, {"1.2.3+7", "version"}
+                        , "v1.2.3+7"
+                        , {"1.2.3+8", "1.2.3+7"})
+
     _check_semver_select(t, {"3.53.0+200", "tag"}
                         , "3.53.0+200"
                         , nil
@@ -52,6 +64,11 @@ function test_semver_select(t)
                         , "3.53.0+999"
                         , nil
                         , {"3.53.0+100"})
+
+    _check_semver_select(t, {"v1.2.3+7", "tag"}
+                        , "=1.2.3+7"
+                        , nil
+                        , {"v1.2.3+7", "v1.2.3+8"})
 
     _check_semver_select(t, {"master", "branch"}
                         , "master"

--- a/tests/modules/semver/test.lua
+++ b/tests/modules/semver/test.lua
@@ -42,7 +42,7 @@ function test_semver_select(t)
                         , "^1.2.3"
                         , {"^1.2.3", "1.2.3", "1.9.0"})
 
-    _check_semver_select(t, {"v1.2.3+7", "version"}
+    _check_semver_select(t, {"1.2.3", "tag"}
                         , "1.2.3"
                         , {"v1.2.3+7"}
                         , {"1.2.3"})
@@ -69,6 +69,11 @@ function test_semver_select(t)
                         , "=1.2.3+7"
                         , nil
                         , {"v1.2.3+7", "v1.2.3+8"})
+
+    _check_semver_select(t, {"v1.2.3+7", "tag"}
+                        , "1.2.3+7"
+                        , {"1.2.3+8"}
+                        , {"v1.2.3+7"})
 
     _check_semver_select(t, {"master", "branch"}
                         , "master"

--- a/tests/modules/semver/test.lua
+++ b/tests/modules/semver/test.lua
@@ -18,6 +18,41 @@ function test_semver_select(t)
                         , "^1.5.0"
                         ,{"1.4.0", "1.5.0", "1.5.1"})
 
+    _check_semver_select(t, {"3.53.0+200", "version"}
+                        , "3.53.0+200"
+                        , {"3.53.0+0", "3.53.0+100", "3.53.0+200"})
+
+    _check_semver_select(t, {"3.53.0+100", "version"}
+                        , "3.53.0+999"
+                        , {"3.53.0+100"})
+
+    _check_semver_select(t, {"1.2.3", "version"}
+                        , "1.2.3"
+                        , {"1.2.3+1", "1.2.3"})
+
+    _check_semver_select(t, {"1.2.9", "version"}
+                        , "1.2"
+                        , {"1.2", "1.2.9"})
+
+    _check_semver_select(t, {"1.9.0", "version"}
+                        , "^1.2.3"
+                        , {"^1.2.3", "1.2.3", "1.9.0"})
+
+    _check_semver_select(t, {"v1.2.3+7", "version"}
+                        , "1.2.3"
+                        , {"v1.2.3+7"}
+                        , {"1.2.3"})
+
+    _check_semver_select(t, {"3.53.0+200", "tag"}
+                        , "3.53.0+200"
+                        , nil
+                        , {"3.53.0+0", "3.53.0+200"})
+
+    _check_semver_select(t, {"3.53.0+100", "tag"}
+                        , "3.53.0+999"
+                        , nil
+                        , {"3.53.0+100"})
+
     _check_semver_select(t, {"master", "branch"}
                         , "master"
                         , {"1.4.0", "1.5.0", "1.5.1"}

--- a/tests/modules/semver/test.lua
+++ b/tests/modules/semver/test.lua
@@ -26,6 +26,22 @@ function test_semver_select(t)
                         , "3.53.0+999"
                         , {"3.53.0+100"})
 
+    _check_semver_select(t, {"3.53.0+200", "version"}
+                        , "3.53.0"
+                        , {"3.53.0+0", "3.53.0+100", "3.53.0+200"})
+
+    _check_semver_select(t, {"3.53.0+200", "version"}
+                        , "3.53.0"
+                        , {"3.53.0+200", "3.53.0+100", "3.53.0+0"})
+
+    _check_semver_select(t, {"3.53.0+beta", "version"}
+                        , "3.53.0"
+                        , {"3.53.0+alpha", "3.53.0+beta"})
+
+    _check_semver_select(t, {"3.53.0+beta", "version"}
+                        , "3.53.0"
+                        , {"3.53.0+beta", "3.53.0+alpha"})
+
     _check_semver_select(t, {"1.2.3", "version"}
                         , "1.2.3"
                         , {"1.2.3+1", "1.2.3"})
@@ -84,6 +100,10 @@ function test_semver_select(t)
     _check_semver_select(t, {"1.5.1", "version"}
                         , "latest"
                         , {"1.4.0", "1.5.0", "1.5.1"})
+
+    _check_semver_select(t, {"3.53.0+200", "version"}
+                        , "latest"
+                        , {"3.53.0+0", "3.53.0+200", "3.53.0+100"})
 end
 
 -- select version

--- a/tests/modules/semver/test.lua
+++ b/tests/modules/semver/test.lua
@@ -7,6 +7,12 @@ function _check_semver_select(t, results, required_ver, versions, tags, branches
     t:are_equal(source, results[2])
 end
 
+function _check_semver_select_failed(t, required_ver, versions, tags, branches)
+    t:will_raise(function()
+        semver.select(required_ver, versions or {}, tags or {}, branches or {})
+    end, "unable to select version")
+end
+
 -- test select version
 function test_semver_select(t)
 
@@ -22,9 +28,7 @@ function test_semver_select(t)
                         , "3.53.0+200"
                         , {"3.53.0+0", "3.53.0+100", "3.53.0+200"})
 
-    _check_semver_select(t, {"3.53.0+100", "version"}
-                        , "3.53.0+999"
-                        , {"3.53.0+100"})
+    _check_semver_select_failed(t, "3.53.0+999", {"3.53.0+100"})
 
     _check_semver_select(t, {"3.53.0+200", "version"}
                         , "3.53.0"
@@ -76,10 +80,7 @@ function test_semver_select(t)
                         , nil
                         , {"3.53.0+0", "3.53.0+200"})
 
-    _check_semver_select(t, {"3.53.0+100", "tag"}
-                        , "3.53.0+999"
-                        , nil
-                        , {"3.53.0+100"})
+    _check_semver_select_failed(t, "3.53.0+999", nil, {"3.53.0+100"})
 
     _check_semver_select(t, {"v1.2.3+7", "tag"}
                         , "=1.2.3+7"
@@ -97,9 +98,23 @@ function test_semver_select(t)
                         , {"v1.2.0", "v1.6.0"}
                         , {"master", "dev"})
 
+    _check_semver_select(t, {"next", "branch"}
+                        , "next"
+                        , nil
+                        , {"vnext"}
+                        , {"next"})
+
     _check_semver_select(t, {"1.5.1", "version"}
                         , "latest"
                         , {"1.4.0", "1.5.0", "1.5.1"})
+
+    _check_semver_select(t, {"1.0.0+10", "version"}
+                        , "latest"
+                        , {"1.0.0+9", "1.0.0+10"})
+
+    _check_semver_select(t, {"1.0.0+rev.10", "version"}
+                        , "latest"
+                        , {"1.0.0+rev.9", "1.0.0+rev.10"})
 
     _check_semver_select(t, {"3.53.0+200", "version"}
                         , "latest"


### PR DESCRIPTION
semver_rangen() accepts an exact version as a range, and SemVer comparison ignores build metadata. This can select a different version than requested.

Try exact string matches for versions and tags before falling back to the range selection.

Fixes #7697

