### PR TITLE
fix(pack): recognize x86_64 when passing -arch to wix

### DIFF
--- a/xmake/plugins/pack/wix/main.lua
+++ b/xmake/plugins/pack/wix/main.lua
@@ -326,7 +326,7 @@ function _pack_wix(wix, package)
     table.join2(argv, {"-ext", "WixToolset.UI.wixext"})
     table.join2(argv, {"-o", package:outputfile()})
 
-    if package:arch() == "x64" then
+    if package:is_arch("x64", "x86_64") then
         table.join2(argv, {"-arch", "x64"})
     elseif package:arch() == "x86" then
         table.join2(argv, {"-arch", "x86"})


### PR DESCRIPTION
## Problem

`xmake pack` builds an x86 MSI when the project is built with mingw, even though the
binaries in it are x64.

`plugins/pack/wix/main.lua` decides the `-arch` switch like this:

```lua
if package:arch() == "x64" then
    table.join2(argv, {"-arch", "x64"})
elseif package:arch() == "x86" then
    table.join2(argv, {"-arch", "x86"})
end
```

`"x64"` is how msvc spells the architecture. Under mingw it is `"x86_64"`, so neither
branch is taken, no `-arch` is passed, and wix falls back to its default of x86.

This is not cosmetic. In an x86 package **every** program files property resolves to
`Program Files (x86)` -- `ProgramFiles64Folder` too, not just `ProgramFilesFolder` and
`ProgramFiles6432Folder` -- so a package that installs 64-bit binaries puts them under
`C:\Program Files (x86)`, and there is no way to say otherwise from the .wxs.

## Reproduce

Build any Windows package with the mingw toolchain and pack it as wix:

```lua
xpack("demo")
    set_formats("wix")
    add_targets("demo")
```

```
xmake f -p mingw -a x86_64
xmake pack demo
```

Then ask the installer where it would put itself:

```powershell
$installer = New-Object -ComObject WindowsInstaller.Installer
$session = $installer.GetType().InvokeMember('OpenPackage','InvokeMethod',$null,$installer,@($msi,1))
foreach ($a in 'CostInitialize','FileCost','CostFinalize') {
    $null = $session.GetType().InvokeMember('DoAction','InvokeMethod',$null,$session,@($a))
}
$session.GetType().InvokeMember('Property','GetProperty',$null,$session,@('ProgramFiles64Folder'))
```

Before: `C:\Program Files (x86)\`
After:  `C:\Program Files\`

## Fix

```lua
if package:is_arch("x64", "x86_64") then
```

`xpack:is_arch` already accepts several spellings, so this only teaches the wix packer
the one it was missing. The x86 branch is left alone: `i386` could be added for the same
reason, but I have not built a 32-bit mingw package to check it, so it is not in this
change.

Verified on Windows 11 with mingw-w64 gcc and WiX 5.0.0: the package is now compiled as
x64, its components come out `Bitness="always64"`, and the install lands in
`C:\Program Files`.
