### PR TITLE
fix(depend): detect appended nested values

### DIFF
--- a/tests/modules/project_depend/test.lua
+++ b/tests/modules/project_depend/test.lua
@@ -1,0 +1,19 @@
+import("core.project.depend")
+
+function test_nested_values_append(t)
+    local dependinfo = {values = {{"clang", "-m64"}}}
+    local changed = depend.is_changed(dependinfo, {values = {{"clang", "-m64", "-DFEATURE_ON"}}})
+    t:require(changed)
+end
+
+function test_nested_values_remove(t)
+    local dependinfo = {values = {{"clang", "-m64", "-DFEATURE_ON"}}}
+    local changed = depend.is_changed(dependinfo, {values = {{"clang", "-m64"}}})
+    t:require(changed)
+end
+
+function test_nested_values_unchanged(t)
+    local dependinfo = {values = {{"clang", "-m64", "-DFEATURE_ON"}}}
+    local changed = depend.is_changed(dependinfo, {values = {{"clang", "-m64", "-DFEATURE_ON"}}})
+    t:require_not(changed)
+end

--- a/xmake/modules/core/project/depend.lua
+++ b/xmake/modules/core/project/depend.lua
@@ -167,6 +167,9 @@ function is_changed(dependinfo, opt)
             end
             return true
         elseif deptype == "table" then
+            if #depvalue ~= #optvalue then
+                return true
+            end
             for subidx, subvalue in ipairs(depvalue) do
                 if subvalue ~= optvalue[subidx] then
                     if _is_show_diagnosis_info() then


### PR DESCRIPTION
## Problem

`depend.is_changed()` compares nested table values by iterating only the
previously recorded table. If the current table only appends new entries,
all recorded entries still match and the dependency is incorrectly treated
as unchanged.

This can leave stale object/static-library artifacts after a configuration
change that adds compile flags.

Fixes #7700.

## Root cause

The outer `values` comparison and the `files` comparison both check lengths,
but nested table values did not.

Therefore:

old = {A, B}
new = {A, B, C}

was incorrectly considered unchanged.

## Fix

Check the nested table lengths before comparing individual elements.

## Regression test

Add a direct `depend.is_changed()` regression covering:

- appended nested value -> changed
- removed nested value -> changed
- identical nested values -> unchanged

The append case fails before this patch and passes after it.

## Verification

- Xmake minimal reproducer: off -> on: PASS
- Xmake minimal reproducer: on -> off: PASS
- Sluice stub -> real without forced rebuild: PASS
- Sluice real -> stub without forced rebuild: PASS
