### PR TITLE
fix clang runtime flags for packages

### DIFF
--- a/xmake/modules/core/tools/clang.lua
+++ b/xmake/modules/core/tools/clang.lua
@@ -263,7 +263,7 @@ function nf_runtime(self, runtime, opt)
               -- on windows force link to compiler_rt builtins
             if llvm_dirs.rtdir and llvm_dirs.rtlink then
                 for name, _ in pairs(maps) do
-                    maps[name] = table.join({"-Xclang", "--dependent-lib=" .. llvm_dirs.rtlink}, maps[name])
+                    maps[name] = table.wrap_lock(table.join({"-Xclang", "--dependent-lib=" .. llvm_dirs.rtlink}, maps[name]))
                 end
             end
         end

--- a/xmake/modules/private/utils/toolchain.lua
+++ b/xmake/modules/private/utils/toolchain.lua
@@ -320,6 +320,28 @@ function get_vs_toolset_ver(vs_toolset)
     return toolset_ver
 end
 
+-- expand grouped flags before passing them to external package build tools
+--
+-- table.wrap_lock() keeps multi-argument flags together while xmake maps and
+-- checks them. this function intentionally ignores that lock because external
+-- build tools expect a flat, ordered argument list.
+function _expand_flaggroups(flags)
+    if not flags then
+        return
+    end
+    local results = {}
+    for _, flag in ipairs(table.wrap(flags)) do
+        if type(flag) == "table" then
+            for _, value in ipairs(flag) do
+                table.insert(results, value)
+            end
+        else
+            table.insert(results, flag)
+        end
+    end
+    return results
+end
+
 -- map compiler flags for package
 function map_compflags_for_package(package, langkind, name, values)
     -- @note we need to patch package:sourcekinds(), because it wiil be called nf_runtime for gcc/clang
@@ -329,7 +351,7 @@ function map_compflags_for_package(package, langkind, name, values)
     end
     local flags = compiler.map_flags(langkind, name, values, {target = package})
     package.sourcekinds = nil
-    return flags
+    return _expand_flaggroups(flags)
 end
 
 -- map linker flags for package
@@ -340,7 +362,7 @@ function map_linkflags_for_package(package, targetkind, sourcekinds, name, value
     end
     local flags = linker.map_flags(targetkind, sourcekinds, name, values, {target = package})
     package.sourcekinds = nil
-    return flags
+    return _expand_flaggroups(flags)
 end
 
 -- ask the clang driver for the absolute path of the given library


### PR DESCRIPTION
Keep multi-argument runtime flags grouped while xmake checks them, then expand the groups before forwarding them to external package build tools.

For Clang on Windows, Xmake generates runtime compiler flags similar to `-Xclang --dependent-lib=windows\clang_rt.builtins-x86_64.lib -fms-runtime-lib=static`
`-Xclang` tells the clang driver to forward the immediately following argument to the internal clang frontend. Therefore, these two arguments must remain together. After the several arguments validations, `-Xclang` incorrectly consumes `-fms-runtime-lib=static` as its frontend argument, removing the `--dependent-lib` part.

Fixes [#7704](https://github.com/xmake-io/xmake/issues/7704)
Fixes https://github.com/xmake-io/xmake/issues/7669