### PR TITLE
Add _instance:reload() for #Issue6404

### DIFF
--- a/xmake/core/tool/toolchain.lua
+++ b/xmake/core/tool/toolchain.lua
@@ -440,6 +440,19 @@ function _instance:_on_load()
     return on_load
 end
 
+
+-- method for forcing ignore caching
+function _instance:reload()
+    -- clean cache-loading flag 
+    self._CONFIGS.__loaded = nil
+    -- clean those cached values in infos
+    self._INFOS = nil
+    self._RUNENVS = nil
+    -- re-calling _load
+    self:_load()
+    return true
+end
+
 -- do load, @note we need to load it repeatly for each architectures
 function _instance:_load()
     if not self:_is_checked() then


### PR DESCRIPTION
Add _instance:reload -> toolchain:reload() for users who wrote side-effect in toolchain on_load() and experiencing cache lost

such as [#Issue 6404](https://github.com/xmake-io/xmake/issues/6404)

