### PR TITLE
fix set_xmakever version comparison

### DIFF
--- a/tests/apis/set_xmakever/test.lua
+++ b/tests/apis/set_xmakever/test.lua
@@ -1,0 +1,25 @@
+-- the minimum version is older than the current xmake version, but its minor
+-- number contains two digits, which broke the previous weighted version
+-- comparison, e.g. v3.1.1 < v2.12.0
+function test_accept_older_minver(t)
+    os.iorunv("xmake", {"f", "-c", "-y"})
+end
+
+function test_reject_newer_minver(t)
+    local tmpdir = path.join(os.tmpdir(), "set_xmakever_newer")
+    if os.isdir(tmpdir) then
+        os.rmdir(tmpdir)
+    end
+    os.mkdir(tmpdir)
+    local oldir = os.cd(tmpdir)
+    io.writefile("xmake.lua", [[
+set_xmakever("999.999.999")
+
+target("test")
+    set_kind("phony")
+]])
+    local ok = try { function () os.iorunv("xmake", {"f", "-y"}) end }
+    t:require(not ok)
+    os.cd(oldir)
+    os.rmdir(tmpdir)
+end

--- a/tests/apis/set_xmakever/xmake.lua
+++ b/tests/apis/set_xmakever/xmake.lua
@@ -1,0 +1,7 @@
+-- this minimum version is older than the current xmake version, but its minor
+-- number contains two digits, which broke the previous weighted version
+-- comparison, e.g. v3.1.1 < v2.12.0
+set_xmakever("2.12.0")
+
+target("test")
+    set_kind("phony")

--- a/xmake/core/base/interpreter.lua
+++ b/xmake/core/base/interpreter.lua
@@ -1797,17 +1797,24 @@ function interpreter:api_builtin_set_xmakever(minver)
         interpreter._raise(string.format("set_xmakever(\"%s\"): invalid version format!", minver))
     end
 
-    -- make minimum numerical version
-    local minvers_num = minvers[1] * 100 + minvers[2] * 10 + minvers[3]
-
     -- parse current version
     local curvers = xmake._VERSION_SHORT:split('.', {plain = true})
 
-    -- make current numerical version
-    local curvers_num = curvers[1] * 100 + curvers[2] * 10 + curvers[3]
-
-    -- check version
-    if curvers_num < minvers_num then
+    -- check version, we cannot compare them as a single weighted number, e.g.
+    -- `major * 100 + minor * 10 + patch`, since it will be wrong once minor/patch >= 10
+    local outdated = false
+    for i = 1, 3 do
+        local minver_num = tonumber(minvers[i])
+        if not minver_num then
+            interpreter._raise(string.format("set_xmakever(\"%s\"): invalid version format!", minver))
+        end
+        local curver_num = tonumber(curvers[i]) or 0
+        if curver_num ~= minver_num then
+            outdated = curver_num < minver_num
+            break
+        end
+    end
+    if outdated then
         interpreter._raise(string.format("xmake v%s < v%s, please run `$xmake update` to upgrade xmake!", xmake._VERSION_SHORT, minver))
     end
 end


### PR DESCRIPTION
## What this PR does / why we need it

`set_xmakever()` compares versions as a single weighted number:

```lua
local minvers_num = minvers[1] * 100 + minvers[2] * 10 + minvers[3]
```

This breaks once a minor/patch component reaches 10, in both directions:

- **False positive**: running xmake v3.1.1 (→ 311) on a project with `set_xmakever("2.12.0")` (→ 320) fails with `xmake v3.1.1 < v2.12.0, please run \`$xmake update\` to upgrade xmake!`, even though v3.1.1 is much newer. Any `2.10.0` – `2.99.99` (and `3.10.0`+ once the current version has a single-digit minor) requirement can hit this.
- **False negative**: xmake v2.19.0 (→ 390) accepts a project requiring v3.0.0 (→ 300), so the required-version check is silently skipped.

Reproduction on xmake v3.1.1 (dev):

```
$ cat xmake.lua
set_xmakever("2.12.0")

target("test")
    set_kind("phony")

$ xmake f
error: xmake v3.1.1 < v2.12.0, please run `$xmake update` to upgrade xmake!
```

## What is changed

- `xmake/core/base/interpreter.lua`: compare the major/minor/patch components one by one instead of folding them into a weighted number. Non-numeric components now raise the existing `invalid version format` error instead of an arithmetic error (e.g. `set_xmakever("a.b.c")` used to fail with `attempt to perform arithmetic on a string value`).
- `tests/apis/set_xmakever/`: new api test that configures a project with `set_xmakever("2.12.0")` (older than the current version, two-digit minor) and one with `set_xmakever("999.999.999")` (newer than the current version, must still be rejected).

## Verification

New test, before the fix:

```
$ xmake lua tests/run.lua set_xmakever
>>     test failed: error: xmake v3.1.1 < v2.12.0, please run `$xmake update` to upgrade xmake!
>>       function test_accept_older_minver tests/apis/set_xmakever/test.lua:4
error: aborting because of unhandled error ...
```

New test, after the fix:

```
$ xmake lua tests/run.lua set_xmakever
> 1 test(s) found
>> [1/1]: testing tests/apis/set_xmakever ...
> 1 test(s) succeed
```

The reproduction project above now configures cleanly.

Full test suite (`xmake lua tests/run.lua`, run per group) on macOS arm64: `actions` 5/5, `apis` 25/25, `benchmarks` 2/2, `cli` 2/2, `modules` 91/91, `plugins` 4/4, `test` 2/2, and the `projects` groups pass except two tests that fail identically without this change on this machine (no Xcode/iOS SDK and no Swift toolchain available: `tests/projects/other/multiplats_xcode`, `tests/projects/swift`).

## Risks

Low: the change only affects the `set_xmakever()` version check. Behavior for well-formed versions that already compared correctly (all components < 10) is unchanged.
