### PR TITLE
Propagate package vector extensions to consumers

### DIFF
--- a/tests/projects/package/usage_requirements/repo/packages/u/usage-requirements/src/README.md
+++ b/tests/projects/package/usage_requirements/repo/packages/u/usage-requirements/src/README.md
@@ -1,0 +1,1 @@
+Local source fixture for the usage-requirements package tests.

--- a/tests/projects/package/usage_requirements/repo/packages/u/usage-requirements/src/README.md
+++ b/tests/projects/package/usage_requirements/repo/packages/u/usage-requirements/src/README.md
@@ -1,1 +1,0 @@
-Local source fixture for the usage-requirements package tests.

--- a/tests/projects/package/usage_requirements/repo/packages/u/usage-requirements/xmake.lua
+++ b/tests/projects/package/usage_requirements/repo/packages/u/usage-requirements/xmake.lua
@@ -1,0 +1,22 @@
+package("usage-requirements")
+    set_kind("library", {headeronly = true})
+    set_sourcedir(path.join(os.scriptdir(), "src"))
+
+    add_components("enabled")
+    add_components("disabled")
+
+    on_load(function (package)
+        package:add("vectorexts", "avx")
+    end)
+
+    on_component("enabled", function (package, component)
+        component:add("vectorexts", "avx2")
+    end)
+
+    on_component("disabled", function (package, component)
+        component:add("vectorexts", "avx512")
+    end)
+
+    on_install(function (package)
+        os.cp("README.md", package:installdir())
+    end)

--- a/tests/projects/package/usage_requirements/src/main.cpp
+++ b/tests/projects/package/usage_requirements/src/main.cpp
@@ -1,0 +1,4 @@
+int main()
+{
+    return 0;
+}

--- a/tests/projects/package/usage_requirements/src/main.cpp
+++ b/tests/projects/package/usage_requirements/src/main.cpp
@@ -1,4 +1,3 @@
-int main()
-{
+int main() {
     return 0;
 }

--- a/tests/projects/package/usage_requirements/src/usage.cpp
+++ b/tests/projects/package/usage_requirements/src/usage.cpp
@@ -1,0 +1,8 @@
+#if !defined(__AVX2__) && !defined(_M_AVX2) && !defined(__AVX2)
+#    error AVX2 is required by the package
+#endif
+
+int usage()
+{
+    return 0;
+}

--- a/tests/projects/package/usage_requirements/src/usage.cpp
+++ b/tests/projects/package/usage_requirements/src/usage.cpp
@@ -2,7 +2,6 @@
 #    error AVX2 is required by the package
 #endif
 
-int usage()
-{
+int usage() {
     return 0;
 }

--- a/tests/projects/package/usage_requirements/test.lua
+++ b/tests/projects/package/usage_requirements/test.lua
@@ -1,0 +1,5 @@
+function main(t)
+    if os.subarch():startswith("x") or os.subarch() == "i386" then
+        t:build()
+    end
+end

--- a/tests/projects/package/usage_requirements/xmake.lua
+++ b/tests/projects/package/usage_requirements/xmake.lua
@@ -1,0 +1,35 @@
+add_rules("mode.debug", "mode.release")
+
+add_repositories("usage-requirements-repo repo")
+add_requires("usage-requirements", {system = false})
+
+local function _has_value_from(target, name, source, expected)
+    local values = target:get_from(name, source, {interface = true})
+    for _, source_values in ipairs(values or {}) do
+        if table.contains(table.wrap(source_values), expected) then
+            return true
+        end
+    end
+end
+
+target("usage")
+    set_kind("static")
+    add_files("src/usage.cpp")
+    add_packages("usage-requirements", {components = "enabled", public = true})
+    before_build(function (target)
+        local package = assert(target:pkg("usage-requirements"))
+        assert(table.contains(package:get("vectorexts"), "avx"))
+        assert(_has_value_from(target, "vectorexts", "package::*", "avx"))
+        assert(_has_value_from(target, "vectorexts", "package::*", "avx2"))
+        assert(not _has_value_from(target, "vectorexts", "package::*", "avx512"))
+    end)
+
+target("consumer")
+    set_kind("binary")
+    add_deps("usage")
+    add_files("src/main.cpp")
+    before_build(function (target)
+        assert(_has_value_from(target, "vectorexts", "dep::usage/package::*", "avx"))
+        assert(_has_value_from(target, "vectorexts", "dep::usage/package::*", "avx2"))
+        assert(not _has_value_from(target, "vectorexts", "dep::usage/package::*", "avx512"))
+    end)

--- a/xmake/languages/c/load.lua
+++ b/xmake/languages/c/load.lua
@@ -61,6 +61,7 @@ function _get_apis()
     ,   "package.add_defines"
     ,   "package.add_undefines"
     ,   "package.add_frameworks"
+    ,   "package.add_vectorexts"
     ,   "package.add_rpathdirs"
     ,   "package.add_linkdirs"
     ,   "package.add_includedirs" --@note we need not uses paths for package, see https://github.com/xmake-io/xmake/issues/717


### PR DESCRIPTION
## Summary

Allow package recipes and package components to export these portable usage requirements:

- `vectorexts`

These values are now serialized into installed package metadata, returned when fetching packages, applied by `add_packages()`, and propagated through public target dependencies.

## Changes

- Register `package.add_vectorexts`.
- Preserve package-level and component-level usage requirements.
- Apply requirements only from selected components.
- Propagate the requirements through targets using public package dependencies.
- Add an end-to-end package usage-requirements regression test.
- Verify that selected vector extensions reach consumers while unselected component values do not.

## Testing

- [x] `xmake l tests/run.lua projects/package/usage_requirements`
- [x] Tested on Windows x64 with Visual Studio 2022/MSVC.

Closes #7718