### PR TITLE
fix: enable exceptions for clang-cl by default

### DIFF
--- a/xmake/core/package/package.lua
+++ b/xmake/core/package/package.lua
@@ -2578,8 +2578,8 @@ function _instance:_generate_build_configs(configs, opt)
     if self:config("asan") then
         _merge(self:_generate_sanitizer_configs("address", sourcekind))
     end
-    -- enable exceptions for msvc by default
-    if opt.sourcekind == "cxx" and configs.exceptions == nil and self:has_tool("cxx", "cl") then
+    -- enable exceptions for msvc and clang-cl by default
+    if opt.sourcekind == "cxx" and configs.exceptions == nil and self:has_tool("cxx", "cl", "clang_cl") then
         configs.exceptions = "cxx"
     end
 


### PR DESCRIPTION
Clang-cl disables exceptions by default as MSVC, so when install packages which its test codes contains `try`(e.g. [pybind11](https://github.com/xmake-io/xmake-repo/blob/dev/packages/p/pybind11/xmake.lua)) with clang-cl toolchain, compiler will throw the error:
```bash
checking for Microsoft C/C++ Compiler (x64) ... ok
checking for Microsoft Visual Studio (x64) version ... 2026
checking for LLVM Clang C/C++ Compiler (x64) ... ok
checking for Microsoft Visual Studio (x64) version ... 2026
note: install or modify (m) these packages (pass -y to skip confirm)?
in xmake-repo:
  -> pybind11 v3.0.1 [license:BSD-3-Clause]
please input: y (y/n/m)

  => install pybind11 v3.0.1 .. failed

C:\Users\shrbo\AppData\Local\Temp\.xmake\260912\_28ec1aed71c16e8fc38a5af95585cbc9.cpp(8,13): error: cannot use 'try' with exceptions disabled
    8 |             PYBIND11_MODULE(example, m) {
      |             ^
C:\Users\shrbo\AppData\Local\.xmake\packages\p\pybind11\v3.0.1\e2490d94671c43a7851001229ac50bef\include\pybind11\detail/common.h(512,5): note: expanded from macro 'PYBIND11_MODULE'
  512 |     PYBIND11_MODULE_EXEC(name, variable)
      |     ^
C:\Users\shrbo\AppData\Local\.xmake\packages\p\pybind11\v3.0.1\e2490d94671c43a7851001229ac50bef\include\pybind11\detail/common.h(456,9): note: expanded from macro 'PYBIND11_MODULE_EXEC'
  456 |         try {                                                                                     \
      |         ^
1 error generated.
if you want to get more verbose errors, please see:
  -> C:\Users\shrbo\AppData\Local\.xmake\cache\packages\2609\p\pybind11\v3.0.1\installdir.failed\logs\install.txt
error: install failed!
```
To reproduce the issue, just adding single line to `xmake.lua`:
```lua
add_requires("pybind11")
```