### PR TITLE
fix: open logfile in binary mode to avoid CRLF on Windows

### DIFF
--- a/xmake/core/base/log.lua
+++ b/xmake/core/base/log.lua
@@ -51,8 +51,12 @@ function log:file()
                 os.mkdir(dir)
             end
 
-            -- open the log file
-            self._FILE = io.open(outputfile, 'w+')
+            -- open the log file in binary mode
+            --
+            -- 'w+' (text mode) translates '\n' to '\r\n' on Windows, which breaks
+            -- downstream consumers (e.g. xmake-vscode's regex with a '$' anchor)
+            -- because a trailing '\r' prevents the pattern from matching.
+            self._FILE = io.open(outputfile, 'w+b')
         end
         self._FILE = self._FILE or false
     end


### PR DESCRIPTION
## Problem

`log:file()` opens the `XMAKE_LOGFILE` output with `io.open(outputfile, 'w+')`, i.e. in **text mode**. On Windows this translates every `\n` into `\r\n` (CRLF).

Downstream consumers that parse the logfile line-by-line (e.g. [xmake-vscode](https://github.com/xmake-io/xmake-vscode) `problem.js`, whose GCC regex ends with a `$` anchor) fail to match because the trailing `\r` is left on the line — `.` does not match `\r` and `$` only anchors at end of string. The result is that compiler errors/warnings are silently dropped from the VS Code problems list.

## Reproduction

On Windows, with a TTY:

```sh
XMAKE_LOGFILE=.xmake/vscode-build.log xmake build
```

Then hex-dump the logfile: line endings are `0D 0A` instead of `0A`.

## Fix

Open the logfile in binary mode (`'w+b'`) so newlines stay as plain LF. The logfile is always consumed by programs (never shown as a text document to users), so binary mode is the more correct choice.

## Change

```lua
- self._FILE = io.open(outputfile, 'w+')
+ self._FILE = io.open(outputfile, 'w+b')
```