### PR TITLE
escape brackets in path.pattern

### DIFF
--- a/tests/modules/os/test.lua
+++ b/tests/modules/os/test.lua
@@ -208,3 +208,13 @@ function test_isexec(t)
 
     os.tryrm(tempdir)
 end
+
+function test_files_with_brackets(t)
+    local tmpdir = os.tmpfile() .. ".dir"
+    io.writefile(path.join(tmpdir, "a[1].lua"), "x")
+    io.writefile(path.join(tmpdir, "a1.lua"), "x")
+    -- a wildcard is required, a plain existing file is matched without converting the pattern
+    local files = os.files(path.join(tmpdir, "a[1]*.lua"))
+    t:are_equal(files, {path.join(tmpdir, "a[1].lua")})
+    os.tryrm(tmpdir)
+end

--- a/xmake/core/base/path.lua
+++ b/xmake/core/base/path.lua
@@ -442,7 +442,7 @@ end
 function path.pattern(pattern)
 
     -- translate wildcards, e.g. *, **
-    pattern = pattern:gsub("([%+%.%-%^%$%(%)%%])", "%%%1")
+    pattern = pattern:gsub("([%+%.%-%^%$%(%)%%%[%]])", "%%%1")
     pattern = pattern:gsub("%*%*", "\001")
     pattern = pattern:gsub("%*", "\002")
     pattern = pattern:gsub("\001", ".*")


### PR DESCRIPTION
## What this PR does / why we need it

`path.pattern()` escapes the Lua pattern magic characters before translating the `*`/`**` wildcards, but the escape set misses `[` and `]`:

```lua
pattern = pattern:gsub("([%+%.%-%^%$%(%)%%])", "%%%1")
```

So a bracket in a file name is interpreted as a Lua character class instead of a literal character:

```
$ ls sub/
a1.lua  a[1].lua

$ xmake lua -c "
import("core.base.json")" # not needed, plain probe:
$ xmake lua /tmp/probe.lua   -- os.files("/tmp/.../sub/a[1]*.lua")
matched:
    /tmp/.../sub/a1.lua      -- wrong file
```

`os.files("dir/a[1]*.lua")` matches `a1.lua` instead of `a[1].lua`, `remove_files("a[1].lua")` removes `a1.lua` instead of `a[1].lua`, and exclude patterns containing brackets never match the intended files. This affects every `path.pattern()` consumer (`os.match`, `target` file matching, `os.cp`/`os.rm` pattern arguments, ...).

Bracket characters are legal in file names on all supported platforms, and the wildcard documentation only promises `*` and `**` semantics, so brackets should be matched literally.

## What is changed

- `xmake/core/base/path.lua`: add `[` and `]` to the escaped magic character set.
- `tests/modules/os/test.lua`: regression test that creates `a[1].lua` and `a1.lua` and requires `os.files(".../a[1]*.lua")` to match only `a[1].lua` (a wildcard is included in the pattern because an existing plain file is matched without pattern conversion).

`string.ipattern()`, applied afterwards on case-insensitive filesystems, passes `%[`/`%]` through unchanged, so case-insensitive matching is unaffected.

## Verification

New test, before the fix:

```
$ xmake lua tests/run.lua modules/os
>>     test failed: expected: `{[1] = `.../a[1].lua`, ...}`, actual `{[1] = `.../a1.lua`, ...}`
>>       function test_files_with_brackets tests/modules/os/test.lua:218
```

After the fix:

```
$ xmake lua tests/run.lua modules/os
> 1 test(s) found
>> [1/1]: testing tests/modules/os ...
> 1 test(s) succeed
```

No regressions on macOS arm64: `modules` 91/91, `plugins` 4/4, `apis` 24/24, `actions` 5/5, `cli` 2/2, `benchmarks` 2/2, `test` 2/2, and the `projects` groups `c` 14/14, `package` 13/13, `rust` 3/3, `zig` 2/2, `other/native_module` 2/2.

## Risks

Low to medium: patterns that (perhaps unknowingly) relied on Lua character-class syntax through `path.pattern()`, e.g. `--group="test[1-3]"`, now match the bracket characters literally. This matches the documented glob semantics (`*`, `**` only).
