### PR TITLE
Add new architectures for cross-compilation

### DIFF
--- a/xmake/platforms/bsd/xmake.lua
+++ b/xmake/platforms/bsd/xmake.lua
@@ -21,7 +21,7 @@
 platform("bsd")
     set_os("bsd")
     set_hosts("bsd")
-    set_archs("i386", "x86_64")
+    set_archs("i386", "x86_64", "arm", "arm64", "ppc", "ppc64", "ppc64el", "riscv64", "sparc64")
 
     set_formats("static", "lib$(name).a")
     set_formats("object", "$(name).o")
@@ -53,5 +53,3 @@ platform("bsd")
                 ,   {nil, "qt_host",        "kv", "auto",       "The Qt Host SDK Directory"         }
                 }
             }
-
-

--- a/xmake/platforms/cross/xmake.lua
+++ b/xmake/platforms/cross/xmake.lua
@@ -20,7 +20,7 @@
 
 platform("cross")
     set_hosts("macosx", "linux", "windows", "bsd")
-    set_archs("i386", "x86_64", "arm", "armv7", "arm64", "mips", "mips64", "mips64el", "riscv", "riscv64", "loong64", "s390x", "ppc", "ppc64", "ppc64el", "sh4")
+    set_archs("i386", "x86_64", "arm", "armv7", "arm64", "mips", "mips64", "mips64el", "riscv", "riscv64", "loong64", "s390x", "ppc", "ppc64", "ppc64el", "sh4", "sparc64")
 
     set_formats("static", "lib$(name).a")
     set_formats("object", "$(name).o")

--- a/xmake/platforms/cross/xmake.lua
+++ b/xmake/platforms/cross/xmake.lua
@@ -20,7 +20,7 @@
 
 platform("cross")
     set_hosts("macosx", "linux", "windows", "bsd")
-    set_archs("i386", "x86_64", "arm", "arm64", "mips", "mips64", "riscv", "riscv64", "loong64", "s390x", "ppc", "ppc64", "sh4")
+    set_archs("i386", "x86_64", "arm", "armv7", "arm64", "mips", "mips64", "mips64el", "riscv", "riscv64", "loong64", "s390x", "ppc", "ppc64", "ppc64el", "sh4")
 
     set_formats("static", "lib$(name).a")
     set_formats("object", "$(name).o")
@@ -28,5 +28,3 @@ platform("cross")
     set_formats("symbol", "$(name).sym")
 
     set_toolchains("envs", "cross")
-
-

--- a/xmake/platforms/linux/xmake.lua
+++ b/xmake/platforms/linux/xmake.lua
@@ -21,7 +21,7 @@
 platform("linux")
     set_os("linux")
     set_hosts("macosx", "linux", "windows", "bsd")
-    set_archs("i386", "x86_64", "armv7", "armv7s", "arm64", "mips", "mips64", "mipsel", "mips64el", "loong64")
+    set_archs("i386", "x86_64", "armv7", "armv7s", "arm64", "mips", "mips64", "mipsel", "mips64el", "loong64", "riscv64", "s390x", "ppc", "ppc64", "ppc64el")
 
     set_formats("static", "lib$(name).a")
     set_formats("object", "$(name).o")

--- a/xmake/platforms/linux/xmake.lua
+++ b/xmake/platforms/linux/xmake.lua
@@ -21,7 +21,7 @@
 platform("linux")
     set_os("linux")
     set_hosts("macosx", "linux", "windows", "bsd")
-    set_archs("i386", "x86_64", "armv7", "armv7s", "arm64", "mips", "mips64", "mipsel", "mips64el", "loong64", "riscv64", "s390x", "ppc", "ppc64", "ppc64el")
+    set_archs("i386", "x86_64", "armv7", "armv7s", "arm64", "mips", "mips64", "mipsel", "mips64el", "loong64", "riscv64", "s390x", "ppc", "ppc64", "ppc64el", "sparc64")
 
     set_formats("static", "lib$(name).a")
     set_formats("object", "$(name).o")

--- a/xmake/platforms/solaris/xmake.lua
+++ b/xmake/platforms/solaris/xmake.lua
@@ -21,7 +21,7 @@
 platform("solaris")
     set_os("solaris")
     set_hosts("solaris")
-    set_archs("i386", "x86_64")
+    set_archs("i386", "x86_64", "sparc64")
 
     set_formats("static", "lib$(name).a")
     set_formats("object", "$(name).o")
@@ -53,5 +53,3 @@ platform("solaris")
                 ,   {nil, "qt_host",        "kv", "auto",       "The Qt Host SDK Directory"         }
                 }
             }
-
-


### PR DESCRIPTION
Some platforms were missing a few popular architectures, they'd show up as `cross(none)`