### PR TITLE
Fix quoted flags in the Conan generator

### DIFF
--- a/tests/modules/package/conan_generator/generate.py
+++ b/tests/modules/package/conan_generator/generate.py
@@ -1,0 +1,35 @@
+import importlib.util
+import sys
+from types import SimpleNamespace
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location("xmake_generator", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+cpp_info = SimpleNamespace(**{
+    "_" + field: [] for field in (
+        "includedirs", "libdirs", "bindirs", "resdirs", "srcdirs",
+        "frameworkdirs", "libs", "frameworks", "system_libs", "defines",
+        "cxxflags", "cflags", "sharedlinkflags", "exelinkflags",
+    )
+})
+cpp_info._includedirs = [r'C:\Program Files\quoted\include']
+cpp_info._defines = [r'ROOT=C:\new\test', 'NAME="hello world"']
+cpp_info._cflags = ['-O2', '-DNAME="hello world"']
+cpp_info._cxxflags = [r'/FI"C:\new folder\test.h"']
+cpp_info._sharedlinkflags = ['-Wl,-rpath,"/opt/my libs"']
+cpp_info._exelinkflags = [r'/LIBPATH:"C:\new folder\lib"']
+cpp_info.aggregated_components = lambda: cpp_info
+
+
+class Requirements:
+    def items(self):
+        return [(SimpleNamespace(ref=SimpleNamespace(name="quoted")),
+                 SimpleNamespace(cpp_info=cpp_info))]
+
+
+module.XmakeGenerator(SimpleNamespace(
+    dependencies=SimpleNamespace(host=Requirements(), test={}, build={}),
+    settings=SimpleNamespace(os="Windows", arch="x86_64", build_type="Release"),
+)).generate()

--- a/tests/modules/package/conan_generator/test.lua
+++ b/tests/modules/package/conan_generator/test.lua
@@ -1,0 +1,23 @@
+import("lib.detect.find_tool")
+
+function test_conan_generator_quoted_flags(t)
+    local python = find_tool("python3") or find_tool("python")
+    if not python then
+        return t:skip("python not found")
+    end
+    local generator = path.join(os.programdir(), "scripts", "conan", "extensions", "generators", "xmake_generator.py")
+    local outputdir = path.absolute(".xmake/conan-generator")
+    os.mkdir(outputdir)
+    os.vrunv(python.program, {path.absolute("generate.py"), generator}, {curdir = outputdir})
+    for _, filename in ipairs({"conanbuildinfo.xmake.lua", "conanbuildinfo_quoted.xmake.lua"}) do
+        local buildinfo = io.load(path.join(outputdir, filename))
+        t:require(buildinfo)
+        local info = buildinfo.Windows_x86_64_Release
+        t:are_equal(info.includedirs, {"C:/Program Files/quoted/include"})
+        t:are_equal(info.defines, {[[ROOT=C:\new\test]], [[NAME="hello world"]]})
+        t:are_equal(info.cflags, {"-O2", [[-DNAME="hello world"]]})
+        t:are_equal(info.cxxflags, {[[/FI"C:\new folder\test.h"]]})
+        t:are_equal(info.shflags, {[[-Wl,-rpath,"/opt/my libs"]]})
+        t:are_equal(info.ldflags, {[[/LIBPATH:"C:\new folder\lib"]]})
+    end
+end

--- a/xmake/scripts/conan/extensions/generators/xmake_generator.py
+++ b/xmake/scripts/conan/extensions/generators/xmake_generator.py
@@ -102,6 +102,7 @@ class XmakeGenerator:
 
 class XmakeDepsFormatter(object):
     def __prepare_process_escape_character(self, raw_string):
+        raw_string = raw_string.replace("\\", "\\\\")
         if raw_string.find('\"') != -1:
             raw_string = raw_string.replace("\"","\\\"")
         return raw_string
@@ -135,8 +136,8 @@ class XmakeDepsFormatter(object):
         self.frameworks      = ", ".join('"%s"' % p for p in frameworks)
         self.system_libs     = ", ".join('"%s"' % p for p in system_libs)
         self.defines         = ", ".join('"%s"' % self.__filter_char(p) for p in defines)
-        self.cppflags        = ", ".join('"%s"' % p for p in cxxflags)
-        self.cflags          = ", ".join('"%s"' % p for p in cflags)
-        self.sharedlinkflags = ", ".join('"%s"' % p for p in sharedlinkflags)
-        self.exelinkflags    = ", ".join('"%s"' % p for p in exelinkflags)
+        self.cppflags        = ", ".join('"%s"' % self.__filter_char(p) for p in cxxflags)
+        self.cflags          = ", ".join('"%s"' % self.__filter_char(p) for p in cflags)
+        self.sharedlinkflags = ", ".join('"%s"' % self.__filter_char(p) for p in sharedlinkflags)
+        self.exelinkflags    = ", ".join('"%s"' % self.__filter_char(p) for p in exelinkflags)
 


### PR DESCRIPTION
Conan compiler and linker flags containing quotes, such as `-DNAME="hello world"`, produce invalid `conanbuildinfo.xmake.lua` files. Backslashes in defines can also be read as Lua escapes instead of literal characters.

Escape backslashes before quotes and apply the existing string filter to compiler and linker flags. The regression test generates both build-info files and reads them with Xmake's `io.load`, checking that flags and defines survive unchanged.

Tested on Windows with Xmake 3.1.1 loading the local scripts: `xmake lua tests/run.lua modules/package` passes both test groups. The new regression fails before the fix. Also checked five cases with Conan 2.32.0's `CppInfo` and Lua 5.4; all pass after the fix.