### PR TITLE
improve: skip msvc/vstudio detection for projects with standalone toolchains

### DIFF
--- a/xmake/actions/config/main.lua
+++ b/xmake/actions/config/main.lua
@@ -25,7 +25,6 @@ import("core.base.hashset")
 import("core.tool.toolchain")
 import("core.project.config")
 import("core.project.project")
-import("core.platform.platform")
 import("private.detect.find_platform")
 import("core.cache.localcache")
 import("core.cache.detectcache")
@@ -308,9 +307,6 @@ force to build in current directory via run `xmake -P .`]], os.projectdir())
     assert(plat == config.plat())
     assert(arch == config.arch())
 
-    -- load platform instance
-    local instance_plat = platform.load(plat, arch)
-
     -- merge the checked configuration
     local recheck = _need_check(options_changed or not configcache_loaded or autogen)
     if recheck then
@@ -329,9 +325,6 @@ force to build in current directory via run `xmake -P .`]], os.projectdir())
         if not opt.loadonly then
             localcache.save()
         end
-
-        -- check platform
-        instance_plat:check()
 
         -- check project options
         if not trybuild then

--- a/xmake/core/platform/platform.lua
+++ b/xmake/core/platform/platform.lua
@@ -162,7 +162,11 @@ end
 
 -- get the toolchains
 function _instance:toolchains(opt)
-    local toolchains = self:_memcache():get("toolchains")
+    local cachekey = "toolchains"
+    if opt and opt.skip_platform_toolchains then
+        cachekey = cachekey .. ".skip_platform_toolchains"
+    end
+    local toolchains = self:_memcache():get(cachekey)
     if not toolchains then
 
         -- get current valid toolchains from configuration cache
@@ -189,7 +193,11 @@ function _instance:toolchains(opt)
             end
 
             -- get the platform toolchains
-            if (not toolchain_given or not toolchain_given:is_standalone()) and self._INFO:get("toolchains") then
+            -- @note we can skip it if all targets have their own standalone toolchains,
+            -- to avoid the unnecessary toolchain detection, e.g. msvc detection for mingw projects
+            if (not toolchain_given or not toolchain_given:is_standalone())
+               and self._INFO:get("toolchains")
+               and not (opt and opt.skip_platform_toolchains) then
                 names = self._INFO:get("toolchains")
             end
         end
@@ -210,7 +218,7 @@ function _instance:toolchains(opt)
                 end
             end
         end
-        self:_memcache():set("toolchains", toolchains)
+        self:_memcache():set(cachekey, toolchains)
     end
     return toolchains
 end
@@ -251,7 +259,11 @@ function _instance:data_add(name, data)
 end
 
 -- do check
-function _instance:check()
+--
+-- @param opt   the options, e.g. {skip_platform_toolchains = true}
+--
+function _instance:check(opt)
+    opt = opt or {}
     -- @see https://github.com/xmake-io/xmake/issues/4645#issuecomment-2201036943
     -- @note avoid check it in the same time leading to deadlock if running in the coroutine
     local lockname = tostring(self)
@@ -265,7 +277,7 @@ function _instance:check()
     end
 
     -- check toolchains
-    local toolchains = self:toolchains({all = true})
+    local toolchains = self:toolchains({all = true, skip_platform_toolchains = opt.skip_platform_toolchains})
     local idx = 1
     local num = #toolchains
     local standalone = false
@@ -285,6 +297,13 @@ function _instance:check()
         end
     end
     if #toolchains == 0 then
+        if opt.skip_platform_toolchains and not config.get(self:is_host() and "toolchain_host" or "toolchain") then
+            -- all targets have their own standalone toolchains, so we can skip
+            -- the platform toolchains check, e.g. set_toolchains("mingw")
+            self:_memcache():set("checked", true)
+            scheduler.co_unlock(lockname)
+            return true
+        end
         self:_memcache():set("checked", false)
         scheduler.co_unlock(lockname)
         return false, "toolchains not found!"

--- a/xmake/modules/private/utils/target.lua
+++ b/xmake/modules/private/utils/target.lua
@@ -23,6 +23,7 @@ import("core.base.option")
 import("core.base.hashset")
 import("core.project.config")
 import("core.project.project")
+import("core.tool.toolchain")
 import("utils.binary.deplibs", {alias = "get_depend_libraries"})
 
 -- Is this target has these tools?
@@ -149,10 +150,53 @@ function get_project_targets()
     return project.targets()
 end
 
+-- do all enabled targets have their own standalone toolchains?
+--
+-- e.g. set_toolchains("mingw") / set_toolchains("gcc"), if so, we can skip the
+-- platform toolchains check to avoid the unnecessary toolchain detection,
+-- e.g. msvc/vstudio detection for mingw projects.
+--
+function _check_skip_platform_toolchains()
+    for _, target in pairs(project.targets()) do
+        if target:is_enabled() then
+            local has_standalone = false
+            local target_toolchains = target:get("toolchains")
+            if target_toolchains then
+                for _, name in ipairs(table.wrap(target_toolchains)) do
+                    local toolchain_opt = table.copy(target:extraconf("toolchains", name))
+                    toolchain_opt.arch = target:arch()
+                    toolchain_opt.plat = target:plat()
+                    toolchain_opt.namespace = target:namespace()
+                    -- we need to catch the errors, because the sandbox toolchain.load
+                    -- will raise an error if the toolchain is not found, e.g. the
+                    -- custom toolchains defined in the project xmake.lua
+                    local toolchain_inst = try { function () return toolchain.load(name, toolchain_opt) end }
+                    -- attempt to load toolchain from project
+                    if not toolchain_inst and project.toolchain then
+                        toolchain_inst = project.toolchain(name, toolchain_opt)
+                    end
+                    if toolchain_inst and toolchain_inst:is_standalone() then
+                        has_standalone = true
+                        break
+                    end
+                end
+            end
+            if not has_standalone then
+                return false
+            end
+        end
+    end
+    return true
+end
+
 -- check target toolchains
 function check_target_toolchains()
     -- check toolchains configuration for all target in the current project
     -- @note we must check targets after loading options
+    local platform_check_opt = {}
+    if _check_skip_platform_toolchains() then
+        platform_check_opt.skip_platform_toolchains = true
+    end
     for _, target in pairs(project.targets()) do
         if target:is_enabled() and (target:get("toolchains") or
                                     not target:is_plat(config.get("plat")) or
@@ -160,7 +204,7 @@ function check_target_toolchains()
 
             -- check platform toolchains first
             -- `target/set_plat()` and target:toolchains() need it
-            target:platform():check()
+            target:platform():check(platform_check_opt)
 
             -- check target toolchains next
             local target_toolchains = target:get("toolchains")
@@ -174,6 +218,9 @@ function check_target_toolchains()
                 end
             end
         elseif not target:get("toolset") then
+            -- check platform toolchains, targets without toolchains rely on them
+            target:platform():check(platform_check_opt)
+
             -- we only abort it when we know that toolchains of platform and target do not found
             local toolchain_found
             for _, toolchain_inst in pairs(target:toolchains()) do


### PR DESCRIPTION
this pr makes xmake skip the unnecessary msvc/vstudio detection when the project already configures its own standalone toolchains, e.g. `set_toolchains("mingw")`.

currently `platform:check()` always runs the platform default toolchain list (`msvc`, `clang`, ...) at config time, and both the msvc and clang checks trigger the full vstudio detection (vswhere/registry/vcvarsall). that takes a few seconds on every recheck even if we only build with mingw, and on machines without vs it's never cached so it keeps re-running.

i moved the platform check into `check_target_toolchains()` where the target toolchains are already known, and skip the platform default list when all enabled targets have their own standalone toolchains. if any target still relies on the platform toolchains, the check runs as before, so the default msvc workflow is unaffected.

tested with a simple mingw project on windows (no vs installed): config time drops from ~1.1s to ~0.4s, and the "checking for Microsoft Visual Studio" lines are gone. the default project (no `set_toolchains`) still detects vs exactly as before, and `--toolchain=mingw` / rebuild / `-p mingw` all behave the same.
