### PR TITLE
Keep the default MSVC environment when a newer toolset is incomplete

### DIFF
--- a/tests/modules/detect/msvc_fallback/check.lua
+++ b/tests/modules/detect/msvc_fallback/check.lua
@@ -8,7 +8,7 @@ function _detect(vc, opt)
     local result = find_vstudio(opt)
     os.setenv("VCInstallDir", old_vc)
     os.setenv("VisualStudioVersion", old_vs)
-    return result["2026"].vcvarsall.x64
+    return result["2026"] and result["2026"].vcvarsall.x64
 end
 
 function main()
@@ -33,6 +33,12 @@ set "VCToolsVersion=14.52.36615"
         assert(result and result.VCToolsVersion == expected, mode .. ": incorrect toolset")
         assert(result.INCLUDE and result.LIB, mode .. ": incomplete environment")
         assert(opt.toolset == nil, mode .. ": mutated caller options")
+        local requested = _detect(vc, {sdkver = mode, toolset = "14.52.36615"})
+        if mode == "success" then
+            assert(requested and requested.VCToolsVersion == "14.52.36615", "explicit newer toolset lost")
+        else
+            assert(not requested, mode .. ": accepted incomplete explicit toolset")
+        end
     end
     local explicit = _detect(vc, {toolset="14.51.36231"})
     assert(explicit.VCToolsVersion == "14.51.36231", "explicit toolset overridden")

--- a/tests/modules/detect/msvc_fallback/check.lua
+++ b/tests/modules/detect/msvc_fallback/check.lua
@@ -1,0 +1,39 @@
+import("detect.sdks.find_vstudio")
+
+function _detect(vc, opt)
+    local old_vc = os.getenv("VCInstallDir")
+    local old_vs = os.getenv("VisualStudioVersion")
+    os.setenv("VCInstallDir", vc)
+    os.setenv("VisualStudioVersion", "18.0")
+    local result = find_vstudio(opt)
+    os.setenv("VCInstallDir", old_vc)
+    os.setenv("VisualStudioVersion", old_vs)
+    return result["2026"].vcvarsall.x64
+end
+
+function main()
+    local root = path.absolute(".xmake/msvc-fallback")
+    local vc = path.join(root, "VC")
+    os.mkdir(path.join(vc, "Tools/MSVC/14.51.36231"))
+    os.mkdir(path.join(vc, "Tools/MSVC/14.52.36615"))
+    local batch = path.join(vc, "vcvarsall.bat")
+    for _, mode in ipairs({"missing_include", "missing_lib", "success"}) do
+        io.writefile(batch, [[@echo off
+set "VCToolsVersion=14.51.36231"
+set "VCInstallDir=]] .. vc .. [["
+set "INCLUDE=fixture-include"
+set "LIB=fixture-lib"
+echo %* | findstr /c:"-vcvars_ver=14.52" >nul
+if errorlevel 1 exit /b 0
+set "VCToolsVersion=14.52.36615"
+]] .. (mode == "missing_include" and 'set "INCLUDE="\n' or mode == "missing_lib" and 'set "LIB="\n' or '') .. "exit /b 0\n")
+        local opt = {sdkver = mode}
+        local result = _detect(vc, opt)
+        local expected = mode == "success" and "14.52.36615" or "14.51.36231"
+        assert(result and result.VCToolsVersion == expected, mode .. ": incorrect toolset")
+        assert(result.INCLUDE and result.LIB, mode .. ": incomplete environment")
+        assert(opt.toolset == nil, mode .. ": mutated caller options")
+    end
+    local explicit = _detect(vc, {toolset="14.51.36231"})
+    assert(explicit.VCToolsVersion == "14.51.36231", "explicit toolset overridden")
+end

--- a/tests/modules/detect/msvc_fallback/test.lua
+++ b/tests/modules/detect/msvc_fallback/test.lua
@@ -1,0 +1,9 @@
+function test_msvc_toolset_fallback(t)
+    if not is_host("windows") then
+        return t:skip("Windows batch environment required")
+    end
+    -- Keep synthetic Visual Studio environments out of the user's detection cache.
+    os.vrunv(os.programfile(), {"lua", path.absolute("check.lua")}, {
+        envs = {XMAKE_GLOBALDIR = os.tmpfile() .. "-msvc-global"}
+    })
+end

--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -321,7 +321,7 @@ function _load_vcvarsall_impl(vcvarsall, vsver, arch, opt)
 
     -- check if the environment variables are truncated
     _check_vcvarsall_env(variables)
-    if not variables.PATH then
+    if not (variables.PATH and variables.INCLUDE and variables.LIB) then
         return
     end
 
@@ -435,7 +435,7 @@ function _load_vcvarsall(vcvarsall, vsver, arch, opt)
             local latest_opt = table.clone(opt)
             latest_opt.toolset = _strip_toolset_ver(latest_toolset)
             local latest_result = _load_vcvarsall_impl(vcvarsall, vsver, arch, latest_opt)
-            if latest_result and latest_result.PATH and latest_result.INCLUDE and latest_result.LIB then
+            if latest_result then
                 result = latest_result
             end
         end

--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -432,8 +432,12 @@ function _load_vcvarsall(vcvarsall, vsver, arch, opt)
             end
         end
         if latest_toolset and VCToolsVersion and semver.compare(latest_toolset, VCToolsVersion) > 0 then
-            opt.toolset = _strip_toolset_ver(latest_toolset)
-            result = _load_vcvarsall_impl(vcvarsall, vsver, arch, opt)
+            local latest_opt = table.clone(opt)
+            latest_opt.toolset = _strip_toolset_ver(latest_toolset)
+            local latest_result = _load_vcvarsall_impl(vcvarsall, vsver, arch, latest_opt)
+            if latest_result and latest_result.PATH and latest_result.INCLUDE and latest_result.LIB then
+                result = latest_result
+            end
         end
     end
     return result


### PR DESCRIPTION
Related to #7720.

After loading the default MSVC environment, detection tries the newest installed toolset. If that attempt returns an environment without INCLUDE or LIB, it currently replaces the usable default and downstream toolchain checks reject it.

Keep the default unless the newer result contains PATH, INCLUDE and LIB, matching the existing toolchain checks. Copy the retry options so automatic selection does not become an explicit toolset request for subsequent architectures. A valid newer environment still takes precedence.

Added a Windows batch fixture through the public detector, covering missing INCLUDE, missing LIB, successful upgrade and an explicitly selected older version. It runs in a child Xmake process with an isolated detection cache. `xmake lua tests/run.lua modules/detect` passes with Xmake 3.1.1 on Windows; the regression fails before the change. No real compiler build or full Xmake suite was run. This does not address an installation whose environment is complete but whose compiler executable is missing.