### PR TITLE
support unicode escapes in the pure lua json decoder

### DIFF
--- a/tests/modules/json/test.lua
+++ b/tests/modules/json/test.lua
@@ -33,6 +33,7 @@ function test_json_decode(t)
     t:are_equal(json_decode('[1,"2"]'), {1, "2"})
     t:are_equal(json_decode('[1,"2", {"a":1, "b":true}]'), {1, "2", {a = 1, b = true}})
     t:are_equal(json_decode('[1,0xa,0xdeadbeef, 0xffffffff,-1]'), {1, 0xa, 0xdeadbeef, 0xffffffff, -1})
+    t:are_equal(json_decode('"a\\u0041b"'), "aAb")
 end
 
 function test_json_encode(t)
@@ -64,6 +65,13 @@ function test_pure_json_decode(t)
     t:are_equal(json_pure_decode('[1,"2"]'), {1, "2"})
     t:are_equal(json_pure_decode('[1,"2", {"a":1, "b":true}]'), {1, "2", {a = 1, b = true}})
     t:are_equal(json_pure_decode('[1,0xa,0xdeadbeef, 0xffffffff,-1]'), {1, 0xa, 0xdeadbeef, 0xffffffff, -1})
+    t:are_equal(json_pure_decode('"a\\u0041b"'), "aAb")
+    t:are_equal(json_pure_decode('"\\u4e2d\\u6587"'), "\228\184\173\230\150\135")
+    t:are_equal(json_pure_decode('"\\u00e9"'), "\195\169")
+    t:are_equal(json_pure_decode('"\\uD83D\\uDE00"'), "\240\159\152\128")
+    t:will_raise(function ()
+        json_pure_decode('"\\uD83D"')
+    end)
 end
 
 function test_pure_json_encode(t)

--- a/xmake/core/base/json.lua
+++ b/xmake/core/base/json.lua
@@ -114,6 +114,35 @@ function json._pure_parse_str_val(str, pos, val)
     if not nextc then
         os.raise(early_end_error)
     end
+
+    -- decode the unicode escape, e.g. \uXXXX, a surrogate pair, e.g. \uD83D\uDE00, is combined
+    if nextc == 'u' then
+        local code = tonumber(str:sub(pos + 2, pos + 5):match('^%x%x%x%x$'), 16)
+        if not code then
+            os.raise("invalid unicode escape near position %d", pos)
+        end
+        if code >= 0xD800 and code <= 0xDBFF and str:sub(pos + 6, pos + 7) == '\\u' then
+            local low = tonumber(str:sub(pos + 8, pos + 11):match('^%x%x%x%x$'), 16)
+            if low and low >= 0xDC00 and low <= 0xDFFF then
+                code = 0x10000 + (code - 0xD800) * 0x400 + low - 0xDC00
+                pos = pos + 6
+            end
+        end
+        if code >= 0xD800 and code <= 0xDFFF then
+            os.raise("invalid unicode escape near position %d", pos)
+        end
+        local utf8char
+        if code < 0x80 then
+            utf8char = string.char(code)
+        elseif code < 0x800 then
+            utf8char = string.char(0xC0 + math.floor(code / 0x40), 0x80 + code % 0x40)
+        elseif code < 0x10000 then
+            utf8char = string.char(0xE0 + math.floor(code / 0x1000), 0x80 + math.floor(code / 0x40) % 0x40, 0x80 + code % 0x40)
+        else
+            utf8char = string.char(0xF0 + math.floor(code / 0x40000), 0x80 + math.floor(code / 0x1000) % 0x40, 0x80 + math.floor(code / 0x40) % 0x40, 0x80 + code % 0x40)
+        end
+        return json._pure_parse_str_val(str, pos + 6, val .. utf8char)
+    end
     return json._pure_parse_str_val(str, pos + 2, val .. (esc_map[nextc] or nextc))
 end
 


### PR DESCRIPTION
## What this PR does / why we need it

The pure Lua JSON decoder does not handle `\uXXXX` unicode escapes. `json._pure_parse_str_val` maps `\b`, `\f`, `\n`, `\r`, `\t` and falls back to appending the escaped character verbatim, so the `u` of `\uXXXX` is appended literally and the four hex digits follow it:

```
$ xmake lua -c "
import("core.base.json")
print(json.decode('"a\\u0041b"'))
print(json.decode('"a\\u0041b"', {pure = true}))"
aAb
au0041b
```

The C decoder returns `aAb` (i.e. `"a" .. utf8(0x41) .. "b"`), so the two decoders disagree, and the pure decoder silently corrupts any string that contains a `\uXXXX` escape.

## What is changed

- `xmake/core/base/json.lua`: in `_pure_parse_str_val`, decode `\uXXXX` escapes to their UTF-8 encoding. Surrogate pairs (e.g. `\uD83D\uDE00` → U+1F600) are combined, and invalid escapes or lone surrogates raise an error, matching the C decoder's behavior (it rejects lone surrogates with `Expected value but found invalid unicode escape code`).
- `tests/modules/json/test.lua`: regression cases for the pure decoder (`\u0041`, `\u4e2d\u6587`, `\u00e9`, surrogate pair, lone surrogate must raise) and a parity case for the C decoder.

The UTF-8 encoding is built with `string.char` and arithmetic only, so it works with both Lua 5.4 and LuaJIT builds.

## Verification

New tests, before the fix:

```
$ xmake lua tests/run.lua json
>>     test failed: expected: `aAb`, actual `au0041b`
>>       function test_pure_json_decode tests/modules/json/test.lua:68
error: aborting because of failed assertion ...
```

After the fix:

```
$ xmake lua tests/run.lua json
> 1 test(s) found
>> [1/1]: testing tests/modules/json ...
> 1 test(s) succeed
```

No regressions: `modules` 91/91, `plugins` 4/4, `apis` 24/24, `actions` 5/5, `cli` 2/2 test groups pass on macOS arm64.

## Risks

Low: only the `pure = true` decode path changes. Previously-accepted inputs without `\uXXXX` escapes decode identically; inputs with `\uXXXX` previously produced corrupted strings and now produce the correct value.
