### PR TITLE
Support Clang 23 `--precompile-reduced-bmi` pipeline

### DIFF
--- a/tests/projects/c++/modules/precompile_reduced_bmi/src/base.mpp
+++ b/tests/projects/c++/modules/precompile_reduced_bmi/src/base.mpp
@@ -1,0 +1,5 @@
+export module base;
+
+export int base_value() {
+    return 40;
+}

--- a/tests/projects/c++/modules/precompile_reduced_bmi/src/hello.mpp
+++ b/tests/projects/c++/modules/precompile_reduced_bmi/src/hello.mpp
@@ -1,0 +1,7 @@
+export module hello;
+
+import base;
+
+export int answer() {
+    return base_value() + 2;
+}

--- a/tests/projects/c++/modules/precompile_reduced_bmi/src/main.cpp
+++ b/tests/projects/c++/modules/precompile_reduced_bmi/src/main.cpp
@@ -1,0 +1,5 @@
+import hello;
+
+int main() {
+    return answer() == 42 ? 0 : 1;
+}

--- a/tests/projects/c++/modules/precompile_reduced_bmi/test.lua
+++ b/tests/projects/c++/modules/precompile_reduced_bmi/test.lua
@@ -1,0 +1,107 @@
+inherit(".test_base")
+import("core.base.json")
+
+local _CLANG_MIN_VER = "23"
+
+function clang_min_ver()
+    return _CLANG_MIN_VER
+end
+
+function _check_commands(config, outdata)
+    local has_precompile_reduced_bmi = outdata:find("--precompile-reduced-bmi", 1, true) ~= nil
+    local expect_precompile_reduced_bmi = config.precompile_reduced_bmi and config.two_phases
+    assert(has_precompile_reduced_bmi == expect_precompile_reduced_bmi,
+        "unexpected --precompile-reduced-bmi usage\n%s", outdata)
+
+    if config.two_phases then
+        local object_command
+        for _, line in ipairs(outdata:split("\n", {plain = true})) do
+            if line:find("hello.mpp", 1, true) and
+               (line:find("hello.mpp.o", 1, true) or line:find("hello.mpp.obj", 1, true)) and
+               line:find(" -c ", 1, true) and
+               not line:find("clang-scan-deps", 1, true) and
+               not line:find("--precompile", 1, true) then
+                object_command = line
+                break
+            end
+        end
+        assert(object_command, "module object command missing\n%s", outdata)
+        local consumes_bmi = object_command:find("hello.pcm", 1, true) ~= nil
+        assert(consumes_bmi ~= expect_precompile_reduced_bmi, "unexpected module object input\n%s", outdata)
+    end
+end
+
+function _check_incremental()
+    local outdata = os.iorun("xmake -v")
+    if outdata:find("compiling", 1, true) or
+       outdata:find("linking", 1, true) or
+       outdata:find("generating", 1, true) then
+        raise("Modules incremental compilation does not work\n%s", outdata)
+    end
+end
+
+function _check_compile_commands(config)
+    os.run("xmake project -k compile_commands")
+    local bmi_command
+    local object_command
+    for _, command in ipairs(assert(json.loadfile("compile_commands.json"))) do
+        if command.file:endswith("hello.mpp") then
+            local commandline = command.command or table.concat(command.arguments or {}, " ")
+            if commandline:find("--precompile", 1, true) then
+                bmi_command = commandline
+            elseif commandline:find("hello.mpp.o", 1, true) or commandline:find("hello.mpp.obj", 1, true) then
+                object_command = commandline
+            end
+        end
+    end
+    assert(bmi_command, "module BMI command missing from compile_commands.json")
+    assert(object_command, "module object command missing from compile_commands.json")
+    local expect_precompile_reduced_bmi = config.precompile_reduced_bmi and config.two_phases
+    assert((bmi_command:find("--precompile-reduced-bmi", 1, true) ~= nil) == expect_precompile_reduced_bmi,
+        "unexpected module BMI command\n%s", bmi_command)
+    assert(object_command:find("hello.mpp", 1, true) and not object_command:find("hello.pcm", 1, true),
+        "unexpected module object command\n%s", object_command)
+end
+
+function _configure(config)
+    local argv = {"f", "--yes", "--toolchain=" .. config.toolchain}
+    if config.platform then
+        table.join2(argv, {"-p", config.platform})
+    end
+    if config.runtimes then
+        table.insert(argv, "--runtimes=" .. config.runtimes)
+    end
+    local policies = "--policies=build.c++.modules.std:" .. (config.stdmodule and "y" or "n")
+    policies = policies .. ",build.c++.modules.fallbackscanner:" .. (config.fallbackscanner and "y" or "n")
+    policies = policies .. ",build.c++.modules.two_phases:" .. (config.two_phases and "y" or "n")
+    policies = policies .. ",build.c++.modules.clang.precompile_reduced_bmi:" .. (config.precompile_reduced_bmi and "y" or "n")
+    table.insert(argv, policies)
+    table.join2(argv, config.flags or {})
+    os.execv("xmake", argv)
+end
+
+function _check_build(config)
+    local outdata = os.iorun("xmake -rv")
+    _check_commands(config, outdata)
+
+    os.run("xmake run")
+    _check_incremental()
+    if config.two_phases then
+        _check_compile_commands(config)
+    end
+
+    if config.two_phases then
+        local toggled_config = table.clone(config)
+        toggled_config.precompile_reduced_bmi = not config.precompile_reduced_bmi
+        _configure(toggled_config)
+        local toggled_outdata = os.iorun("xmake -v")
+        _check_commands(toggled_config, toggled_outdata)
+        os.run("xmake run")
+        _check_incremental()
+        _check_compile_commands(toggled_config)
+    end
+end
+
+function main(_)
+    run_tests({compiler = "clang", version = clang_min_ver(), precompile_reduced_bmi = true, build = _check_build})
+end

--- a/tests/projects/c++/modules/precompile_reduced_bmi/test.lua
+++ b/tests/projects/c++/modules/precompile_reduced_bmi/test.lua
@@ -7,6 +7,10 @@ function clang_min_ver()
     return _CLANG_MIN_VER
 end
 
+function clang_cl_min_ver()
+    return _CLANG_MIN_VER
+end
+
 function _check_commands(config, outdata)
     local has_precompile_reduced_bmi = outdata:find("--precompile-reduced-bmi", 1, true) ~= nil
     local expect_precompile_reduced_bmi = config.precompile_reduced_bmi and config.two_phases

--- a/tests/projects/c++/modules/precompile_reduced_bmi/test.lua
+++ b/tests/projects/c++/modules/precompile_reduced_bmi/test.lua
@@ -7,10 +7,6 @@ function clang_min_ver()
     return _CLANG_MIN_VER
 end
 
-function clang_cl_min_ver()
-    return _CLANG_MIN_VER
-end
-
 function _check_commands(config, outdata)
     local has_precompile_reduced_bmi = outdata:find("--precompile-reduced-bmi", 1, true) ~= nil
     local expect_precompile_reduced_bmi = config.precompile_reduced_bmi and config.two_phases

--- a/tests/projects/c++/modules/precompile_reduced_bmi/xmake.lua
+++ b/tests/projects/c++/modules/precompile_reduced_bmi/xmake.lua
@@ -1,0 +1,6 @@
+add_rules("mode.release", "mode.debug")
+set_languages("c++20")
+
+target("precompile_reduced_bmi")
+    set_kind("binary")
+    add_files("src/*.cpp", "src/*.mpp")

--- a/tests/projects/c++/modules/stdmodules_deps/src/bar.mpp
+++ b/tests/projects/c++/modules/stdmodules_deps/src/bar.mpp
@@ -4,11 +4,9 @@ import std;
 
 export auto my_sum2(std::size_t a, std::size_t b) -> std::size_t;
 
-#if defined(__GNUC__) && !defined(__clang__)
-inline
-#else
-module :private;
-#endif
-    auto my_sum2(std::size_t a, std::size_t b) -> std::size_t {
+// Clang 23 implements P1857R3, which rejects module directives controlled by
+// preprocessing conditionals. This test therefore uses an inline definition.
+// See https://wg21.link/P1857R3
+inline auto my_sum2(std::size_t a, std::size_t b) -> std::size_t {
   return a + a + b + b;
 }

--- a/tests/projects/c++/modules/test_base.lua
+++ b/tests/projects/c++/modules/test_base.lua
@@ -103,6 +103,9 @@ function build_tests(toolchain_name, opt)
     local policies = "--policies=build.c++.modules.std:" .. (opt.stdmodule and "y" or "n")
     policies = policies .. ",build.c++.modules.fallbackscanner:" .. (opt.fallbackscanner and "y" or "n")
     policies = policies .. ",build.c++.modules.two_phases:" .. (two_phases and "y" or "n")
+    if opt.precompile_reduced_bmi ~= nil then
+        policies = policies .. ",build.c++.modules.clang.precompile_reduced_bmi:" .. (opt.precompile_reduced_bmi and "y" or "n")
+    end
 
     local platform = " "
     if opt.platform then
@@ -127,7 +130,7 @@ function build_tests(toolchain_name, opt)
     os.exec("xmake clean -a")
     os.exec("xmake f" .. platform .. "--toolchain=" .. toolchain_name .. runtimes .. "-c --yes " .. policies .. flags)
     if opt.build then
-        opt.build()
+        opt.build(table.join(opt, {toolchain = toolchain_name, two_phases = two_phases}))
     else
         _build(opt.check_outdata)
     end

--- a/tests/projects/c++/modules/test_base.lua
+++ b/tests/projects/c++/modules/test_base.lua
@@ -153,9 +153,12 @@ function run_tests(clang_options, gcc_options, msvc_options)
             if not clang_options.disable_clang_cl then
                 local clang_cl_options = table.clone(clang_options)
                 clang_cl_options.compiler = "clang-cl"
-                clang_cl_options.version = clang_cl_min_ver()
+                local clang_cl_minver = clang_cl_min_ver()
+                if semver.compare(clang_cl_options.version, clang_cl_minver) < 0 then
+                    clang_cl_options.version = clang_cl_minver
+                end
                 build_tests("clang-cl", clang_cl_options)
-                build_tests("clang-cl", table.join(clang_options, {two_phases = false}))
+                build_tests("clang-cl", table.join(clang_cl_options, {two_phases = false}))
             end
             if clang_options.stdmodule then
                 wprint("std modules tests skipped for Windows clang libc++ as it's not currently supported officially")

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -83,6 +83,8 @@ function policy.policies()
             ["build.c++.modules.hide_dependencies"] = {description = "Hide dependencies from the commandline when build C++ modules.", default = false, type = "boolean"},
             -- Enable two phase compilation for C++ modules if supported by the compiler
             ["build.c++.modules.two_phases"]      = {description = "Enable two phase compilation if supported.", default = true, type = "boolean"},
+            -- Use --precompile-reduced-bmi for Clang two-phase module compilation if supported
+            ["build.c++.modules.clang.precompile_reduced_bmi"] = {description = "Use --precompile-reduced-bmi for Clang two-phase module compilation if supported.", default = false, type = "boolean"},
             -- Enable std module
             ["build.c++.modules.std"]             = {description = "Enable std modules.", default = true, type = "boolean"},
             -- Enable unreferenced and non-public named module culling

--- a/xmake/rules/c++/modules/builder.lua
+++ b/xmake/rules/c++/modules/builder.lua
@@ -195,7 +195,7 @@ function should_build(target, module)
         dependinfo.files = {module.sourcefile}
         dependinfo.values = {compinst:program(), compflags}
         if module.bmifile and not module.headerunit and support.has_two_phase_compilation_support(target) then
-            local bmi_mode = support.has_precompile_reduced_bmi_support(target) and "--precompile-reduced-bmi" or "--precompile"
+            local bmi_mode = support.has_precompile_reduced_bmi_support(target) and support.get_modulesprecompilereducedbmiflag(target) or "--precompile"
             table.insert(dependinfo.values, bmi_mode)
         end
         local objectfile_exists = (module.headerunit or support.is_bmionly(target, module.sourcefile)) and true or os.isfile(module.objectfile)

--- a/xmake/rules/c++/modules/builder.lua
+++ b/xmake/rules/c++/modules/builder.lua
@@ -194,6 +194,10 @@ function should_build(target, module)
         local dependinfo = {}
         dependinfo.files = {module.sourcefile}
         dependinfo.values = {compinst:program(), compflags}
+        if module.bmifile and not module.headerunit and support.has_two_phase_compilation_support(target) then
+            local bmi_mode = support.has_precompile_reduced_bmi_support(target) and "--precompile-reduced-bmi" or "--precompile"
+            table.insert(dependinfo.values, bmi_mode)
+        end
         local objectfile_exists = (module.headerunit or support.is_bmionly(target, module.sourcefile)) and true or os.isfile(module.objectfile)
         dependinfo.lastmtime = (os.isfile(module.bmifile or module.objectfile) and objectfile_exists) and os.mtime(dependfile) or 0
 
@@ -241,6 +245,7 @@ function build_modules_for_jobgraph(target, jobgraph, built_modules)
     profiler.enter(target:fullname(), "c++ modules", "builder", "schedule module bmi build jobs")
     local builder = _builder(target)
     local has_two_phase_compilation_support = support.has_two_phase_compilation_support(target)
+    local has_precompile_reduced_bmi = support.has_precompile_reduced_bmi_support(target)
     local jobdeps = {}
     local buildfilejobs = {}
 
@@ -272,19 +277,24 @@ function build_modules_for_jobgraph(target, jobgraph, built_modules)
             local buildfilejob = _get_module_buildfilejob_for(target, sourcefile, moduletype)
             table.insert(buildfilejobs, buildfilejob)
             jobgraph:add(buildfilejob, function(_, _, jobopt)
-                progress.set_target(jobopt.progress, target)
+                local moduleopt = table.clone(jobopt)
+                progress.set_target(moduleopt.progress, target)
                 -- build bmi if named job
-                jobopt.bmi = module.name
+                moduleopt.bmi = module.name
                 -- build objectfile here if two phase compilation is not supported
-                jobopt.objectfile = not has_two_phase_compilation_support and not bmionly
-                builder.make_module_job(target, module, jobopt)
+                moduleopt.objectfile = not has_two_phase_compilation_support and not bmionly
+                builder.make_module_job(target, module, moduleopt)
             end)
             _merge_jobdeps(jobdeps, _get_jobdeps(target, module, jobgraph, buildfilejob))
 
             -- if two phase compilation supported set jobdeps for objectfile job
             if has_two_phase_compilation_support and not bmionly then
                 local objbuildfilejob = _get_module_buildfilejob_for(target, sourcefile, "objectfile")
-                _merge_jobdeps(jobdeps, {[objbuildfilejob] = {buildfilejob}})
+                if has_precompile_reduced_bmi then
+                    _merge_jobdeps(jobdeps, _get_jobdeps(target, module, jobgraph, objbuildfilejob))
+                else
+                    _merge_jobdeps(jobdeps, {[objbuildfilejob] = {buildfilejob}})
+                end
             end
         end
     end)
@@ -327,10 +337,11 @@ function build_objectfiles_for_jobgraph(target, jobgraph, built_modules)
                 local module = mapper.get(target, sourcefile)
                 local buildfilejob = _get_module_buildfilejob_for(target, sourcefile, "objectfile")
                 jobgraph:add(buildfilejob, function(_, _, jobopt)
-                    progress.set_target(jobopt.progress, target)
-                    jobopt.bmi = false
-                    jobopt.objectfile = true
-                    builder.make_module_job(target, module, jobopt)
+                    local moduleopt = table.clone(jobopt)
+                    progress.set_target(moduleopt.progress, target)
+                    moduleopt.bmi = false
+                    moduleopt.objectfile = true
+                    builder.make_module_job(target, module, moduleopt)
                 end)
             end
         end
@@ -719,6 +730,16 @@ function build_bmis(target, jobgraph, _, opt)
         local built_modules, built_headerunits, _ = scanner.sort_modules_by_dependencies(target, modules, {jobgraph = target:policy("build.jobgraph")})
         local headerunits, stlheaderunits = scanner.sort_headerunits(target, built_headerunits)
         if jobgraph.add_orders then -- jobgraph
+            if support.has_precompile_reduced_bmi_support(target) then
+                -- schedule object jobs in the BMI stage so both jobs can run concurrently
+                -- after their imported BMIs are ready
+                local append_requires_flags = _builder(target).append_requires_flags
+                if append_requires_flags then
+                    append_requires_flags(target, built_modules)
+                end
+                build_objectfiles_for_jobgraph(target, jobgraph, built_modules)
+            end
+
             -- build headerunits
             if stlheaderunits or headerunits then
                 build_headerunits_for_jobgraph(target, jobgraph, stlheaderunits, headerunits)
@@ -758,6 +779,10 @@ function build_objectfiles(target, jobgraph, _, opt)
 
     if target:data("cxx.has_modules") then
         if target:is_moduleonly() and not target:data("cxx.modules.reused") or target:is_phony() then
+            return
+        end
+        if jobgraph.add_orders and support.has_precompile_reduced_bmi_support(target) then
+            -- object jobs have already been scheduled by build_bmis()
             return
         end
         profiler.enter(target:fullname(), "c++ modules", "builder", "objectfiles")

--- a/xmake/rules/c++/modules/clang/builder.lua
+++ b/xmake/rules/c++/modules/clang/builder.lua
@@ -66,6 +66,7 @@ function _make_modulebuildflags(target, module, opt)
     local modules_reduced_bmi_flag = support.get_modulesreducedbmiflag(target)
     local has_two_phases = target:policy("build.c++.modules.two_phases")
     local has_precompile_reduced_bmi = support.has_precompile_reduced_bmi_support(target)
+    local modules_precompile_reduced_bmi_flag = has_precompile_reduced_bmi and support.get_modulesprecompilereducedbmiflag(target)
     local flags
     if opt.bmi then
         local module_outputflag = support.get_moduleoutputflag(target)
@@ -73,7 +74,7 @@ function _make_modulebuildflags(target, module, opt)
         flags = {"-x", "c++-module"}
 
         if not opt.objectfile then
-            table.insert(flags, has_precompile_reduced_bmi and "--precompile-reduced-bmi" or "--precompile")
+            table.insert(flags, modules_precompile_reduced_bmi_flag or "--precompile")
             if target:has_tool("cxx", "clang_cl") then
                 table.join2(flags, "/clang:-o", "/clang:" .. module.bmifile)
             end

--- a/xmake/rules/c++/modules/clang/builder.lua
+++ b/xmake/rules/c++/modules/clang/builder.lua
@@ -65,6 +65,7 @@ function _make_modulebuildflags(target, module, opt)
 
     local modules_reduced_bmi_flag = support.get_modulesreducedbmiflag(target)
     local has_two_phases = target:policy("build.c++.modules.two_phases")
+    local has_precompile_reduced_bmi = support.has_precompile_reduced_bmi_support(target)
     local flags
     if opt.bmi then
         local module_outputflag = support.get_moduleoutputflag(target)
@@ -72,7 +73,7 @@ function _make_modulebuildflags(target, module, opt)
         flags = {"-x", "c++-module"}
 
         if not opt.objectfile then
-            table.insert(flags, "--precompile")
+            table.insert(flags, has_precompile_reduced_bmi and "--precompile-reduced-bmi" or "--precompile")
             if target:has_tool("cxx", "clang_cl") then
                 table.join2(flags, "/clang:-o", "/clang:" .. module.bmifile)
             end
@@ -92,7 +93,7 @@ function _make_modulebuildflags(target, module, opt)
         end
     else
         flags = {}
-        if not has_two_phases or not module.bmifile then
+        if (has_precompile_reduced_bmi and support.has_module_extension(module.sourcefile)) or not has_two_phases or not module.bmifile then
             flags = {"-x", "c++"}
         end
         local std = (module.name == "std" or module.name == "std.compat")
@@ -171,7 +172,7 @@ function _compile(target, flags, module, opt)
 
     opt = opt or {}
     local sourcefile = module.sourcefile
-    if not opt.bmi and opt.objectfile and module.bmifile then
+    if not support.has_precompile_reduced_bmi_support(target) and not opt.bmi and opt.objectfile and module.bmifile then
         sourcefile = module.bmifile
     end
     local outputfile = ((opt.bmi and not opt.objectfile) or opt.headerunit) and module.bmifile or module.objectfile

--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -119,6 +119,14 @@ function has_two_phase_compilation_support(target)
     return target:policy("build.c++.modules.two_phases")
 end
 
+function has_precompile_reduced_bmi_support(target)
+    if not target:policy("build.c++.modules.clang.precompile_reduced_bmi") or not has_two_phase_compilation_support(target) then
+        return false
+    end
+    local clang_version = get_clang_version(target)
+    return clang_version and semver.compare(clang_version, "23.0") >= 0 or false
+end
+
 -- flags that doesn't affect bmi generation
 function strippeable_flags()
     -- speculative list as there is no resource that list flags that prevent reusability, this list will likely be improve over time

--- a/xmake/rules/c++/modules/clang/support.lua
+++ b/xmake/rules/c++/modules/clang/support.lua
@@ -123,8 +123,7 @@ function has_precompile_reduced_bmi_support(target)
     if not target:policy("build.c++.modules.clang.precompile_reduced_bmi") or not has_two_phase_compilation_support(target) then
         return false
     end
-    local clang_version = get_clang_version(target)
-    return clang_version and semver.compare(clang_version, "23.0") >= 0 or false
+    return get_modulesprecompilereducedbmiflag(target) ~= nil
 end
 
 -- flags that doesn't affect bmi generation
@@ -388,6 +387,25 @@ function get_modulesreducedbmiflag(target)
         _g.modulesreducedbmiflag = modulesreducedbmiflag or false
     end
     return modulesreducedbmiflag or nil
+end
+
+function get_modulesprecompilereducedbmiflag(target)
+    local modulesprecompilereducedbmiflag = _g.modulesprecompilereducedbmiflag
+    if modulesprecompilereducedbmiflag == nil then
+        local compinst = target:compiler("cxx")
+        local checkflags = "--precompile-reduced-bmi"
+        if target:has_tool("cxx", "clang_cl") then
+            -- clang_cl.has_flags() appends -c and treats unused-argument warnings as errors,
+            -- but --precompile-reduced-bmi does not use -c. Ignore that specific warning and
+            -- treat unknown-argument warnings as errors to reject unsupported flags.
+            checkflags = {checkflags, "-Wno-unused-command-line-argument", "-Werror=unknown-argument"}
+        end
+        if compinst:has_flags(checkflags, "cxxflags", {flagskey = "clang_modules_precompile_reduced_bmi", tryrun = true}) then
+            modulesprecompilereducedbmiflag = "--precompile-reduced-bmi"
+        end
+        _g.modulesprecompilereducedbmiflag = modulesprecompilereducedbmiflag or false
+    end
+    return modulesprecompilereducedbmiflag or nil
 end
 
 function has_clangscandepssupport(target)

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -83,6 +83,9 @@ function has_precompile_reduced_bmi_support(_)
     return false
 end
 
+function get_modulesprecompilereducedbmiflag(_)
+end
+
 -- flags that doesn't affect bmi generation
 function strippeable_flags()
     -- speculative list as there is no resource that list flags that prevent reusability, this list will likely be improve over time

--- a/xmake/rules/c++/modules/gcc/support.lua
+++ b/xmake/rules/c++/modules/gcc/support.lua
@@ -79,6 +79,10 @@ function has_two_phase_compilation_support(_)
     return false
 end
 
+function has_precompile_reduced_bmi_support(_)
+    return false
+end
+
 -- flags that doesn't affect bmi generation
 function strippeable_flags()
     -- speculative list as there is no resource that list flags that prevent reusability, this list will likely be improve over time

--- a/xmake/rules/c++/modules/msvc/support.lua
+++ b/xmake/rules/c++/modules/msvc/support.lua
@@ -120,6 +120,10 @@ function has_two_phase_compilation_support(_)
     return false
 end
 
+function has_precompile_reduced_bmi_support(_)
+    return false
+end
+
 -- build c++23 standard modules if needed
 function get_stdmodules(target, opt)
     opt = opt or {}

--- a/xmake/rules/c++/modules/msvc/support.lua
+++ b/xmake/rules/c++/modules/msvc/support.lua
@@ -124,6 +124,9 @@ function has_precompile_reduced_bmi_support(_)
     return false
 end
 
+function get_modulesprecompilereducedbmiflag(_)
+end
+
 -- build c++23 standard modules if needed
 function get_stdmodules(target, opt)
     opt = opt or {}

--- a/xmake/rules/c++/modules/support.lua
+++ b/xmake/rules/c++/modules/support.lua
@@ -111,6 +111,10 @@ function has_two_phase_compilation_support(target)
     return _support(target).has_two_phase_compilation_support(target)
 end
 
+function has_precompile_reduced_bmi_support(target)
+    return _support(target).has_precompile_reduced_bmi_support(target)
+end
+
 -- strip flags not relevent for module reuse
 function strip_flags(target, flags, opt)
 
@@ -437,4 +441,3 @@ function add_installfiles_for_modules(target, modules)
         end
     end
 end
-

--- a/xmake/rules/c++/modules/support.lua
+++ b/xmake/rules/c++/modules/support.lua
@@ -115,6 +115,10 @@ function has_precompile_reduced_bmi_support(target)
     return _support(target).has_precompile_reduced_bmi_support(target)
 end
 
+function get_modulesprecompilereducedbmiflag(target)
+    return _support(target).get_modulesprecompilereducedbmiflag(target)
+end
+
 -- strip flags not relevent for module reuse
 function strip_flags(target, flags, opt)
 


### PR DESCRIPTION
## Summary

Add the opt-in `build.c++.modules.clang.precompile_reduced_bmi`
policy for Clang 23 and newer. The policy is disabled by default and
requires two-phase module compilation.

When enabled:

- BMI jobs use `--precompile-reduced-bmi`;
- module object jobs compile directly from the module source with `-x c++`
  instead of consuming the module unit's own PCM;
- BMI and object jobs depend on the imported BMIs, but not on each other;
- both jobs are scheduled in the same rule stage so they can run in parallel
  once their imported BMIs are ready;
- switching between the existing and new pipelines invalidates the relevant
  incremental build state.

The existing `--precompile` and PCM-to-object pipeline remains unchanged when
the policy is disabled or unsupported.

Clang documents `--precompile-reduced-bmi` as producing a Reduced BMI and notes
that two-phase Reduced BMI compilation requires build-system support:
https://clang.llvm.org/docs/StandardCPlusPlusModules.html#reduced-bmi

## Build graph

```text
                       +-- --precompile-reduced-bmi --> module.pcm --> importers
source + imported BMIs |
                       +-- -x c++ -c ----------------> module.o   --> linker
```

## Clang 23 test compatibility

The existing `stdmodules_deps` fixture placed `module :private;` inside a
preprocessing conditional. Clang 23 rejects module directives controlled by
preprocessing conditionals as part of its P1857R3 implementation.

The fixture now uses an inline definition for all compilers, keeping the test
focused on standard-module dependency propagation. The source documents the
reason with a link to P1857R3:

https://wg21.link/P1857R3

This allows the complete C++ modules test suite to run with LLVM Clang 23.

## Testing

Tested on macOS arm64 with Homebrew LLVM Clang 23.1.0.

- Added `precompile_reduced_bmi` coverage for:
  - policy enabled and disabled;
  - two-phase and single-phase compilation;
  - `--precompile-reduced-bmi` command generation;
  - direct source-to-object compilation without consuming the unit's own PCM;
  - `compile_commands.json` BMI and source-to-object entries with the policy enabled and disabled;
  - incremental no-op rebuilds.
- Complete C++ modules suite: `57 test(s) succeed`.

Closes #7670
