### PR TITLE
fix: sanitize control chars when writing to logfile

### DIFF
--- a/xmake/core/base/log.lua
+++ b/xmake/core/base/log.lua
@@ -101,6 +101,31 @@ function log:close()
     end
 end
 
+-- sanitize plain text before writing to the log file
+--
+-- strip carriage returns and ANSI escape sequences (color codes, cursor/erase
+-- control) that xmake emits when rendering progress or re-emitting colored
+-- compiler diagnostics on a TTY. without this, the logfile (e.g. read by
+-- xmake-vscode via XMAKE_LOGFILE) gets corrupted by overwrite control chars.
+--
+-- @param s   the raw string to sanitize
+-- @return    the sanitized plain text
+--
+function log._sanitize(s)
+    if type(s) ~= "string" then
+        return s
+    end
+    -- strip ANSI CSI sequences, e.g. \x1b[01;31m, \x1b[K, \x1b[G, \x1b[2J
+    s = s:gsub("\x1b%[[0-9;?]*[a-zA-Z@]", "")
+    -- strip any remaining escape characters
+    s = s:gsub("\x1b", "")
+    -- normalize CRLF to LF
+    s = s:gsub("\r\n", "\n")
+    -- strip bare carriage returns (progress overwrite)
+    s = s:gsub("\r", "")
+    return s
+end
+
 -- print log with newline to the log file
 --
 -- @param ...   the format string and arguments
@@ -108,7 +133,7 @@ end
 function log:print(...)
     local file = self:file()
     if file then
-        file:write(string.format(...) .. "\n")
+        file:write(log._sanitize(string.format(...)) .. "\n")
     end
 end
 
@@ -123,7 +148,7 @@ function log:printv(...)
         for i, v in ipairs(values) do
             -- dump basic type
             if type(v) == "string" or type(v) == "boolean" or type(v) == "number" then
-                file:write(tostring(v))
+                file:write(log._sanitize(tostring(v)))
             else
                 file:write("<" .. tostring(v) .. ">")
             end
@@ -142,7 +167,7 @@ end
 function log:printf(...)
     local file = self:file()
     if file then
-        file:write(string.format(...))
+        file:write(log._sanitize(string.format(...)))
     end
 end
 
@@ -153,7 +178,13 @@ end
 function log:write(...)
     local file = self:file()
     if file then
-        file:write(...)
+        local args = {...}
+        for i, v in ipairs(args) do
+            if type(v) == "string" then
+                args[i] = log._sanitize(v)
+            end
+        end
+        file:write(table.unpack(args))
     end
 end
 


### PR DESCRIPTION
## Problem

When `XMAKE_LOGFILE` is set and xmake runs on a TTY, progress rendering and colored compiler diagnostics write **carriage returns** and **ANSI escape sequences** into the logfile.

- The progress bar uses `\r` + ANSI erase/cursor control (`tty.erase_line().cr()`) to overwrite lines.
- The compiler output is re-emitted with `-fdiagnostics-color=always` color codes.

These control characters are written verbatim into the logfile, corrupting it. In our reproduction a 638-byte clean error log was reduced to 170 bytes of mangled, overwritten text.

## Reproduction

On Windows, with a TTY (not piped):

```sh
XMAKE_LOGFILE=.xmake/vscode-build.log xmake build
```

The logfile contains `\r` overwrite sequences and `\x1b[...m` color codes mixed into the error text. Piping the same build to a file (non-TTY) produces clean output.

## Fix

Add `log._sanitize()` and route all logfile writes through it. It:

1. strips ANSI CSI sequences (`\x1b[01;31m`, `\x1b[K`, `\x1b[G`, `\x1b[2J`, ...)
2. strips any remaining escape characters
3. normalizes CRLF → LF
4. strips bare carriage returns

Applied to `log:print`, `log:printv`, `log:printf`, and `log:write`, which are the single convergence point for all `XMAKE_LOGFILE` output (including the `utils.print/printf` family, which delegates here).

## Notes

This is intentionally a separate fix from the binary-mode logfile change, which addresses the line-ending translation independently. This PR only concerns in-band control characters emitted on a TTY.